### PR TITLE
Issue #190 Editing cobra doc strings

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -105,9 +105,11 @@ var settings []Setting = []Setting{
 
 var ConfigCmd = &cobra.Command{
 	Use:   "config SUBCOMMAND [flags]",
-	Short: "Modify minishift config",
-	Long: `config modifies minishift config files using subcommands like "minishift config set vm-driver kvm"
-Configurable fields: ` + "\n\n" + configurableFields(),
+	Short: "Modifies Minishift configuration properties.",
+	Long: `Modifies Minishift configuration properties. Some of the configuration properties are equivalent
+to the options that you set when you run the minishift start command.
+
+Configurable properties (enter as SUBCOMMAND): ` + "\n\n" + configurableFields(),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
@@ -128,12 +130,12 @@ func ReadConfig() (MinikubeConfig, error) {
 		if os.IsNotExist(err) {
 			return make(map[string]interface{}), nil
 		}
-		return nil, fmt.Errorf("Could not open file %s: %s", constants.ConfigFile, err)
+		return nil, fmt.Errorf("Cannot open file %s: %s", constants.ConfigFile, err)
 	}
 	var m MinikubeConfig
 	m, err = decode(f)
 	if err != nil {
-		return nil, fmt.Errorf("Could not decode config %s: %s", constants.ConfigFile, err)
+		return nil, fmt.Errorf("Cannot decode config %s: %s", constants.ConfigFile, err)
 	}
 
 	return m, nil
@@ -143,12 +145,12 @@ func ReadConfig() (MinikubeConfig, error) {
 func WriteConfig(m MinikubeConfig) error {
 	f, err := os.Create(constants.ConfigFile)
 	if err != nil {
-		return fmt.Errorf("Could not open file %s: %s", constants.ConfigFile, err)
+		return fmt.Errorf("Cannot create file %s: %s", constants.ConfigFile, err)
 	}
 	defer f.Close()
 	err = encode(f, m)
 	if err != nil {
-		return fmt.Errorf("Error encoding config %s: %s", constants.ConfigFile, err)
+		return fmt.Errorf("Cannot encode config %s: %s", constants.ConfigFile, err)
 	}
 	return nil
 }

--- a/cmd/minikube/cmd/config/config_test.go
+++ b/cmd/minikube/cmd/config/config_test.go
@@ -63,7 +63,7 @@ func TestReadConfig(t *testing.T) {
 		r := bytes.NewBufferString(tt.data)
 		config, err := decode(r)
 		if reflect.DeepEqual(config, tt.config) || err != nil {
-			t.Errorf("Did not read config correctly,\n\n wanted %+v, \n\n got %+v", tt.config, config)
+			t.Errorf("Cannot decode config. \n\n expected %+v, \n\n received %+v", tt.config, config)
 		}
 	}
 }
@@ -76,7 +76,7 @@ func TestWriteConfig(t *testing.T) {
 			t.Errorf("Error encoding: %s", err)
 		}
 		if b.String() != tt.data {
-			t.Errorf("Did not write config correctly, \n\n expected:\n %+v \n\n actual:\n %+v", tt.data, b.String())
+			t.Errorf("Cannot encode config. \n\n expected \n %+v, \n\n received \n %+v", tt.data, b.String())
 		}
 		b.Reset()
 	}

--- a/cmd/minikube/cmd/config/get.go
+++ b/cmd/minikube/cmd/config/get.go
@@ -25,8 +25,8 @@ import (
 
 var configGetCmd = &cobra.Command{
 	Use:   "get PROPERTY_NAME",
-	Short: "Gets the value of PROPERTY_NAME from the minishift config file",
-	Long:  "Returns the value of PROPERTY_NAME from the minishift config file.  Can be overwritten at runtime by flags or environmental variables.",
+	Short: "Gets the value of a configuration property from the Minishift configuration file.",
+	Long: "Gets the value of a configuration property from the minishift configuration file. This value can be overwritten at runtime by flags or environmental variables.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			fmt.Fprintln(os.Stderr, "usage: minishift config get PROPERTY_NAME")

--- a/cmd/minikube/cmd/config/set.go
+++ b/cmd/minikube/cmd/config/set.go
@@ -25,9 +25,9 @@ import (
 
 var configSetCmd = &cobra.Command{
 	Use:   "set PROPERTY_NAME PROPERTY_VALUE",
-	Short: "Sets an individual value in a minishift config file",
-	Long: `Sets the PROPERTY_NAME config value to PROPERTY_VALUE
-	These values can be overwritten by flags or environment variables at runtime.`,
+	Short: "Sets the value of a configuration property in the Minishift configuration file.",
+	Long: `Sets the value of one or more configuration properties in the Minishift configuration file.
+These values can be overwritten by flags or environment variables at runtime.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 2 {
 			fmt.Fprintln(os.Stderr, "usage: minishift config set PROPERTY_NAME PROPERTY_VALUE")

--- a/cmd/minikube/cmd/config/unset.go
+++ b/cmd/minikube/cmd/config/unset.go
@@ -25,8 +25,8 @@ import (
 
 var configUnsetCmd = &cobra.Command{
 	Use:   "unset PROPERTY_NAME",
-	Short: "unsets an individual value in a minishift config file",
-	Long:  "unsets PROPERTY_NAME from the minishift config file.  Can be overwritten by flags or environmental variables",
+	Short: "Clears the value of a configuration property in the Minishift configuration file.",
+	Long: "Clears the value of a configuration property in the Minishift configuration file. The value can be overwritten at runtime by flags or environment variables",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			fmt.Fprintf(os.Stdout, "usage: minishift config unset PROPERTY_NAME")

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -43,7 +43,7 @@ func findSetting(name string) (Setting, error) {
 			return s, nil
 		}
 	}
-	return Setting{}, fmt.Errorf("Property name %s not found", name)
+	return Setting{}, fmt.Errorf("Cannot find property name %s", name)
 }
 
 // Set Functions

--- a/cmd/minikube/cmd/config/util_test.go
+++ b/cmd/minikube/cmd/config/util_test.go
@@ -27,51 +27,51 @@ var minikubeConfig = MinikubeConfig{
 func TestFindSettingNotFound(t *testing.T) {
 	s, err := findSetting("nonexistant")
 	if err == nil {
-		t.Fatalf("Shouldn't have found setting, but did. [%+v]", s)
+		t.Fatalf("Unexpected setting found. [%+v]", s)
 	}
 }
 
 func TestFindSetting(t *testing.T) {
 	s, err := findSetting("vm-driver")
 	if err != nil {
-		t.Fatalf("Couldn't find setting, vm-driver: %s", err)
+		t.Fatalf("Cannot find the setting of the vm-driver: %s", err)
 	}
 	if s.name != "vm-driver" {
-		t.Fatalf("Found wrong setting, expected vm-driver, got %s", s.name)
+		t.Fatalf("Incorrect setting, expected vm-driver, received %s", s.name)
 	}
 }
 
 func TestSetString(t *testing.T) {
 	err := SetString(minikubeConfig, "vm-driver", "virtualbox")
 	if err != nil {
-		t.Fatalf("Couldnt set string: %s", err)
+		t.Fatalf("Cannot set the string: %s", err)
 	}
 }
 
 func TestSetInt(t *testing.T) {
 	err := SetInt(minikubeConfig, "cpus", "22")
 	if err != nil {
-		t.Fatalf("Couldn't set int in config: %s", err)
+		t.Fatalf("Cannot set integer value in config: %s", err)
 	}
 	val, ok := minikubeConfig["cpus"].(int)
 	if !ok {
-		t.Fatalf("Type not set to int")
+		t.Fatalf("Type is not set to int")
 	}
 	if val != 22 {
-		t.Fatalf("SetInt set wrong value")
+		t.Fatalf("SetInt set value is incorrect")
 	}
 }
 
 func TestSetBool(t *testing.T) {
 	err := SetBool(minikubeConfig, "show-libmachine-logs", "true")
 	if err != nil {
-		t.Fatalf("Couldn't set bool in config: %s", err)
+		t.Fatalf("Cannot set boolean value in config: %s", err)
 	}
 	val, ok := minikubeConfig["show-libmachine-logs"].(bool)
 	if !ok {
-		t.Fatalf("Type not set to bool")
+		t.Fatalf("Type is not set to bool")
 	}
 	if !val {
-		t.Fatalf("SetBool set wrong value")
+		t.Fatalf("SetBool set value is incorrect")
 	}
 }

--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -37,14 +37,14 @@ func IsValidDriver(string, driver string) error {
 }
 
 func RequiresRestartMsg(string, string) error {
-	fmt.Fprintln(os.Stdout, "These changes will take effect upon a minishift delete and then a minishift start")
+	fmt.Fprintln(os.Stdout, "To apply the changes, you must delete the current VM with `minishift delete` and start a new VM with `minishift start`.")
 	return nil
 }
 
 func IsValidDiskSize(name string, disksize string) error {
 	_, err := units.FromHumanSize(disksize)
 	if err != nil {
-		return fmt.Errorf("Not valid disk size: %v", err)
+		return fmt.Errorf("Disk size is not valid: %v", err)
 	}
 	return nil
 }

--- a/cmd/minikube/cmd/config/view.go
+++ b/cmd/minikube/cmd/config/view.go
@@ -36,8 +36,8 @@ type ConfigViewTemplate struct {
 
 var configViewCmd = &cobra.Command{
 	Use:   "view",
-	Short: "Display values currently set in the minishift config file",
-	Long:  "Display values currently set in the minishift  config file.",
+	Short: "Display the properties and values of the Minishift configuration file.",
+	Long: "Display the properties and values of the Minishift configuration file. You can set the output format from one of the available Go templates.",
 	Run: func(cmd *cobra.Command, args []string) {
 		err := configView()
 		if err != nil {
@@ -49,8 +49,8 @@ var configViewCmd = &cobra.Command{
 
 func init() {
 	configViewCmd.Flags().StringVar(&configViewFormat, "format", constants.DefaultConfigViewFormat,
-		`Go template format string for the config view output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-For the list of accessible variables for the template, see the struct values here: https://godoc.org/github.com/jimmidyson/minishift/cmd/minikube/cmd/config#ConfigViewTemplate`)
+		`Go template format to apply to the configuration file. For more information about Go templates, see: https://golang.org/pkg/text/template/
+		For the list of configurable variables for the template, see the struct values section of ConfigViewTemplate at: https://godoc.org/github.com/minishift/minishift/cmd/minikube/cmd/config#ConfigViewTemplate`)
 }
 
 func init() {

--- a/cmd/minikube/cmd/console.go
+++ b/cmd/minikube/cmd/console.go
@@ -35,26 +35,26 @@ var (
 // consoleCmd represents the console command
 var consoleCmd = &cobra.Command{
 	Use:   "console",
-	Short: "Opens/displays the OpenShift console URL for your local cluster",
-	Long:  `Opens/displays the OpenShift console URL for your local cluster`,
+	Short: "Opens the OpenShift Web console to the root of your local cluster.",
+	Long:  `Opens the OpenShift Web console to the root of your local cluster in the default browser.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
 		url, err := cluster.GetConsoleURL(api)
 		if err != nil {
-			glog.Errorln("Error accessing the OpenShift console (is minishift running?): Error: ", err)
+			glog.Errorln("Cannot access the OpenShift console. Verify that Minishift is running. Error: ", err)
 			os.Exit(1)
 		}
 		if consoleURLMode {
 			fmt.Fprintln(os.Stdout, url)
 		} else {
-			fmt.Fprintln(os.Stdout, "Opening OpenShift console in default browser...")
+			fmt.Fprintln(os.Stdout, "Opening the OpenShift Web console in the default browser...")
 			browser.OpenURL(url)
 		}
 	},
 }
 
 func init() {
-	consoleCmd.Flags().BoolVar(&consoleURLMode, "url", false, "Display the OpenShift console in the CLI instead of opening it in the default browser")
+	consoleCmd.Flags().BoolVar(&consoleURLMode, "url", false, "Open the local cluster in the OpenShift CLI console instead of the Web console.")
 	RootCmd.AddCommand(consoleCmd)
 }

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -32,32 +32,31 @@ import (
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Deletes a local OpenShift cluster.",
-	Long: `Deletes a local OpenShift cluster. This command deletes the VM, and removes all
-associated files.`,
+	Short: "Deletes the Minishift VM.",
+	Long: `Deletes the Minishift VM, including the local OpenShift cluster and all associated files.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Deleting local OpenShift instance...")
+		fmt.Println("Deleting the Minishift VM...")
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			fmt.Println("Error occurred deleting machine: ", err)
+			fmt.Println("Error occurred while deleting the VM: ", err)
 			os.Exit(1)
 		}
 
 		if !drivers.MachineInState(host.Driver, state.Stopped)() {
 			// Unregister Host VM
 			if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
-				fmt.Printf("Error unregistring machine: %s", err)
+				fmt.Printf("Error unregistring the VM: %s", err)
 				os.Exit(1)
 			}
 		}
 
 		if err := cluster.DeleteHost(api); err != nil {
-			fmt.Println("Errors occurred deleting machine: ", err)
+			fmt.Println("Error deleting the VM: ", err)
 			os.Exit(1)
 		}
-		fmt.Println("Machine deleted.")
+		fmt.Println("Minishift VM deleted.")
 	},
 }
 

--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -224,8 +224,8 @@ func findNoProxyFromEnv() (string, string) {
 // envCmd represents the docker-env command
 var dockerEnvCmd = &cobra.Command{
 	Use:   "docker-env",
-	Short: "sets up docker env variables; similar to '$(docker-machine env)'",
-	Long:  `sets up docker env variables; similar to '$(docker-machine env)'`,
+	Short: "Sets Docker environment variables.",
+	Long:  `Sets Docker environment variables, similar to '$(docker-machine env)'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
@@ -239,13 +239,13 @@ var dockerEnvCmd = &cobra.Command{
 		if unset {
 			shellCfg, err = shellCfgUnset(api)
 			if err != nil {
-				glog.Errorln("Error setting machine env variable(s):", err)
+				glog.Errorln("Error unsetting environment variables:", err)
 				os.Exit(1)
 			}
 		} else {
 			shellCfg, err = shellCfgSet(api)
 			if err != nil {
-				glog.Errorln("Error setting machine env variable(s):", err)
+				glog.Errorln("Error setting environment variables:", err)
 				os.Exit(1)
 			}
 		}
@@ -256,7 +256,7 @@ var dockerEnvCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(dockerEnvCmd)
-	dockerEnvCmd.Flags().BoolVar(&noProxy, "no-proxy", false, "Add machine IP to NO_PROXY environment variable")
-	dockerEnvCmd.Flags().StringVar(&forceShell, "shell", "", "Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect")
-	dockerEnvCmd.Flags().BoolVarP(&unset, "unset", "u", false, "Unset variables instead of setting them")
+	dockerEnvCmd.Flags().BoolVar(&noProxy, "no-proxy", false, "Add the virtual machine IP to the NO_PROXY environment variable.")
+	dockerEnvCmd.Flags().StringVar(&forceShell, "shell", "", "Force setting the environment for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh]. Default is auto-detect.")
+	dockerEnvCmd.Flags().BoolVarP(&unset, "unset", "u", false, "Clear the environment variable values instead of setting them.")
 }

--- a/cmd/minikube/cmd/get_openshift_versions.go
+++ b/cmd/minikube/cmd/get_openshift_versions.go
@@ -26,8 +26,8 @@ import (
 // getVersionsCmd represents the ip command
 var getVersionsCmd = &cobra.Command{
 	Use:   "get-openshift-versions",
-	Short: "Gets the list of available OpenShift versions available for minishift.",
-	Long:  `Gets the list of available OpenShift versions available for minishift.`,
+	Short: "Gets the list of OpenShift versions available for Minishift.",
+	Long:  `Gets the list of OpenShift versions available for Minishift.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		openshiftversions.PrintOpenShiftVersionsFromGitHub(os.Stdout)
 	},

--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -30,8 +30,8 @@ import (
 // ipCmd represents the ip command
 var ipCmd = &cobra.Command{
 	Use:   "ip",
-	Short: "Retrieve the IP address of the running cluster.",
-	Long:  `Retrieves the IP address of the running cluster, and writes it to STDOUT.`,
+	Short: "Gets the IP address of the running cluster.",
+	Long:  `Gets the IP address of the running cluster and prints it to the standard output.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -30,14 +30,14 @@ import (
 // logsCmd represents the logs command
 var logsCmd = &cobra.Command{
 	Use:   "logs",
-	Short: "Gets the logs of the running OpenShift instance, used for debugging minishift, not user code.",
-	Long:  `Gets the logs of the running OpenShift instance, used for debugging minishift, not user code.`,
+	Short: "Gets the logs of the running OpenShift cluster.",
+	Long:  `Gets the logs of the running OpenShift cluster. The logs do not contain information about your application code.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
 		s, err := cluster.GetHostLogs(api)
 		if err != nil {
-			log.Println("Error getting machine logs:", err)
+			log.Println("Error getting logs:", err)
 			os.Exit(1)
 		}
 		fmt.Fprintln(os.Stdout, s)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -66,8 +66,8 @@ var viperWhiteList = []string{
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "minishift",
-	Short: "Minishift is a tool for managing local OpenShift clusters.",
-	Long:  `Minishift is a CLI tool that provisions and manages single-node OpenShift clusters optimized for development workflows.`,
+	Short: "Minishift is a tool for application development in local OpenShift clusters.",
+	Long:  `Minishift is a command-line tool that provisions and manages single-node OpenShift clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {
@@ -112,9 +112,9 @@ func setFlagsUsingViper() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Whether or not to show logs from libmachine.")
-	RootCmd.PersistentFlags().String(username, "", "Username to register Virtual Machine")
-	RootCmd.PersistentFlags().String(password, "", "Password to register Virtual Machine")
+	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Show logs from libmachine.")
+	RootCmd.PersistentFlags().String(username, "", "User name for the virtual machine.")
+	RootCmd.PersistentFlags().String(password, "", "Password for the virtual machine.")
 	RootCmd.AddCommand(configCmd.ConfigCmd)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	logDir := pflag.Lookup("log_dir")

--- a/cmd/minikube/cmd/root_test.go
+++ b/cmd/minikube/cmd/root_test.go
@@ -94,7 +94,7 @@ func TestViperConfig(t *testing.T) {
 	defer viper.Reset()
 	err := cli.InitTestConfig(`{ "v": "999" }`)
 	if viper.GetString("v") != "999" || err != nil {
-		t.Fatalf("Viper did not read test config file: %v", err)
+		t.Fatalf("Viper cannot read the test config file: %v", err)
 	}
 }
 
@@ -106,7 +106,7 @@ func TestViperAndFlags(t *testing.T) {
 		setupViper()
 		f := pflag.Lookup(testOption.Name)
 		if f == nil {
-			t.Fatalf("Could not find flag for %s", testOption.Name)
+			t.Fatalf("Cannot find the flag for %s", testOption.Name)
 		}
 		actual := f.Value.String()
 		if actual != testOption.ExpectedValue {

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -41,19 +41,19 @@ var (
 // serviceCmd represents the service command
 var serviceCmd = &cobra.Command{
 	Use:   "service [flags] SERVICE",
-	Short: "Gets the URL for the specified service in your local cluster",
-	Long:  `Gets the URL for the specified service in your local cluster`,
+	Short: "Opens the specified service in the OpenShift Web console.",
+	Long:  `Opens the specified service in the OpenShift Web console using the default browser. You must specify the service name and namespace.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		t, err := template.New("serviceURL").Parse(serviceURLFormat)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "The value passed to --format is invalid:\n\n", err)
+			fmt.Fprintln(os.Stderr, "The URL format specified in the --format option is not valid: \n\n", err)
 			os.Exit(1)
 		}
 		serviceURLTemplate = t
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 || len(args) > 1 {
-			fmt.Fprintln(os.Stderr, "Please specify a service name.")
+			fmt.Fprintln(os.Stderr, "You must specify the name of the service.")
 			os.Exit(1)
 		}
 
@@ -66,7 +66,7 @@ var serviceCmd = &cobra.Command{
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			if _, ok := err.(cluster.MissingNodePortError); !ok {
-				fmt.Fprintln(os.Stderr, "Check that minishift is running and that you have specified the correct namespace (-n flag).")
+				fmt.Fprintln(os.Stderr, "Verify that Minishift is running and that the correct namespace is specified in the -n option.")
 			}
 			os.Exit(1)
 		}
@@ -77,16 +77,16 @@ var serviceCmd = &cobra.Command{
 		if serviceURLMode {
 			fmt.Fprintln(os.Stdout, url)
 		} else {
-			fmt.Fprintln(os.Stdout, "Opening kubernetes service "+namespace+"/"+service+" in default browser...")
+			fmt.Fprintln(os.Stdout, "Opening the service "+namespace+"/"+service+" in the default browser...")
 			browser.OpenURL(url)
 		}
 	},
 }
 
 func init() {
-	serviceCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "The service namespace")
-	serviceCmd.Flags().BoolVar(&serviceURLMode, "url", false, "Display the kubernetes service URL in the CLI instead of opening it in the default browser")
-	serviceCmd.PersistentFlags().StringVar(&serviceURLFormat, "format", "http://{{.IP}}:{{.Port}}", "Format to output service URL in")
-	serviceCmd.Flags().BoolVar(&https, "https", false, "Open the service URL with https instead of http")
+	serviceCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "The namespace of the service.")
+	serviceCmd.Flags().BoolVar(&serviceURLMode, "url", false, "Access the service in the command-line console instead of the default browser.")
+	serviceCmd.PersistentFlags().StringVar(&serviceURLFormat, "format", "http://{{.IP}}:{{.Port}}", "The URL format of the service.")
+	serviceCmd.Flags().BoolVar(&https, "https", false, "Access the service with HTTPS instead of HTTP.")
 	RootCmd.AddCommand(serviceCmd)
 }

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -34,15 +34,15 @@ var serviceListNamespace string
 // serviceListCmd represents the service list command
 var serviceListCmd = &cobra.Command{
 	Use:   "list [flags]",
-	Short: "Lists the URLs for the services in your local cluster",
-	Long:  `Lists the URLs for the services in your local cluster`,
+	Short: "Gets the URLs of the services in your local cluster.",
+	Long:  `Gets the URLs of the services in your local cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
 		serviceURLs, err := cluster.GetServiceURLs(api, serviceListNamespace, serviceURLTemplate)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			fmt.Fprintln(os.Stderr, "Check that minishift is running and that you have specified the correct namespace (-n flag) if required.")
+			fmt.Fprintln(os.Stderr, "Check that Minishift is running and that the correct namespace is specified in the -n option if it is required.")
 			os.Exit(1)
 		}
 
@@ -61,6 +61,6 @@ var serviceListCmd = &cobra.Command{
 }
 
 func init() {
-	serviceListCmd.Flags().StringVarP(&serviceListNamespace, "namespace", "n", v1.NamespaceAll, "The services namespace")
+	serviceListCmd.Flags().StringVarP(&serviceListNamespace, "namespace", "n", v1.NamespaceAll, "The namespace of the services.")
 	serviceCmd.AddCommand(serviceListCmd)
 }

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -29,14 +29,14 @@ import (
 // sshCmd represents the docker-ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
-	Short: "Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'",
-	Long:  "Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'",
+	Short: "Log in to or run a command on a Minishift VM with SSH.",
+	Long:  "Log in to or run a command on a Minishift VM with SSH. This command is similar to 'docker-machine ssh'.",
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
 		err := cluster.CreateSSHShell(api, args)
 		if err != nil {
-			glog.Errorln("Error attempting to ssh into machine: ", err)
+			glog.Errorln("Cannot establish SSH connection to the VM: ", err)
 			os.Exit(1)
 		}
 	},

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -60,7 +60,7 @@ func TestStartClusterUpNoFlags(t *testing.T) {
 
 	expectedOc := filepath.Join(testDir, "cache", "oc", testMachineConfig.OpenShiftVersion, constants.OC_BINARY_NAME)
 	if testRunner.Cmd != expectedOc {
-		t.Errorf("Expected command '%s'. Got '%s'", expectedOc, testRunner.Cmd)
+		t.Errorf("Expected command '%s'. Received '%s'", expectedOc, testRunner.Cmd)
 	}
 
 	expectedArguments := []string{"cluster", "up", "--use-existing-config",
@@ -68,7 +68,7 @@ func TestStartClusterUpNoFlags(t *testing.T) {
 		"--host-data-dir", hostDataDirectory}
 	for i, v := range testRunner.Args {
 		if v != expectedArguments[i] {
-			t.Errorf("Expected argument '%s'. Got '%s'", expectedArguments[i], v)
+			t.Errorf("Expected argument '%s'. Received '%s'", expectedArguments[i], v)
 		}
 	}
 }
@@ -145,16 +145,16 @@ func TestStartClusterUpWithOpenShiftEnv(t *testing.T) {
 
 func assertCommandLineArguments(expectedArguments []string, t *testing.T) {
 	if len(expectedArguments) > len(testRunner.Args) {
-		t.Errorf("Expected more arguments than were received. Expected: '%s'. Got: '%s'", expectedArguments, testRunner.Args)
+		t.Errorf("Expected more arguments than received. Expected: '%s'. Got: '%s'", expectedArguments, testRunner.Args)
 	}
 
 	if len(expectedArguments) < len(testRunner.Args) {
-		t.Errorf("Got more arguments than were expected. Expected: '%s'. Got '%s'", expectedArguments, testRunner.Args)
+		t.Errorf("Received more arguments than expected. Expected: '%s'. Got '%s'", expectedArguments, testRunner.Args)
 	}
 
 	for i, v := range testRunner.Args {
 		if v != expectedArguments[i] {
-			t.Errorf("Expected argument '%s'. Got '%s'", expectedArguments[i], v)
+			t.Errorf("Expected argument '%s'. Received '%s'", expectedArguments[i], v)
 		}
 	}
 }

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -31,14 +31,14 @@ import (
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Gets the status of a local OpenShift cluster.",
-	Long:  `Gets the status of a local OpenShift cluster.`,
+	Short: "Gets the status of the local OpenShift cluster.",
+	Long:  `Gets the status of the local OpenShift cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
 		s, err := cluster.GetHostStatus(api)
 		if err != nil {
-			glog.Errorln("Error getting machine status:", err)
+			glog.Errorln("Error getting cluster status:", err)
 			os.Exit(1)
 		}
 		fmt.Fprintln(os.Stdout, s)

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -32,9 +32,10 @@ import (
 // stopCmd represents the stop command
 var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stops a running local OpenShift cluster.",
-	Long: `Stops a local OpenShift cluster running in Virtualbox. This command stops the VM
-itself, leaving all files intact. The cluster can be started again with the "start" command.`,
+	Short: "Stops the running local OpenShift cluster.",
+	Long: `Stops the running local OpenShift cluster. This command stops the Minishift
+VM but does not delete any associated files. To start the cluster again, use
+the 'minishift start' command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Stopping local OpenShift cluster...")
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
@@ -42,23 +43,23 @@ itself, leaving all files intact. The cluster can be started again with the "sta
 
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			fmt.Println("Error occurred stopping machine: ", err)
+			fmt.Println("Error occurred while stopping the VM: ", err)
 			os.Exit(1)
 		}
 
 		if !drivers.MachineInState(host.Driver, state.Stopped)() {
 			// Unregister Host VM
 			if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
-				fmt.Printf("Error unregistring machine: %s", err)
+				fmt.Printf("Error unregistring the VM: %s", err)
 				os.Exit(1)
 			}
 		}
 
 		if err := cluster.StopHost(api); err != nil {
-			fmt.Println("Error stopping machine: ", err)
+			fmt.Println("Error stopping cluster: ", err)
 			os.Exit(1)
 		}
-		fmt.Println("Machine stopped.")
+		fmt.Println("Cluster stopped.")
 	},
 }
 

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -26,13 +26,13 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version of minishift.",
-	Long:  `Print the version of minishift.`,
+	Short: "Gets the version of Minishift.",
+	Long:  `Gets the currently installed version of Minishift and prints it to the standard output.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		RootCmd.PersistentPreRun(cmd, args)
 	},
 	Run: func(command *cobra.Command, args []string) {
-		fmt.Println("minishift version:", version.GetVersion())
+		fmt.Println("Minishift version:", version.GetVersion())
 	},
 }
 

--- a/docs/minishift.md
+++ b/docs/minishift.md
@@ -1,11 +1,11 @@
 ## minishift
 
-Minishift is a tool for managing local OpenShift clusters.
+Minishift is a tool for application development in local OpenShift clusters.
 
 ### Synopsis
 
 
-Minishift is a CLI tool that provisions and manages single-node OpenShift clusters optimized for development workflows.
+Minishift is a command-line tool that provisions and manages single-node OpenShift clusters optimized for development workflows.
 
 ### Options
 
@@ -15,26 +15,26 @@ Minishift is a CLI tool that provisions and manages single-node OpenShift cluste
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift config](minishift_config.md)	 - Modify minishift config
-* [minishift console](minishift_console.md)	 - Opens/displays the OpenShift console URL for your local cluster
-* [minishift delete](minishift_delete.md)	 - Deletes a local OpenShift cluster.
-* [minishift docker-env](minishift_docker-env.md)	 - sets up docker env variables; similar to '$(docker-machine env)'
-* [minishift get-openshift-versions](minishift_get-openshift-versions.md)	 - Gets the list of available OpenShift versions available for minishift.
-* [minishift ip](minishift_ip.md)	 - Retrieve the IP address of the running cluster.
-* [minishift logs](minishift_logs.md)	 - Gets the logs of the running OpenShift instance, used for debugging minishift, not user code.
-* [minishift service](minishift_service.md)	 - Gets the URL for the specified service in your local cluster
-* [minishift ssh](minishift_ssh.md)	 - Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'
+* [minishift config](minishift_config.md)	 - Modifies Minishift configuration properties.
+* [minishift console](minishift_console.md)	 - Opens the OpenShift Web console to the root of your local cluster.
+* [minishift delete](minishift_delete.md)	 - Deletes the Minishift VM.
+* [minishift docker-env](minishift_docker-env.md)	 - Sets Docker environment variables.
+* [minishift get-openshift-versions](minishift_get-openshift-versions.md)	 - Gets the list of OpenShift versions available for Minishift.
+* [minishift ip](minishift_ip.md)	 - Gets the IP address of the running cluster.
+* [minishift logs](minishift_logs.md)	 - Gets the logs of the running OpenShift cluster.
+* [minishift service](minishift_service.md)	 - Opens the specified service in the OpenShift Web console.
+* [minishift ssh](minishift_ssh.md)	 - Log in to or run a command on a Minishift VM with SSH.
 * [minishift start](minishift_start.md)	 - Starts a local OpenShift cluster.
-* [minishift status](minishift_status.md)	 - Gets the status of a local OpenShift cluster.
-* [minishift stop](minishift_stop.md)	 - Stops a running local OpenShift cluster.
-* [minishift version](minishift_version.md)	 - Print the version of minishift.
+* [minishift status](minishift_status.md)	 - Gets the status of the local OpenShift cluster.
+* [minishift stop](minishift_stop.md)	 - Stops the running local OpenShift cluster.
+* [minishift version](minishift_version.md)	 - Gets the version of Minishift.
 

--- a/docs/minishift_config.md
+++ b/docs/minishift_config.md
@@ -1,12 +1,14 @@
 ## minishift config
 
-Modify minishift config
+Modifies Minishift configuration properties.
 
 ### Synopsis
 
 
-config modifies minishift config files using subcommands like "minishift config set vm-driver kvm"
-Configurable fields: 
+Modifies Minishift configuration properties. Some of the configuration properties are equivalent
+to the options that you set when you run the minishift start command.
+
+Configurable properties (enter as SUBCOMMAND): 
 
  * vm-driver
  * v
@@ -32,18 +34,18 @@ minishift config SUBCOMMAND [flags]
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
-* [minishift config get](minishift_config_get.md)	 - Gets the value of PROPERTY_NAME from the minishift config file
-* [minishift config set](minishift_config_set.md)	 - Sets an individual value in a minishift config file
-* [minishift config unset](minishift_config_unset.md)	 - unsets an individual value in a minishift config file
-* [minishift config view](minishift_config_view.md)	 - Display values currently set in the minishift config file
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
+* [minishift config get](minishift_config_get.md)	 - Gets the value of a configuration property from the Minishift configuration file.
+* [minishift config set](minishift_config_set.md)	 - Sets the value of a configuration property in the Minishift configuration file.
+* [minishift config unset](minishift_config_unset.md)	 - Clears the value of a configuration property in the Minishift configuration file.
+* [minishift config view](minishift_config_view.md)	 - Display the properties and values of the Minishift configuration file.
 

--- a/docs/minishift_config_get.md
+++ b/docs/minishift_config_get.md
@@ -1,11 +1,11 @@
 ## minishift config get
 
-Gets the value of PROPERTY_NAME from the minishift config file
+Gets the value of a configuration property from the Minishift configuration file.
 
 ### Synopsis
 
 
-Returns the value of PROPERTY_NAME from the minishift config file.  Can be overwritten at runtime by flags or environmental variables.
+Gets the value of a configuration property from the minishift configuration file. This value can be overwritten at runtime by flags or environmental variables.
 
 ```
 minishift config get PROPERTY_NAME
@@ -19,14 +19,14 @@ minishift config get PROPERTY_NAME
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift config](minishift_config.md)	 - Modify minishift config
+* [minishift config](minishift_config.md)	 - Modifies Minishift configuration properties.
 

--- a/docs/minishift_config_set.md
+++ b/docs/minishift_config_set.md
@@ -1,12 +1,12 @@
 ## minishift config set
 
-Sets an individual value in a minishift config file
+Sets the value of a configuration property in the Minishift configuration file.
 
 ### Synopsis
 
 
-Sets the PROPERTY_NAME config value to PROPERTY_VALUE
-	These values can be overwritten by flags or environment variables at runtime.
+Sets the value of one or more configuration properties in the Minishift configuration file.
+These values can be overwritten by flags or environment variables at runtime.
 
 ```
 minishift config set PROPERTY_NAME PROPERTY_VALUE
@@ -20,14 +20,14 @@ minishift config set PROPERTY_NAME PROPERTY_VALUE
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift config](minishift_config.md)	 - Modify minishift config
+* [minishift config](minishift_config.md)	 - Modifies Minishift configuration properties.
 

--- a/docs/minishift_config_unset.md
+++ b/docs/minishift_config_unset.md
@@ -1,11 +1,11 @@
 ## minishift config unset
 
-unsets an individual value in a minishift config file
+Clears the value of a configuration property in the Minishift configuration file.
 
 ### Synopsis
 
 
-unsets PROPERTY_NAME from the minishift config file.  Can be overwritten by flags or environmental variables
+Clears the value of a configuration property in the Minishift configuration file. The value can be overwritten at runtime by flags or environment variables
 
 ```
 minishift config unset PROPERTY_NAME
@@ -19,14 +19,14 @@ minishift config unset PROPERTY_NAME
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift config](minishift_config.md)	 - Modify minishift config
+* [minishift config](minishift_config.md)	 - Modifies Minishift configuration properties.
 

--- a/docs/minishift_config_view.md
+++ b/docs/minishift_config_view.md
@@ -1,11 +1,11 @@
 ## minishift config view
 
-Display values currently set in the minishift config file
+Display the properties and values of the Minishift configuration file.
 
 ### Synopsis
 
 
-Display values currently set in the minishift  config file.
+Display the properties and values of the Minishift configuration file. You can set the output format from one of the available Go templates.
 
 ```
 minishift config view
@@ -14,8 +14,8 @@ minishift config view
 ### Options
 
 ```
-      --format string   Go template format string for the config view output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-For the list of accessible variables for the template, see the struct values here: https://godoc.org/github.com/jimmidyson/minishift/cmd/minikube/cmd/config#ConfigViewTemplate (default "- {{.ConfigKey}}: {{.ConfigValue}}\n")
+      --format string   Go template format to apply to the configuration file. For more information about Go templates, see: https://golang.org/pkg/text/template/
+		For the list of configurable variables for the template, see the struct values section of ConfigViewTemplate at: https://godoc.org/github.com/minishift/minishift/cmd/minikube/cmd/config#ConfigViewTemplate (default "- {{.ConfigKey}}: {{.ConfigValue}}\n")
 ```
 
 ### Options inherited from parent commands
@@ -26,14 +26,14 @@ For the list of accessible variables for the template, see the struct values her
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift config](minishift_config.md)	 - Modify minishift config
+* [minishift config](minishift_config.md)	 - Modifies Minishift configuration properties.
 

--- a/docs/minishift_console.md
+++ b/docs/minishift_console.md
@@ -1,11 +1,11 @@
 ## minishift console
 
-Opens/displays the OpenShift console URL for your local cluster
+Opens the OpenShift Web console to the root of your local cluster.
 
 ### Synopsis
 
 
-Opens/displays the OpenShift console URL for your local cluster
+Opens the OpenShift Web console to the root of your local cluster in the default browser.
 
 ```
 minishift console
@@ -14,7 +14,7 @@ minishift console
 ### Options
 
 ```
-      --url   Display the OpenShift console in the CLI instead of opening it in the default browser
+      --url   Open the local cluster in the OpenShift CLI console instead of the Web console.
 ```
 
 ### Options inherited from parent commands
@@ -25,14 +25,14 @@ minishift console
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_delete.md
+++ b/docs/minishift_delete.md
@@ -1,12 +1,11 @@
 ## minishift delete
 
-Deletes a local OpenShift cluster.
+Deletes the Minishift VM.
 
 ### Synopsis
 
 
-Deletes a local OpenShift cluster. This command deletes the VM, and removes all
-associated files.
+Deletes the Minishift VM, including the local OpenShift cluster and all associated files.
 
 ```
 minishift delete
@@ -20,14 +19,14 @@ minishift delete
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_docker-env.md
+++ b/docs/minishift_docker-env.md
@@ -1,11 +1,11 @@
 ## minishift docker-env
 
-sets up docker env variables; similar to '$(docker-machine env)'
+Sets Docker environment variables.
 
 ### Synopsis
 
 
-sets up docker env variables; similar to '$(docker-machine env)'
+Sets Docker environment variables, similar to '$(docker-machine env)'.
 
 ```
 minishift docker-env
@@ -14,9 +14,9 @@ minishift docker-env
 ### Options
 
 ```
-      --no-proxy       Add machine IP to NO_PROXY environment variable
-      --shell string   Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect
-  -u, --unset          Unset variables instead of setting them
+      --no-proxy       Add the virtual machine IP to the NO_PROXY environment variable.
+      --shell string   Force setting the environment for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh]. Default is auto-detect.
+  -u, --unset          Clear the environment variable values instead of setting them.
 ```
 
 ### Options inherited from parent commands
@@ -27,14 +27,14 @@ minishift docker-env
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_get-openshift-versions.md
+++ b/docs/minishift_get-openshift-versions.md
@@ -1,11 +1,11 @@
 ## minishift get-openshift-versions
 
-Gets the list of available OpenShift versions available for minishift.
+Gets the list of OpenShift versions available for Minishift.
 
 ### Synopsis
 
 
-Gets the list of available OpenShift versions available for minishift.
+Gets the list of OpenShift versions available for Minishift.
 
 ```
 minishift get-openshift-versions
@@ -19,14 +19,14 @@ minishift get-openshift-versions
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_ip.md
+++ b/docs/minishift_ip.md
@@ -1,11 +1,11 @@
 ## minishift ip
 
-Retrieve the IP address of the running cluster.
+Gets the IP address of the running cluster.
 
 ### Synopsis
 
 
-Retrieves the IP address of the running cluster, and writes it to STDOUT.
+Gets the IP address of the running cluster and prints it to the standard output.
 
 ```
 minishift ip
@@ -19,14 +19,14 @@ minishift ip
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_logs.md
+++ b/docs/minishift_logs.md
@@ -1,11 +1,11 @@
 ## minishift logs
 
-Gets the logs of the running OpenShift instance, used for debugging minishift, not user code.
+Gets the logs of the running OpenShift cluster.
 
 ### Synopsis
 
 
-Gets the logs of the running OpenShift instance, used for debugging minishift, not user code.
+Gets the logs of the running OpenShift cluster. The logs do not contain information about your application code.
 
 ```
 minishift logs
@@ -19,14 +19,14 @@ minishift logs
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_service.md
+++ b/docs/minishift_service.md
@@ -1,11 +1,11 @@
 ## minishift service
 
-Gets the URL for the specified service in your local cluster
+Opens the specified service in the OpenShift Web console.
 
 ### Synopsis
 
 
-Gets the URL for the specified service in your local cluster
+Opens the specified service in the OpenShift Web console using the default browser. You must specify the service name and namespace.
 
 ```
 minishift service [flags] SERVICE
@@ -14,10 +14,10 @@ minishift service [flags] SERVICE
 ### Options
 
 ```
-      --format string      Format to output service URL in (default "http://{{.IP}}:{{.Port}}")
-      --https              Open the service URL with https instead of http
-  -n, --namespace string   The service namespace (default "default")
-      --url                Display the kubernetes service URL in the CLI instead of opening it in the default browser
+      --format string      The URL format of the service. (default "http://{{.IP}}:{{.Port}}")
+      --https              Access the service with HTTPS instead of HTTP.
+  -n, --namespace string   The namespace of the service. (default "default")
+      --url                Access the service in the command-line console instead of the default browser.
 ```
 
 ### Options inherited from parent commands
@@ -28,15 +28,15 @@ minishift service [flags] SERVICE
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
-* [minishift service list](minishift_service_list.md)	 - Lists the URLs for the services in your local cluster
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
+* [minishift service list](minishift_service_list.md)	 - Gets the URLs of the services in your local cluster.
 

--- a/docs/minishift_service_list.md
+++ b/docs/minishift_service_list.md
@@ -1,11 +1,11 @@
 ## minishift service list
 
-Lists the URLs for the services in your local cluster
+Gets the URLs of the services in your local cluster.
 
 ### Synopsis
 
 
-Lists the URLs for the services in your local cluster
+Gets the URLs of the services in your local cluster.
 
 ```
 minishift service list [flags]
@@ -14,26 +14,26 @@ minishift service list [flags]
 ### Options
 
 ```
-  -n, --namespace string   The services namespace
+  -n, --namespace string   The namespace of the services.
 ```
 
 ### Options inherited from parent commands
 
 ```
       --alsologtostderr value          log to standard error as well as files
-      --format string                  Format to output service URL in (default "http://{{.IP}}:{{.Port}}")
+      --format string                  The URL format of the service. (default "http://{{.IP}}:{{.Port}}")
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift service](minishift_service.md)	 - Gets the URL for the specified service in your local cluster
+* [minishift service](minishift_service.md)	 - Opens the specified service in the OpenShift Web console.
 

--- a/docs/minishift_ssh.md
+++ b/docs/minishift_ssh.md
@@ -1,11 +1,11 @@
 ## minishift ssh
 
-Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'
+Log in to or run a command on a Minishift VM with SSH.
 
 ### Synopsis
 
 
-Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'
+Log in to or run a command on a Minishift VM with SSH. This command is similar to 'docker-machine ssh'.
 
 ```
 minishift ssh
@@ -19,14 +19,14 @@ minishift ssh
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_start.md
+++ b/docs/minishift_start.md
@@ -5,8 +5,9 @@ Starts a local OpenShift cluster.
 ### Synopsis
 
 
-Starts a local OpenShift cluster using Virtualbox. This command
-assumes you already have Virtualbox installed.
+Starts a local single-node OpenShift cluster on the specified hypervisor.
+If you are restarting the cluster and you use persistant storage for the host data,
+you can specify --use-existing-config to maintain the cluster state.
 
 ```
 minishift start
@@ -15,26 +16,26 @@ minishift start
 ### Options
 
 ```
-      --cpus int                   Number of CPUs allocated to the minishift VM (default 2)
-      --disk-size string           Disk size allocated to the minishift VM (format: <number>[<unit>], where unit = b, k, m or g) (default "20g")
-      --docker-env value           Environment variables to pass to the Docker daemon. (format: key=value) (default [])
-      --forward-ports              Use Docker port-forwarding to communicate with origin container. Requires 'socat' locally.
-      --host-config-dir string     Directory on Docker host for OpenShift configuration (default "/var/lib/minishift/openshift.local.config")
-      --host-data-dir string       Directory on Docker host for OpenShift data. If not specified, etcd data will not be persisted on the host. (default "/var/lib/minishift/hostdata")
-      --host-only-cidr string      The CIDR to be used for the minishift VM (only supported with Virtualbox driver) (default "192.168.99.1/24")
-      --host-volumes-dir string    Directory on Docker host for OpenShift volumes (default "/var/lib/origin/openshift.local.volumes")
-      --insecure-registry value    Insecure Docker registries to pass to the Docker daemon (default [172.30.0.0/16])
-      --iso-url string             Location of the minishift iso (default "https://github.com/minishift/minishift/releases/download/v1.0.0-beta.2/boot2docker.iso")
-      --memory int                 Amount of RAM allocated to the minishift VM (default 2048)
+      --cpus int                   Number of CPU cores to allocate to the Minishift VM. (default 2)
+      --disk-size string           Disk size to allocate to the Minishift VM. Use the format <size><unit>, where unit = b, k, m or g. (default "20g")
+      --docker-env value           Environment variables to pass to the Docker daemon. Use the format <key>=<value>. (default [])
+      --forward-ports              Use Docker port forwarding to communicate with the origin container. Requires 'socat' locally.
+      --host-config-dir string     Location of the OpenShift configuration on the Docker host. (default "/var/lib/minishift/openshift.local.config")
+      --host-data-dir string       Location of the OpenShift data on the Docker host. If not specified, etcd data will not be persisted on the host. (default "/var/lib/minishift/hostdata")
+      --host-only-cidr string      The CIDR to be used for the minishift VM. (Only supported with VirtualBox driver.) (default "192.168.99.1/24")
+      --host-volumes-dir string    Location of the OpenShift volumes on the Docker host. (default "/var/lib/origin/openshift.local.volumes")
+      --insecure-registry value    Non-secure Docker registries to pass to the Docker daemon. (default [172.30.0.0/16])
+      --iso-url string             Location of the minishift ISO. (default "https://github.com/minishift/minishift/releases/download/v1.0.0-beta.2/boot2docker.iso")
+      --memory int                 Amount of RAM to allocate to the Minishift VM. (default 2048)
       --metrics                    Install metrics (experimental)
-  -e, --openshift-env value        Specify key value pairs of environment variables to set on OpenShift container (default [])
-      --openshift-version string   The OpenShift version that the minishift VM will run (ex: v1.2.3) (default "v1.3.1")
-      --public-hostname string     Public hostname for OpenShift cluster
-      --registry-mirror value      Registry mirrors to pass to the Docker daemon (default [])
-      --routing-suffix string      Default suffix for server routes
-      --server-loglevel int        Log level for OpenShift server
-      --skip-registry-check        Skip Docker daemon registry check
-      --vm-driver string           VM driver is one of: [virtualbox vmwarefusion kvm xhyve hyperv] (default "kvm")
+  -e, --openshift-env value        Specify key-value pairs of environment variables to set on the OpenShift container. (default [])
+      --openshift-version string   The OpenShift version to run. Use the format v<n.n.n> (default "v1.3.1")
+      --public-hostname string     Public host name of the OpenShift cluster.
+      --registry-mirror value      Registry mirrors to pass to the Docker daemon. (default [])
+      --routing-suffix string      Default suffix for the server routes.
+      --server-loglevel int        Log level for the OpenShift server.
+      --skip-registry-check        Skip the Docker daemon registry check.
+      --vm-driver string           The driver to use for the Minishift VM. Possible values: [virtualbox vmwarefusion kvm xhyve hyperv] (default "kvm")
 ```
 
 ### Options inherited from parent commands
@@ -45,14 +46,14 @@ minishift start
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_status.md
+++ b/docs/minishift_status.md
@@ -1,11 +1,11 @@
 ## minishift status
 
-Gets the status of a local OpenShift cluster.
+Gets the status of the local OpenShift cluster.
 
 ### Synopsis
 
 
-Gets the status of a local OpenShift cluster.
+Gets the status of the local OpenShift cluster.
 
 ```
 minishift status
@@ -19,14 +19,14 @@ minishift status
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_stop.md
+++ b/docs/minishift_stop.md
@@ -1,12 +1,13 @@
 ## minishift stop
 
-Stops a running local OpenShift cluster.
+Stops the running local OpenShift cluster.
 
 ### Synopsis
 
 
-Stops a local OpenShift cluster running in Virtualbox. This command stops the VM
-itself, leaving all files intact. The cluster can be started again with the "start" command.
+Stops the running local OpenShift cluster. This command stops the Minishift
+VM but does not delete any associated files. To start the cluster again, use
+the 'minishift start' command.
 
 ```
 minishift stop
@@ -20,14 +21,14 @@ minishift stop
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 

--- a/docs/minishift_version.md
+++ b/docs/minishift_version.md
@@ -1,11 +1,11 @@
 ## minishift version
 
-Print the version of minishift.
+Gets the version of Minishift.
 
 ### Synopsis
 
 
-Print the version of minishift.
+Gets the currently installed version of Minishift and prints it to the standard output.
 
 ```
 minishift version
@@ -19,14 +19,14 @@ minishift version
       --log_backtrace_at value         when logging hits line file:N, emit a stack trace (default :0)
       --log_dir value                  If non-empty, write log files in this directory
       --logtostderr value              log to standard error instead of files
-      --password string                Password to register Virtual Machine
-      --show-libmachine-logs           Whether or not to show logs from libmachine.
+      --password string                Password for the virtual machine.
+      --show-libmachine-logs           Show logs from libmachine.
       --stderrthreshold value          logs at or above this threshold go to stderr (default 2)
-      --username string                Username to register Virtual Machine
+      --username string                User name for the virtual machine.
   -v, --v value                        log level for V logs
       --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ### SEE ALSO
-* [minishift](minishift.md)	 - Minishift is a tool for managing local OpenShift clusters.
+* [minishift](minishift.md)	 - Minishift is a tool for application development in local OpenShift clusters.
 


### PR DESCRIPTION
Fixes #190 

This PR was originally submitted as PR #198 but following feedback and request from @hferentschik was split into a new PR.

Notes about this PR:

- All feedback implemented from previous PR 
- Rebased against master, tested locally, and generated MD docs for the check-in
- Cleaned up all NEEDINFO comments and will create follow-up issues for open questions or issues that need further investigation
- Consulted with OpenShift doc writers and based on their style guide was advised that we should use "cluster" when describing the OpenShift that we run inside the VM, because the term refers to the combined elements required to run the instance, and the term "instance" is too generic (OpenShift is also working to standardize this in their docs). So we can use "local OpenShift cluster", "single-node OpenShift cluster", etc. See the style guide for clarification: https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/term_glossary.adoc#cluster