### PR TITLE
Issue #278 Ensure major flags can be configured via persistent options on config.json

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -94,6 +94,12 @@ var settings []Setting = []Setting{
 		set:  SetString,
 	},
 	{
+		name:        "iso-url",
+		set:         SetString,
+		validations: []setFn{IsValidUrl},
+		callbacks:   []setFn{RequiresRestartMsg},
+	},
+	{
 		name: config.WantUpdateNotification,
 		set:  SetBool,
 	},

--- a/cmd/minikube/cmd/config/config_test.go
+++ b/cmd/minikube/cmd/config/config_test.go
@@ -41,12 +41,14 @@ var configTestCases = []configTestCase{
     "ReminderWaitPeriodInHours": 99,
     "cpus": 4,
     "disk-size": "20g",
+    "iso-url": "http://foo.bar/minishift-centos.iso",
     "log_dir": "/etc/hosts",
     "show-libmachine-logs": true,
     "v": 5,
     "vm-driver": "kvm"
 }`,
 		config: map[string]interface{}{
+			"iso-url": "http://foo.bar/minishift-centos.iso",
 			"vm-driver": "kvm",
 			"cpus":      4,
 			"disk-size": "20g",

--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -16,11 +16,36 @@ limitations under the License.
 
 package config
 
-import "testing"
+import (
+	"testing"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"os"
+)
 
 func TestNotFound(t *testing.T) {
 	err := set("nonexistant", "10")
 	if err == nil {
 		t.Fatalf("Set did not return error for unknown property")
+	}
+}
+
+func TestModifyData(t *testing.T) {
+	constants.ConfigFile = "/tmp/config.json"
+	defer os.Remove("/tmp/config.json")
+	err := set("cpus", "4")
+	if err != nil {
+		t.Fatalf("Error setting value %s", err)
+	}
+	// override existing value and check if that persistent
+	err = set("cpus", "10")
+	if err != nil {
+		t.Fatalf("Error setting value %s", err)
+	}
+	getValue, err := get("cpus")
+	if err != nil {
+		t.Fatalf("Error getting value %s", err)
+	}
+	if getValue != "10" {
+		t.Fatal("Not able to update data to config file")
 	}
 }

--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"net/url"
 
 	units "github.com/docker/go-units"
 
@@ -72,6 +73,14 @@ func IsValidPath(name string, path string) error {
 	_, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("%s path is not valid: %v", name, err)
+	}
+	return nil
+}
+
+func IsValidUrl(string, isoURL string) error {
+	_, err := url.ParseRequestURI(isoURL)
+	if err != nil {
+		return fmt.Errorf("%s url is not valid: %v", isoURL, err)
 	}
 	return nil
 }

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -94,3 +94,27 @@ func TestValidCIDR(t *testing.T) {
 
 	runValidations(t, tests, "cidr", IsValidCIDR)
 }
+
+func TestValidURL(t *testing.T) {
+
+	var tests = []validationTest{
+		{
+			value:	   "http://foo.com/minishift.tar.gz",
+			shouldErr: false,
+		},
+		{
+			value:     "http/foo.com/minishift.tar.gz",
+			shouldErr: true,
+		},
+		{
+			value:     "file:///foo/download/minishift.tar.gz",
+			shouldErr: false,
+
+		},
+		{
+			value:      "file/foo/download/minishift.tar.gz",
+			shouldErr:  true,
+		},
+	}
+	runValidations(t, tests, "iso-url", IsValidUrl)
+}

--- a/docs/minishift_config.md
+++ b/docs/minishift_config.md
@@ -19,6 +19,7 @@ Configurable properties (enter as SUBCOMMAND):
  * show-libmachine-logs
  * log_dir
  * openshift-version
+ * iso-url
  * WantUpdateNotification
  * ReminderWaitPeriodInHours
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -10,6 +10,7 @@ overview of different components and services.
   - [Stopping OpenShift](#stopping-openshift)
   - [Deleting OpenShift](#deleting-openshift)
 - [Environment variables](#environment-variables)
+- [Config file](#config-file)
 - [Interacting with OpenShift](#interacting-with-openshift)
   - [OpenShift client binary \(oc\)](#openshift-client-binary-oc)
   - [Console](#console)
@@ -64,6 +65,33 @@ also specify this URL by setting the environment variable _MINISHIFT_ISO_URL_.
 its runtime state into _~/.minishift_. Using _MINISHIFT_HOME_, you can choose a different directory
 as Minishift's home directory. This is currently experimental and semantics might change in
 future releases.
+
+<a name="config-file"></a>
+## Config file
+
+Minishift also maintains a config file (_~/.minishift/config/config.json_) which can be used to set some
+variables like (CPU, memory ...etc.) and can be used without using different parameter in start command.
+This can be used to control some of the default behavior similar to using
+[environment variables](#environment-variables).
+
+**Note:**
+
+* config.json file is not generated automatic until user use `set` sub-command as described below.
+* Manual edit to this file is discouraged because it might be error-prone, use defined sub-command for required use-case.
+
+```shell
+$ minishift config -h
+```
+
+You can set using `set` sub-command provided by config and it expect `PROPERTY_NAME PROPERTY_VALUE`
+
+    # Set default memory 4096 MB
+    $ minishift config set memory 4096
+
+To view what already set and available you can use `view` sub-command
+
+    $ minishift config view
+    - memory: 4096
 
 <a name="interacting-with-openshift"></a>
 ## Interacting with OpenShift


### PR DESCRIPTION
This patch will add some document around config.json and also add `--iso-url` to make it persistent.