### PR TITLE
Issue #137 Allow registration for host VM

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,9 @@ build_script:
 - make cross test
 
 artifacts:
-  - path: out\minishift-*
+  - path: out\linux-amd64\minishift
+    name: Linux minishift binary
+  - path: out\darwin-amd64\minishift
+    name: OS-X minishift binary
+  - path: out\windows-amd64\minishift.exe
+    name: Windows minishift binary

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/spf13/cobra"
+	"github.com/minishift/minishift/pkg/minishift/registration"
 )
 
 // deleteCmd represents the delete command
@@ -36,6 +37,16 @@ associated files.`,
 		fmt.Println("Deleting local OpenShift cluster...")
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
+		host, err := api.Load(constants.MachineName)
+		if err != nil {
+			fmt.Println("Errors occurred deleting machine: ", err)
+			os.Exit(1)
+		}
+		// Unregister Host VM
+		if err := registration.UnregisterHostVM(host, RegistrationParameters); err !=nil {
+			fmt.Printf("Error unregistring Host VM: %s", err)
+			os.Exit(1)
+		}
 
 		if err := cluster.DeleteHost(api); err != nil {
 			fmt.Println("Errors occurred deleting machine: ", err)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/config"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/update"
+	"github.com/minishift/minishift/pkg/minishift/registration"
 )
 
 var dirs = [...]string{
@@ -49,14 +50,14 @@ var dirs = [...]string{
 
 const (
 	showLibmachineLogs = "show-libmachine-logs"
-)
-
-const (
 	disableUpdateNotification = "disable-update-notification"
+	username                  = "username"
+	password                  = "password"
 )
 
 var (
 	enableUpdateNotification = true
+	RegistrationParameters = new(registration.RegistrationParametersStruct)
 )
 
 var viperWhiteList = []string{
@@ -123,6 +124,8 @@ func setFlagsUsingViper() {
 func init() {
 	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Whether or not to show logs from libmachine.")
 	RootCmd.PersistentFlags().Bool(disableUpdateNotification, false, "Whether to disable VM update check.")
+	RootCmd.PersistentFlags().String(username, "", "Username to register Virtual Machine")
+	RootCmd.PersistentFlags().String(password, "", "Password to register Virtual Machine")
 	RootCmd.AddCommand(configCmd.ConfigCmd)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	logDir := pflag.Lookup("log_dir")
@@ -155,4 +158,10 @@ func setupViper() {
 	viper.SetDefault(config.WantUpdateNotification, true)
 	viper.SetDefault(config.ReminderWaitPeriodInHours, 24)
 	setFlagsUsingViper()
+	setRegistrationParam()
+}
+
+func setRegistrationParam()  {
+	RegistrationParameters.Username = viper.GetString("username")
+	RegistrationParameters.Password = viper.GetString("password")
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -36,6 +36,7 @@ import (
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/minishift/minishift/pkg/minishift/registration"
 )
 
 const (
@@ -134,6 +135,11 @@ func runStart(cmd *cobra.Command, args []string) {
 	err := util.Retry(3, start)
 	if err != nil {
 		glog.Errorln("Error starting host: ", err)
+		os.Exit(1)
+	}
+	// Register Host VM
+	if err := registration.RegisterHostVM(host, RegistrationParameters); err !=nil {
+		fmt.Printf("Error registering Host VM: %s", err)
 		os.Exit(1)
 	}
 

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -24,6 +24,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/spf13/cobra"
+	"github.com/minishift/minishift/pkg/minishift/registration"
 )
 
 // stopCmd represents the stop command
@@ -36,6 +37,17 @@ itself, leaving all files intact. The cluster can be started again with the "sta
 		fmt.Println("Stopping local OpenShift cluster...")
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
+
+		host, err := api.Load(constants.MachineName)
+		if err != nil {
+			fmt.Println("Errors occurred deleting machine: ", err)
+			os.Exit(1)
+		}
+		// Unregister Host VM
+		if err := registration.UnregisterHostVM(host, RegistrationParameters); err !=nil {
+			fmt.Printf("Error unregistring Host VM: %s", err)
+			os.Exit(1)
+		}
 
 		if err := cluster.StopHost(api); err != nil {
 			fmt.Println("Error stopping machine: ", err)

--- a/docs/minishift.md
+++ b/docs/minishift.md
@@ -16,8 +16,10 @@ Minishift is a CLI tool that provisions and manages single-node OpenShift cluste
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_config.md
+++ b/docs/minishift_config.md
@@ -33,8 +33,10 @@ minishift config SUBCOMMAND [flags]
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_config_get.md
+++ b/docs/minishift_config_get.md
@@ -20,8 +20,10 @@ minishift config get PROPERTY_NAME
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_config_set.md
+++ b/docs/minishift_config_set.md
@@ -21,8 +21,10 @@ minishift config set PROPERTY_NAME PROPERTY_VALUE
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_config_unset.md
+++ b/docs/minishift_config_unset.md
@@ -20,8 +20,10 @@ minishift config unset PROPERTY_NAME
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_config_view.md
+++ b/docs/minishift_config_view.md
@@ -27,8 +27,10 @@ For the list of accessible variables for the template, see the struct values her
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_console.md
+++ b/docs/minishift_console.md
@@ -26,8 +26,10 @@ minishift console
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_delete.md
+++ b/docs/minishift_delete.md
@@ -21,8 +21,10 @@ minishift delete
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_docker-env.md
+++ b/docs/minishift_docker-env.md
@@ -28,8 +28,10 @@ minishift docker-env
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_get-openshift-versions.md
+++ b/docs/minishift_get-openshift-versions.md
@@ -20,8 +20,10 @@ minishift get-openshift-versions
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_ip.md
+++ b/docs/minishift_ip.md
@@ -20,8 +20,10 @@ minishift ip
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_logs.md
+++ b/docs/minishift_logs.md
@@ -20,8 +20,10 @@ minishift logs
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_service.md
+++ b/docs/minishift_service.md
@@ -29,8 +29,10 @@ minishift service [flags] SERVICE
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_service_list.md
+++ b/docs/minishift_service_list.md
@@ -27,8 +27,10 @@ minishift service list [flags]
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_ssh.md
+++ b/docs/minishift_ssh.md
@@ -20,8 +20,10 @@ minishift ssh
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_start.md
+++ b/docs/minishift_start.md
@@ -47,8 +47,10 @@ minishift start
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_status.md
+++ b/docs/minishift_status.md
@@ -20,8 +20,10 @@ minishift status
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_stop.md
+++ b/docs/minishift_stop.md
@@ -21,8 +21,10 @@ minishift stop
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/minishift_version.md
+++ b/docs/minishift_version.md
@@ -20,8 +20,10 @@ minishift version
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
+      --password string                Password to register Virtual Machine
       --show-libmachine-logs           Whether or not to show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
+      --username string                Username to register Virtual Machine
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/pkg/minishift/registration/redhat.go
+++ b/pkg/minishift/registration/redhat.go
@@ -1,0 +1,80 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine/provision"
+	"strings"
+)
+
+func init() {
+	Register("Redhat", &RegisteredRegistrator{
+		New: NewRedhatRegistrator,
+	})
+}
+
+func NewRedhatRegistrator(c provision.SSHCommander) Registrator {
+	return &RedhatRegistrator{
+		SSHCommander: c,
+	}
+}
+
+type RedhatRegistrator struct {
+	provision.SSHCommander
+}
+
+func (registrator *RedhatRegistrator) CompatibleWithDistribution(osReleaseInfo *provision.OsRelease) bool {
+	if osReleaseInfo.ID != "rhel" {
+		return false
+	}
+	if _, err := registrator.SSHCommand("sudo subscription-manager version"); err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func (registrator *RedhatRegistrator) Register(param *RegistrationParametersStruct) error {
+	if output, err := registrator.SSHCommand("sudo subscription-manager version"); err != nil {
+		return err
+	} else {
+		if strings.Contains(output, "not registered") {
+			subscriptionCommand := fmt.Sprintf("sudo subscription-manager register --auto-attach " +
+							"--username %s " +
+							"--password %s ", param.Username, param.Password)
+			if _, err := registrator.SSHCommand(subscriptionCommand); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (registrator *RedhatRegistrator) Unregister(param *RegistrationParametersStruct) error {
+	if output, err := registrator.SSHCommand("sudo subscription-manager version"); err != nil {
+		return err
+	} else {
+		if !strings.Contains(output, "not registered") {
+			if _, err := registrator.SSHCommand(
+				"sudo subscription-manager unregister"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/minishift/registration/redhat_test.go
+++ b/pkg/minishift/registration/redhat_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration
+
+import (
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/minishift/minishift/pkg/minikube/tests"
+	"testing"
+	"github.com/docker/machine/libmachine/provision"
+)
+
+var (
+	param = &RegistrationParametersStruct{
+		Username: "foo",
+		Password: "foo",
+	}
+)
+
+func TestRedhatRegistratorCompatibleWithDistribution(t *testing.T) {
+	s, _ := tests.NewSSHServer()
+	s.CommandToOutput = make(map[string]string)
+	s.CommandToOutput["sudo subscription-manager version"] = `server type: This system is currently not registered.`
+	port, err := s.Start()
+	if err != nil {
+		t.Fatalf("Error starting ssh server: %s", err)
+	}
+	d := &tests.MockDriver{
+		Port: port,
+		BaseDriver: drivers.BaseDriver{
+			IPAddress:  "127.0.0.1",
+			SSHKeyPath: "",
+		},
+	}
+
+	commander := provision.GenericSSHCommander{Driver: d}
+
+	registrator := NewRedhatRegistrator(commander)
+	info := &provision.OsRelease{
+		Name:      "Red Hat Enterprise Linux Server",
+		ID: 	   "rhel",
+		VersionID: "7.3",
+	}
+	if !registrator.CompatibleWithDistribution(info) {
+		t.Fatal("Registration capability should be in the Distribution")
+	}
+}
+
+func TestRedhatRegistratorRegister(t *testing.T) {
+	s, _ := tests.NewSSHServer()
+	s.CommandToOutput = make(map[string]string)
+	port, err := s.Start()
+	if err != nil {
+		t.Fatalf("Error starting ssh server: %s", err)
+	}
+	d := &tests.MockDriver{
+		Port: port,
+		BaseDriver: drivers.BaseDriver{
+			IPAddress:  "127.0.0.1",
+			SSHKeyPath: "",
+		},
+	}
+	commander := provision.GenericSSHCommander{Driver: d}
+	registrator := NewRedhatRegistrator(commander)
+	s.CommandToOutput["sudo subscription-manager version"] = `server type: RedHat Subscription Management`
+	if err := registrator.Register(param); err != nil {
+		t.Fatal("Distribution shouldn't have to register")
+	} else {
+		cmd := "sudo subscription-manager register --auto-attach --username foo --password foo"
+		if _, ok := s.Commands[cmd]; ok{
+			t.Fatalf("Expected command: %s", cmd)
+		}
+	}
+	s.CommandToOutput["sudo subscription-manager version"] = `server type: This system is currently not registered.`
+	if err := registrator.Register(param); err != nil {
+		t.Fatal("Distribution should able to register")
+	} else {
+		cmd := "sudo subscription-manager register --auto-attach --username foo --password foo "
+		if _, ok := s.Commands[cmd]; !ok{
+			t.Fatalf("Expected command: %s", cmd)
+		}
+	}
+
+}
+
+func TestRedhatRegistratorUnregister(t *testing.T) {
+	s, _ := tests.NewSSHServer()
+	s.CommandToOutput = make(map[string]string)
+	port, err := s.Start()
+	if err != nil {
+		t.Fatalf("Error starting ssh server: %s", err)
+	}
+	d := &tests.MockDriver{
+		Port: port,
+		BaseDriver: drivers.BaseDriver{
+			IPAddress:  "127.0.0.1",
+			SSHKeyPath: "",
+		},
+	}
+	commander := provision.GenericSSHCommander{Driver: d}
+	registrator := NewRedhatRegistrator(commander)
+	s.CommandToOutput["sudo subscription-manager version"] = `server type: This system is currently not registered.`
+	if err := registrator.Unregister(param); err != nil {
+		t.Fatal("Distribution shouldn't able to unregister")
+	} else {
+		cmd := "sudo subscription-manager unregister"
+		if _, ok := s.Commands[cmd]; ok{
+			t.Fatalf("Expected command: %s", cmd)
+		}
+	}
+	s.CommandToOutput["sudo subscription-manager version"] = `server type: RedHat Subscription Management`
+	if err := registrator.Unregister(param); err != nil {
+		t.Fatal("Distribution should able to unregister")
+	} else {
+		cmd := "sudo subscription-manager unregister"
+		if _, ok := s.Commands[cmd]; !ok{
+			t.Fatalf("Expected command: %s", cmd)
+		}
+	}
+}

--- a/pkg/minishift/registration/registration.go
+++ b/pkg/minishift/registration/registration.go
@@ -1,0 +1,91 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration
+
+import (
+	"errors"
+	"fmt"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/provision"
+)
+
+var (
+	ErrDetectionFailed          = errors.New("Distro type not recognized to Registration")
+	registrators                = make(map[string]*RegisteredRegistrator)
+	detector           Detector = &StandardRegistrator{}
+)
+
+type Detector interface {
+	DetectRegistrator(c provision.SSHCommander) (Registrator, error)
+}
+
+type StandardRegistrator struct{}
+
+func SetDetector(newDetector Detector) {
+	detector = newDetector
+}
+
+// Registration defines distribution specific actions
+type Registrator interface {
+	provision.SSHCommander
+
+	// Register
+	Register(param *RegistrationParametersStruct) error
+
+	// Return the auth options used to configure remote connection for the daemon.
+	Unregister(param *RegistrationParametersStruct) error
+
+	// Figure out whether this is a matching registrar
+	CompatibleWithDistribution(osReleaseInfo *provision.OsRelease) bool
+}
+
+// RegisteredRegistrator creates a new registrator
+type RegisteredRegistrator struct {
+	New func(c provision.SSHCommander) Registrator
+}
+
+func Register(name string, r *RegisteredRegistrator) {
+	registrators[name] = r
+}
+
+func DetectRegistrator(c provision.SSHCommander) (Registrator, error) {
+	return detector.DetectRegistrator(c)
+}
+
+func (detector StandardRegistrator) DetectRegistrator(c provision.SSHCommander) (Registrator, error) {
+	osReleaseOut, err := c.SSHCommand("sudo cat /etc/os-release")
+	if err != nil {
+		return nil, err
+	}
+	osReleaseInfo, err := provision.NewOsRelease([]byte(osReleaseOut))
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing /etc/os-release file: %s", err)
+	}
+
+	log.Info("Detecting Host VM is managed by registration manager...")
+
+	for _, r := range registrators {
+		registrator := r.New(c)
+
+		if registrator.CompatibleWithDistribution(osReleaseInfo) {
+			log.Debugf("found compatible host")
+			return registrator, nil
+		}
+	}
+
+	return nil, ErrDetectionFailed
+}

--- a/pkg/minishift/registration/utils.go
+++ b/pkg/minishift/registration/utils.go
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/drivers"
+)
+
+
+type RegistrationParametersStruct struct {
+	Username      string
+	Password      string
+	Proxy         string
+	Proxyuser     string
+	Proxypassword string
+}
+
+// Register host VM
+func RegisterHostVM(host *host.Host, param *RegistrationParametersStruct) error {
+	commander := provision.GenericSSHCommander{Driver: host.Driver}
+	registrator, err := DetectRegistrator(commander)
+	if err == ErrDetectionFailed {
+		fmt.Println("Distribution doesn't support registration")
+	} else if err != nil {
+		fmt.Errorf("Error running registration: %s", err)
+		return fmt.Errorf("Error running registration: %s", err)
+	}
+
+	if registrator != nil {
+		if param.Username == "" || param.Password == "" {
+			return fmt.Errorf("Either MINISHIFT_USERNAME/MINISHIFT_PASSWORD not set as Environment" +
+				" variable or username/password not provided using --username/--password\n")
+		}
+		if err := registrator.Register(param); err != nil {
+			return fmt.Errorf("Error running registration: %s", err)
+		}
+	}
+	return nil
+}
+
+// Unregister host VM
+func UnregisterHostVM(host *host.Host, param *RegistrationParametersStruct) error {
+	commander := provision.GenericSSHCommander{Driver: host.Driver}
+	registrator, err := DetectRegistrator(commander)
+
+	if err == ErrDetectionFailed {
+		fmt.Println("Distribution doesn't support unregistration")
+	} else if err != drivers.ErrHostIsNotRunning { } else if err != nil {
+		return fmt.Errorf("Error during unregistration: %s", err)
+
+	}
+
+	if registrator != nil {
+		fmt.Println("Unregistering Distribution")
+		if err := registrator.Unregister(param); err != nil {
+			return fmt.Errorf("Error during unregistration: %s", err)
+		}
+	}
+	return nil
+}
+
+


### PR DESCRIPTION
Below is some test run from this patch.

```
 $ ./minikube start --vm-driver=xhyve --iso-url=file:/Users/prkumar/minishift-rhel.iso --username=<vaild_username> --password=<vaild_password>
Starting local OpenShift cluster...
Provisioning OpenShift via '/Users/prkumar/.minishift/cache/oc/v1.3.1/oc [cluster up]'
-- Checking OpenShift client ... OK
-- Checking Docker client ... OK
-- Checking Docker version ... OK
-- Checking for existing OpenShift container ... OK
-- Checking for openshift/origin:v1.3.1 image ... 

$ ./minikube start --vm-driver=xhyve --iso-url=file:/Users/prkumar/minishift-rhel.iso --username=<valid_username>
Starting local OpenShift cluster...
Error registering Host VM: Either MINISHIFT_USERNAME/MINISHIFT_PASSWORD not set as Environment variable or username/password not provided using --username/--password

$ ./minikube delete
Deleting local OpenShift cluster...
Unregistering Distribution
Machine deleted

$ ./minikube start --vm-driver=xhyve --iso-url=file:/Users/prkumar/minishift-rhel.iso --username=<valid_username> --password=<invalid_password>
Starting local OpenShift cluster...
Error registering Host VM: Error running registration: Something went wrong running an SSH command!
command : sudo subscription-manager register --auto-attach --username ******* --password ****** 
err     : exit status 70
output  : Registering to: subscription.rhsm.redhat.com:443/subscription
Invalid username or password. To create a login, please visit https://www.redhat.com/wapps/ugc/register.html

$ ./minikube stop
Stopping local OpenShift cluster...
Unregistering Distribution
Machine stopped.

12:46 $ ./minikube stop
Stopping local OpenShift cluster...
Error stopping machine:  Machine "minishift" is already stopped.

$ ./minikube start --vm-driver=xhyve --iso-url=file:/Users/prkumar/minishift-centos.iso --show-libmachine-logs
Starting local OpenShift cluster...
Running pre-create checks...
Creating machine...
(minishift) Downloading /Users/prkumar/.minishift/cache/boot2docker.iso from file:/Users/prkumar/minishift-centos.iso...
(minishift) Creating VM...
(minishift) /dev/disk12         	                               	/Users/prkumar/.minishift/machines/minishift/b2d-image
(minishift) "disk12" unmounted.
(minishift) "disk12" ejected.
(minishift) Generating 20000MB disk image...
(minishift) created: /Users/prkumar/.minishift/machines/minishift/root-volume.sparsebundle
(minishift) Creating SSH key...
(minishift) Fix file permission...
(minishift) Using Supplied UUID: F4BB3F79-AB4E-4708-95CA-E32FBFCDEFD3
(minishift) Convert UUID to MAC address...
(minishift) Starting minishift...
(minishift) Waiting for VM to come online...
(minishift) Waiting on a pseudo-terminal to be ready... done
(minishift) Hook up your terminal emulator to /dev/ttys002 in order to connect to your VM
Waiting for machine to be running, this may take a few minutes...
Detecting operating system of created instance...
Waiting for SSH to be available...
Detecting the provisioner...
Provisioning with minishift...
Copying certs to the local machine directory...
Copying certs to the remote machine...
Setting Docker configuration on the remote daemon...
Checking connection to Docker...
Docker is up and running!
Detecting Host VM is managed by registration manager...
Distribution doesn't support registration
Provisioning OpenShift via '/Users/prkumar/.minishift/cache/oc/v1.3.1/oc [cluster up]'
-- Checking OpenShift client ... OK
-- Checking Docker client ... OK
-- Checking Docker version ... OK
-- Checking for existing OpenShift container ... OK
-- Checking for openshift/origin:v1.3.1 image ... 
   Pulling image openshift/origin:v1.3.1
   Pulled 0/3 layers, 3% complete
   Pulled 1/3 layers, 67% complete
   Pulled 2/3 layers, 87% complete
   Pulled 3/3 layers, 100% complete
   Extracting
   Image pull complete
-- Checking Docker daemon configuration ... OK
-- Checking for available ports ... OK
-- Checking type of volume mount ... 
   Using nsenter mounter for OpenShift volumes
-- Creating host directories ... OK
-- Finding server IP ... 
   Using 192.168.64.2 as the server IP
-- Starting OpenShift container ... 
   Creating initial OpenShift configuration
   Starting OpenShift using container 'origin'
   Waiting for API server to start listening
   OpenShift server started
-- Installing registry ... OK
-- Installing router ... OK
-- Importing image streams ... OK
-- Importing templates ... OK
-- Login to server ... OK
-- Creating initial project "myproject" ... OK
-- Server Information ... 
   OpenShift server started.
   The server is accessible via web console at:
       https://192.168.64.2:8443

   You are logged in as:
       User:     developer
       Password: developer

   To login as administrator:
       oc login -u system:admin

$ ./minikube delete
Deleting local OpenShift cluster...
Distribution doesn't support unregistration
Machine deleted.

$ ./minikube delete
Deleting local OpenShift cluster...
Errors occurred deleting machine:  Host does not exist: "minishift"
```

With environment variable test

```
$ export MINISHIFT_USERNAME=<valid_username>
$ export MINISHIFT_PASSWORD=<valid_password>

$ ./minikube start --vm-driver=xhyve --iso-url=file:/Users/prkumar/minishift-rhel.iso  --show-libmachine-logs
Starting local OpenShift cluster...
Running pre-create checks...
Creating machine...
(minishift) Downloading /Users/prkumar/.minishift/cache/boot2docker.iso from file:/Users/prkumar/minishift-rhel.iso...
(minishift) Creating VM...
(minishift) /dev/disk12         	                               	/Users/prkumar/.minishift/machines/minishift/b2d-image
(minishift) "disk12" unmounted.
(minishift) "disk12" ejected.
(minishift) Generating 20000MB disk image...
(minishift) created: /Users/prkumar/.minishift/machines/minishift/root-volume.sparsebundle
(minishift) Creating SSH key...
(minishift) Fix file permission...
(minishift) Using Supplied UUID: F4BB3F79-AB4E-4708-95CA-E32FBFCDEFD3
(minishift) Convert UUID to MAC address...
(minishift) Starting minishift...
(minishift) Waiting for VM to come online...
(minishift) Waiting on a pseudo-terminal to be ready... done
(minishift) Hook up your terminal emulator to /dev/ttys002 in order to connect to your VM
Waiting for machine to be running, this may take a few minutes...
Detecting operating system of created instance...
Waiting for SSH to be available...
Detecting the provisioner...
Provisioning with minishift...
Copying certs to the local machine directory...
Copying certs to the remote machine...
Setting Docker configuration on the remote daemon...
Checking connection to Docker...
Docker is up and running!
Detecting Host VM is managed by registration manager...
Provisioning OpenShift via '/Users/prkumar/.minishift/cache/oc/v1.3.1/oc [cluster up]'
-- Checking OpenShift client ... OK
-- Checking Docker client ... OK
-- Checking Docker version ... OK
...

$ ./minikube ssh
Last login: Fri Dec 23 02:59:14 2016 from gateway
[docker@minishift ~]$ sudo subscription-manager version
server type: Red Hat Subscription Management => registered
subscription management server: 0.9.51.11-1
subscription management rules: 5.15
subscription-manager: 1.17.15-1.el7
python-rhsm: 1.17.9-1.el7
```