### PR TITLE
Issue #210 Minishift automatically apply use-existing-config

### DIFF
--- a/docs/minishift_start.md
+++ b/docs/minishift_start.md
@@ -19,8 +19,8 @@ minishift start
       --disk-size string           Disk size allocated to the minishift VM (format: <number>[<unit>], where unit = b, k, m or g) (default "20g")
       --docker-env value           Environment variables to pass to the Docker daemon. (format: key=value) (default [])
       --forward-ports              Use Docker port-forwarding to communicate with origin container. Requires 'socat' locally.
-      --host-config-dir string     Directory on Docker host for OpenShift configuration (default "/var/lib/origin/openshift.local.config")
-      --host-data-dir string       Directory on Docker host for OpenShift data. If not specified, etcd data will not be persisted on the host.
+      --host-config-dir string     Directory on Docker host for OpenShift configuration (default "/var/lib/minishift/openshift.local.config")
+      --host-data-dir string       Directory on Docker host for OpenShift data. If not specified, etcd data will not be persisted on the host. (default "/var/lib/minishift/hostdata")
       --host-only-cidr string      The CIDR to be used for the minishift VM (only supported with Virtualbox driver) (default "192.168.99.1/24")
       --host-volumes-dir string    Directory on Docker host for OpenShift volumes (default "/var/lib/origin/openshift.local.volumes")
       --insecure-registry value    Insecure Docker registries to pass to the Docker daemon (default [172.30.0.0/16])
@@ -34,7 +34,6 @@ minishift start
       --routing-suffix string      Default suffix for server routes
       --server-loglevel int        Log level for OpenShift server
       --skip-registry-check        Skip Docker daemon registry check
-      --use-existing-config        Use existing configuration if present
       --vm-driver string           VM driver is one of: [virtualbox vmwarefusion kvm xhyve hyperv] (default "kvm")
 ```
 


### PR DESCRIPTION
This patch will add `use-existing-config` by default and set `host-data-dir` and `host-config-dir` to it's default value and use can overwrite it with flags.