### PR TITLE
Issue #221 Unable to use cached boot2docker.iso in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ it needs to be disabled.
 Download the archive matching your host OS from the Minishift [releases page](https://github.com/minishift/minishift/releases) and unpack it. Copy the contained binary to your preferred
 location and optionally ensure it is added to your _PATH_.
 
+**Note**: Due to issue [#236](https://github.com/minishift/minishift/issues/236), you need to execute the minishift binary on Windows OS from the drive containing your %USERPROFILE% directory.
+
 <a name="installing-via-homebrew"></a>
 #### Installing via Homebrew
 

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"path/filepath"
+)
+
+func TestRemoteBoot2DockerURL(t *testing.T) {
+	var machineConfig = MachineConfig{
+		MinikubeISO: "http://github.com/fake/boot2docker.iso",
+	}
+
+	isoPath:= filepath.Join(constants.Minipath, "cache", "iso", filepath.Base(machineConfig.MinikubeISO))
+	expectedURL := "file://" + filepath.ToSlash(isoPath)
+	url := machineConfig.GetISOFileURI()
+
+	if url != expectedURL {
+		t.Fatalf("Expected URL : %s", expectedURL)
+	}
+}
+
+func TestLocalBoot2DockerURL(t *testing.T) {
+	isoPath := filepath.Join(constants.Minipath, "cache", "iso", "boot2docker.iso")
+	localISOUrl := "file://" + filepath.ToSlash(isoPath)
+
+	machineConfig := MachineConfig{
+		MinikubeISO: localISOUrl,
+	}
+
+	url := machineConfig.GetISOFileURI()
+
+	if url != localISOUrl {
+		t.Fatalf("Expected URL : %s", localISOUrl)
+	}
+}

--- a/pkg/minikube/cluster/cluster_windows.go
+++ b/pkg/minikube/cluster/cluster_windows.go
@@ -24,7 +24,7 @@ import (
 
 func createHypervHost(config MachineConfig) drivers.Driver {
 	d := hyperv.NewDriver(constants.MachineName, constants.Minipath)
-	d.Boot2DockerURL = config.MinikubeISO
+	d.Boot2DockerURL = config.GetISOFileURI()
 	d.MemSize = config.Memory
 	d.CPU = config.CPUs
 	d.DiskSize = int(config.DiskSize)

--- a/pkg/minikube/cluster/cluster_windows_test.go
+++ b/pkg/minikube/cluster/cluster_windows_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+	"reflect"
+	"path/filepath"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/docker/machine/drivers/hyperv"
+)
+
+var machineConfig = MachineConfig{
+	MinikubeISO: "https://github.com/fake/boot2docker.iso",
+	Memory: 2048,
+	CPUs: 2,
+	DiskSize: 10000,
+	VMDriver: "hyperv",
+}
+
+func TestCreateHypervHost(t *testing.T) {
+	isoPath := filepath.Join(constants.Minipath, "cache", "iso", "boot2docker.iso")
+	expectedURL := "file://" + filepath.ToSlash(isoPath)
+
+	d := createHypervHost(machineConfig)
+	expectedDriver := "*hyperv.Driver"
+
+	if reflect.TypeOf(d).String() != expectedDriver {
+		t.Fatalf("Unexpected driver type. Expected '%s' but got '%s'", expectedDriver, reflect.TypeOf(d).String())
+	}
+
+	driver := d.(*hyperv.Driver)
+
+	if driver.Boot2DockerURL != expectedURL {
+		t.Fatalf("Expected url: %s", expectedURL)
+	}
+	if driver.DiskSize != machineConfig.DiskSize {
+		t.Fatalf("Expected disk size : %d", machineConfig.DiskSize)
+	}
+	if driver.MemSize != machineConfig.Memory {
+		t.Fatalf("Expected Memory : %d", machineConfig.Memory)
+	}
+	if driver.CPU != machineConfig.CPUs {
+		t.Fatalf("Expected CPUs : %d", machineConfig.CPUs)
+	}
+	if driver.SSHUser != "docker" {
+		t.Fatal("Expected SSH User : docker")
+	}
+}


### PR DESCRIPTION
Fixes #221 .

Creating another issue to track [`Ministart start fails when running from drive other than user profile in Windows`](https://github.com/minishift/minishift/issues/236)