### PR TITLE
Issue #208 Adding instructions for homebrew cask install of minishift-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can also install the latest unstable version of minishift, after you install
 You can now install the latest unstable version of minishift.
 
   ```sh
-  $ brew cask install minishift-unstable
+  $ brew cask install minishift-beta
   ```
 
 <a name="quickstart"></a>

--- a/README.md
+++ b/README.md
@@ -58,8 +58,20 @@ location and optionally ensure it is added to your _PATH_.
 
 On OS X you can also use [Homebrew Cask](https://caskroom.github.io) to install Minishift:
 
-  ```
+  ```sh
   $ brew cask install minishift
+  ```
+
+You can also install the latest unstable version of minishift, after you install homebrew-cask, run the following command:
+
+  ```sh
+  $ brew tap caskroom/versions
+  ```
+
+You can now install the latest unstable version of minishift.
+
+  ```sh
+  $ brew cask install minishift-unstable
   ```
 
 <a name="quickstart"></a>

--- a/README.md
+++ b/README.md
@@ -56,23 +56,29 @@ it needs to be disabled.
 Download the archive matching your host OS from the Minishift [releases page](https://github.com/minishift/minishift/releases) and unpack it. Then copy the contained binary to your preferred
 location and optionally ensure it is added to your _PATH_.
 
-On OS X you can also use [Homebrew Cask](https://caskroom.github.io) to install Minishift:
+#### macOS
 
-  ```sh
+##### Stable
+
+On macOS you can also use [Homebrew Cask](https://caskroom.github.io) to install Minishift:
+
+```sh
   $ brew cask install minishift
-  ```
+```
 
-If you want to install the latest unstable version of minishift you will need the homebrew-cask versions tap. After you install homebrew-cask, run the following command:
+##### Latest Beta
 
-  ```sh
+If you want to install the latest beta version of minishift you will need the homebrew-cask versions tap. After you install homebrew-cask, run the following command:
+
+```sh
   $ brew tap caskroom/versions
-  ```
+```
 
-You can now install the latest unstable version of minishift.
+You can now install the latest beta version of minishift.
 
-  ```sh
+```sh
   $ brew cask install minishift-beta
-  ```
+```
 
 <a name="quickstart"></a>
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ On OS X you can also use [Homebrew Cask](https://caskroom.github.io) to install 
   $ brew cask install minishift
   ```
 
-You can also install the latest unstable version of minishift, after you install homebrew-cask, run the following command:
+If you want to install the latest unstable version of minishift you will need the homebrew-cask versions tap. After you install homebrew-cask, run the following command:
 
   ```sh
   $ brew tap caskroom/versions


### PR DESCRIPTION
As my PR has been accepted at `homebrew-versions` for the `minishift-beta` formula https://github.com/caskroom/homebrew-versions/pull/3046 this PR is to update the `README.md` to document how to install the latest beta version.

This PR also closes #208 

In the future when a minishift release is done there will need to be updates to the following homebrew cask repository files:

- all releases - https://github.com/caskroom/homebrew-versions/blob/master/Casks/minishift-beta.rb
- stable releases - https://github.com/caskroom/homebrew-cask/blob/master/Casks/minishift.rb