### PR TITLE
Issue #233 Add overlay as default storage driver for minishift provisioners

### DIFF
--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -105,7 +105,7 @@ func (provisioner *MinishiftProvisioner) Provision(swarmOptions swarm.Options, a
 	swarmOptions.Env = engineOptions.Env
 
 	// set default storage driver for minishift
-	storageDriver, err := decideStorageDriver(provisioner, "devicemapper", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/pkg/minishift/provisioner/minishift_provisioner_test.go
+++ b/pkg/minishift/provisioner/minishift_provisioner_test.go
@@ -40,8 +40,8 @@ func TestMinishiftDefaultStorageDriver(t *testing.T) {
 	p := NewMinishiftProvisioner("", &fakedriver.Driver{})
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "devicemapper" {
-		t.Fatal("Default storage driver should be devicemapper")
+	if p.EngineOptions.StorageDriver != "overlay" {
+		t.Fatal("Default storage driver should be overlay")
 	}
 }
 


### PR DESCRIPTION
This patch will add `overlay` as default storage driver for minishift custom provisioners.