### PR TITLE
Fix #186 Building the default b2d ISO fails

### DIFF
--- a/deploy/iso/Dockerfile
+++ b/deploy/iso/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fSL -o /tmp/dockerbin.tgz https://get.docker.com/builds/Linux/x86_64/d
 RUN $ROOTFS/usr/local/bin/docker -v
 
 # Build the actual iso image
-RUN /make_iso.sh
+RUN /tmp/make_iso.sh
 
 # Output it to transfer back to the host
 CMD ["cat", "boot2docker.iso"]


### PR DESCRIPTION
This patch will fix b2d iso creation. https://github.com/boot2docker/boot2docker/commit/2d5e77def87a9b9daa156c44bc17d8af183a4744 what caused this issue. 