### PR TITLE
Fix #136 Add custom provisioner for minishift ISO based on RHEL/CentOS

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -34,6 +34,8 @@ import (
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/minishift/minishift/pkg/minishift/provisioner"
 )
 
 const (
@@ -163,6 +165,8 @@ func init() {
 
 	viper.BindPFlags(startCmd.Flags())
 	RootCmd.AddCommand(startCmd)
+
+	provision.SetDetector(&provisioner.MinishiftProvisionerDetector{Delegate: provision.StandardDetector{}})
 }
 
 // initClusterUpFlags creates the CLI flags which needs to be passed on to 'oc cluster up'

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -60,7 +60,6 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		Memory:         config.Memory,
 		CPU:            config.CPUs,
 		Boot2DockerURL: config.GetISOFileURI(),
-		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 base host=" + constants.MachineName,
 		DiskSize:       int64(config.DiskSize),
 		Virtio9p:       true,
 		Virtio9pFolder: "/Users",

--- a/pkg/minishift/provisioner/minishift_detector.go
+++ b/pkg/minishift/provisioner/minishift_detector.go
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/log"
+	"fmt"
+)
+
+type MinishiftProvisionerDetector struct {
+	Delegate provision.Detector
+}
+
+func (detector *MinishiftProvisionerDetector) DetectProvisioner(driver drivers.Driver) (provision.Provisioner, error) {
+	log.Info("Waiting for SSH to be available...")
+	if err := drivers.WaitForSSH(driver); err != nil {
+		return nil, err
+	}
+	osReleaseOut, err := drivers.RunSSHCommandFromDriver(driver, "cat /etc/os-release")
+	if err != nil {
+		return nil, fmt.Errorf("Error getting SSH command: %s", err)
+	}
+
+	log.Info("Detecting the provisioner...")
+	osReleaseInfo, err := provision.NewOsRelease([]byte(osReleaseOut))
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing /etc/os-release file: %s", err)
+	}
+
+	if detector.isMinishiftIso(osReleaseInfo) {
+		provisioner := NewMinishiftProvisioner("minishift", driver)
+		provisioner.SetOsReleaseInfo(osReleaseInfo)
+		return provisioner, nil
+	} else {
+		return detector.Delegate.DetectProvisioner(driver)
+	}
+	return nil, provision.ErrDetectionFailed
+}
+
+func (detector *MinishiftProvisionerDetector) isMinishiftIso(osReleaseInfo *provision.OsRelease) (bool) {
+	if osReleaseInfo.Variant == "minishift" {
+		return true
+	}
+	return false
+}

--- a/pkg/minishift/provisioner/minishift_detector_test.go
+++ b/pkg/minishift/provisioner/minishift_detector_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"testing"
+	"reflect"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/minishift/minishift/pkg/minikube/tests"
+	"github.com/docker/machine/libmachine/drivers"
+)
+
+func TestMinishiftDetector(t *testing.T){
+	s, _ := tests.NewSSHServer()
+	s.CommandToOutput = make(map[string]string)
+	s.CommandToOutput["cat /etc/os-release"] = `NAME="CentOS Linux"
+VERSION="7 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="7"
+PRETTY_NAME="CentOS Linux 7 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:7"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-7"
+CENTOS_MANTISBT_PROJECT_VERSION="7"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="7"
+
+VARIANT="minishift"
+VARIANT_VERSION="1.0.0-alpha.1"
+`
+	port, err := s.Start()
+	if err != nil {
+		t.Fatalf("Error starting ssh server: %s", err)
+	}
+	d := &tests.MockDriver{
+		Port: port,
+		BaseDriver: drivers.BaseDriver{
+			IPAddress:  "127.0.0.1",
+			SSHKeyPath: "",
+		},
+	}
+
+	detector := MinishiftProvisionerDetector{Delegate: provision.StandardDetector{}}
+	provisioner, err := detector.DetectProvisioner(d)
+	if err != nil {
+		t.Fatalf("Error Getting detector: %s", err)
+	}
+
+	if reflect.TypeOf(provisioner).String() != "*provisioner.MinishiftProvisioner" {
+		t.Fatal("Provisioner suppose to part of Minishift detector")
+	}
+
+	osRelease, _ := provisioner.GetOsReleaseInfo()
+	if osRelease.Variant != "minishift" {
+		t.Fatal("Expected to be detect Minishift detector")
+	}
+
+}
+
+func TestStandardDetector(t *testing.T){
+	s, _ := tests.NewSSHServer()
+	s.CommandToOutput = make(map[string]string)
+	s.CommandToOutput["cat /etc/os-release"] = `NAME="CentOS Linux"
+VERSION="7 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="7"
+PRETTY_NAME="CentOS Linux 7 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:7"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-7"
+CENTOS_MANTISBT_PROJECT_VERSION="7"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="7"
+`
+	port, err := s.Start()
+	if err != nil {
+		t.Fatalf("Error starting ssh server: %s", err)
+	}
+	d := &tests.MockDriver{
+		Port: port,
+		BaseDriver: drivers.BaseDriver{
+			IPAddress:  "127.0.0.1",
+			SSHKeyPath: "",
+		},
+	}
+
+	detector := MinishiftProvisionerDetector{Delegate: provision.StandardDetector{}}
+	provisioner, err := detector.DetectProvisioner(d)
+	if err != nil {
+		t.Fatalf("Error Getting detector: %s", err)
+	}
+
+	if reflect.TypeOf(provisioner).String() == "*provisioner.MinishiftProvisioner" {
+		t.Fatal("Provisioner suppose to part of standard detector")
+	}
+
+	osRelease, _ := provisioner.GetOsReleaseInfo()
+	if osRelease.Variant == "minishift" {
+		t.Fatal("Expected to be detect Standard detector")
+	}
+}

--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -1,0 +1,172 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/provision/pkgaction"
+	"github.com/docker/machine/libmachine/swarm"
+)
+
+func NewMinishiftProvisioner(osReleaseID string, d drivers.Driver) *MinishiftProvisioner {
+	systemdProvisioner := provision.NewSystemdProvisioner(osReleaseID, d)
+	systemdProvisioner.SSHCommander = provision.RedHatSSHCommander{Driver: d}
+	return &MinishiftProvisioner{
+		systemdProvisioner,
+	}
+}
+
+type MinishiftProvisioner struct {
+	provision.SystemdProvisioner
+}
+
+func (provisioner *MinishiftProvisioner) String() string {
+	return "minishift"
+}
+
+func (provisioner *MinishiftProvisioner) SetHostname(hostname string) error {
+	// we have to have SetHostname here as well to use the RedHat provisioner
+	// SSHCommand to add the tty allocation
+	if _, err := provisioner.SSHCommand(fmt.Sprintf(
+		"sudo hostname %s && echo %q | sudo tee /etc/hostname",
+		hostname,
+		hostname,
+	)); err != nil {
+		return err
+	}
+
+	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
+	if _, err := provisioner.SSHCommand(fmt.Sprintf(
+		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
+		hostname,
+		hostname,
+	)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *MinishiftProvisioner) GetRedhatRelease() bool {
+	OsRelease, _ := provisioner.GetOsReleaseInfo()
+	if strings.Contains(OsRelease.Name, "Red Hat Enterprise") {
+		return true
+	}
+	return false
+}
+
+func (provisioner *MinishiftProvisioner) Package(name string, action pkgaction.PackageAction) error {
+	// Since required packages is already installed, it does not support package function.
+	return errors.New("Custom provisioner does not support package")
+}
+
+func (provisioner *MinishiftProvisioner) dockerDaemonResponding() bool {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
+		return false
+	}
+
+	// The daemon is up if the command worked.  Carry on.
+	return true
+}
+
+func (provisioner *MinishiftProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+	provisioner.SwarmOptions = swarmOptions
+	provisioner.AuthOptions = authOptions
+	provisioner.EngineOptions = engineOptions
+	swarmOptions.Env = engineOptions.Env
+
+	// set default storage driver for minishift
+	storageDriver, err := decideStorageDriver(provisioner, "devicemapper", engineOptions.StorageDriver)
+	if err != nil {
+		return err
+	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
+
+	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
+		return err
+	}
+
+	if err := mcnutils.WaitFor(provisioner.dockerDaemonResponding); err != nil {
+		return err
+	}
+
+	if err := makeDockerOptionsDir(provisioner); err != nil {
+		return err
+	}
+
+	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
+
+	if err := provision.ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *MinishiftProvisioner) GenerateDockerOptions(dockerPort int) (*provision.DockerOptions, error) {
+	var (
+		engineCfg  bytes.Buffer
+		configPath = provisioner.DaemonOptionsFile
+	)
+
+	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
+	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
+
+	// systemd / redhat will not load options if they are on newlines
+	// instead, it just continues with a different set of options; yeah...
+	engineConfigTemplate := ""
+	if provisioner.GetRedhatRelease() {
+		engineConfigTemplate = engineConfigTemplateRHEL
+	} else {
+		engineConfigTemplate = engineConfigTemplateCentOS
+	}
+
+	t, err := template.New("engineConfig").Parse(engineConfigTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	engineConfigContext := provision.EngineConfigContext{
+		DockerPort:       dockerPort,
+		AuthOptions:      provisioner.AuthOptions,
+		EngineOptions:    provisioner.EngineOptions,
+		DockerOptionsDir: provisioner.DockerOptionsDir,
+	}
+
+	t.Execute(&engineCfg, engineConfigContext)
+
+	daemonOptsDir := configPath
+	return &provision.DockerOptions{
+		EngineOptions:     engineCfg.String(),
+		EngineOptionsPath: daemonOptsDir,
+	}, nil
+}

--- a/pkg/minishift/provisioner/minishift_provisioner_test.go
+++ b/pkg/minishift/provisioner/minishift_provisioner_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/provisiontest"
+	"github.com/docker/machine/libmachine/swarm"
+	"github.com/docker/machine/libmachine/provision"
+)
+
+func TestMinishiftLogLevel(t *testing.T) {
+	p := NewMinishiftProvisioner("", &fakedriver.Driver{})
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{LogLevel: "5"})
+	if p.EngineOptions.LogLevel != "5" {
+		t.Fatal("LogLevel should be 5")
+	}
+}
+
+func TestMinishiftDefaultStorageDriver(t *testing.T) {
+	p := NewMinishiftProvisioner("", &fakedriver.Driver{})
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
+	if p.EngineOptions.StorageDriver != "devicemapper" {
+		t.Fatal("Default storage driver should be devicemapper")
+	}
+}
+
+func TestRhelImage(t *testing.T) {
+	p := NewMinishiftProvisioner("", &fakedriver.Driver{})
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
+	info := &provision.OsRelease{
+		Name:      "Red Hat Enterprise Linux Server",
+		VersionID: "7.3",
+	}
+	p.SetOsReleaseInfo(info)
+	if ! p.GetRedhatRelease() {
+		t.Fatal("Provisioner should detect RHEL")
+	}
+}
+
+func TestCentOSImage(t *testing.T) {
+	p := NewMinishiftProvisioner("", &fakedriver.Driver{})
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
+	info := &provision.OsRelease{
+		Name:      "CentOS Linux",
+		VersionID: "7.3",
+	}
+	p.SetOsReleaseInfo(info)
+	if p.GetRedhatRelease() {
+		t.Fatal("Provisioner should detect CentOS")
+	}
+}

--- a/pkg/minishift/provisioner/utils.go
+++ b/pkg/minishift/provisioner/utils.go
@@ -1,0 +1,141 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This include functions and variable used by provisioner
+package provisioner
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/log"
+	"path"
+	"strings"
+)
+
+var (
+	engineConfigTemplateRHEL = `[Unit]
+Description=Docker Application Container Engine
+After=network.target rc-local.service
+Requires=rhel-push-plugin.socket
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock \
+           --authorization-plugin rhel-push-plugin \
+           --add-registry registry.access.redhat.com \
+           --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} \
+           --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} \
+           {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecReload=/bin/kill -s HUP $MAINPID
+MountFlags=slave
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+TimeoutStartSec=0
+Delegate=yes
+KillMode=process
+Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
+
+[Install]
+WantedBy=multi-user.target
+`
+	engineConfigTemplateCentOS = `[Unit]
+Description=Docker Application Container Engine
+After=network.target rc-local.service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock \
+           --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} \
+           --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} \
+           {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecReload=/bin/kill -s HUP $MAINPID
+MountFlags=slave
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+TimeoutStartSec=0
+Delegate=yes
+KillMode=process
+Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
+
+[Install]
+WantedBy=multi-user.target
+`
+)
+
+func makeDockerOptionsDir(p *MinishiftProvisioner) error {
+	dockerDir := p.GetDockerOptionsDir()
+	if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s", dockerDir)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setRemoteAuthOptions(p *MinishiftProvisioner) auth.Options {
+	dockerDir := p.GetDockerOptionsDir()
+	authOptions := p.GetAuthOptions()
+
+	// due to windows clients, we cannot use filepath.Join as the paths
+	// will be mucked on the linux hosts
+	authOptions.CaCertRemotePath = path.Join(dockerDir, "ca.pem")
+	authOptions.ServerCertRemotePath = path.Join(dockerDir, "server.pem")
+	authOptions.ServerKeyRemotePath = path.Join(dockerDir, "server-key.pem")
+
+	return authOptions
+}
+
+
+func decideStorageDriver(p *MinishiftProvisioner, defaultDriver, suppliedDriver string) (string, error) {
+	if suppliedDriver != "" {
+		return suppliedDriver, nil
+	}
+	bestSuitedDriver := ""
+
+	defer func() {
+		if bestSuitedDriver != "" {
+			log.Debugf("No storagedriver specified, using %s\n", bestSuitedDriver)
+		}
+	}()
+
+	if defaultDriver != "aufs" {
+		bestSuitedDriver = defaultDriver
+	} else {
+		remoteFilesystemType, err := getFilesystemType(p, "/var/lib")
+		if err != nil {
+			return "", err
+		}
+		if remoteFilesystemType == "btrfs" {
+			bestSuitedDriver = "btrfs"
+		} else {
+			bestSuitedDriver = "aufs"
+		}
+	}
+	return bestSuitedDriver, nil
+
+}
+
+func getFilesystemType(p *MinishiftProvisioner, directory string) (string, error) {
+	statCommandOutput, err := p.SSHCommand("stat -f -c %T " + directory)
+	if err != nil {
+		err = fmt.Errorf("Error looking up filesystem type: %s", err)
+		return "", err
+	}
+
+	fstype := strings.TrimSpace(statCommandOutput)
+	return fstype, nil
+}


### PR DESCRIPTION
Fix for issue #136

This patch will add a custom provisioner for our minishift/rhel iso. I will include test around it also. Currently it's just to get feedback about the approach. 

- Provide images to test this PR
     - For CentOS you can create images using https://github.com/minishift/minishift-centos-iso 

TODO
=====

- Modification as per review.