### PR TITLE
Issue #223 Improve code around VM registration

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -25,6 +25,8 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/registration"
 	"github.com/spf13/cobra"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/state"
 )
 
 // deleteCmd represents the delete command
@@ -39,14 +41,16 @@ associated files.`,
 		defer api.Close()
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			fmt.Println("Errors occurred deleting machine: ", err)
+			fmt.Println("Error occurred deleting machine: ", err)
 			os.Exit(1)
 		}
 
-		// Unregister Host VM
-		if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
-			fmt.Printf("Error unregistring machine: %s", err)
-			os.Exit(1)
+		if ! drivers.MachineInState(host.Driver, state.Stopped)() {
+			// Unregister Host VM
+			if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
+				fmt.Printf("Error unregistring machine: %s", err)
+				os.Exit(1)
+			}
 		}
 
 		if err := cluster.DeleteHost(api); err != nil {

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -25,6 +25,8 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/registration"
 	"github.com/spf13/cobra"
+	"github.com/docker/machine/libmachine/state"
+	"github.com/docker/machine/libmachine/drivers"
 )
 
 // stopCmd represents the stop command
@@ -40,14 +42,16 @@ itself, leaving all files intact. The cluster can be started again with the "sta
 
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			fmt.Println("Errors occurred deleting machine: ", err)
+			fmt.Println("Error occurred stopping machine: ", err)
 			os.Exit(1)
 		}
 
-		// Unregister Host VM
-		if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
-			fmt.Printf("Error unregistring machine: %s", err)
-			os.Exit(1)
+		if ! drivers.MachineInState(host.Driver, state.Stopped)() {
+			// Unregister Host VM
+			if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
+				fmt.Printf("Error unregistring machine: %s", err)
+				os.Exit(1)
+			}
 		}
 
 		if err := cluster.StopHost(api); err != nil {


### PR DESCRIPTION
This patch is try to resolve below issues.

>  Improve registrar detection algorithm. Don't use error (ErrDetectionFailed) for handling normal program flow

Resolved, added a bool to check registration functionality instead err.

> Review TestRedHatRegistratorRegister and TestRedHatRegistratorUnregister
        Why are register resp. unregister called twice?
        One seems to be still able to change the cmd string (at least the first time around, why?)

Resolved, fixed a error message around the command. Mock ssh only handle command output doesn't have any provision for command error or returned value.

> Add test around providing credentials, either via flags or environment variables

Tests for flags/env are already there as part of `root_test.go`. Adding `username/password` there doesn't mean any sense because that already tested against a generic way.

