### PR TITLE
Issue #297 Provide ability to retrieve OpenShift URL in machine readable format

### DIFF
--- a/cmd/minikube/cmd/console.go
+++ b/cmd/minikube/cmd/console.go
@@ -30,6 +30,10 @@ import (
 
 var (
 	consoleURLMode bool
+	machineReadAble bool
+	machineDetails = `HOST=%s
+PORT=%d
+CONSOLE_URL=%s`
 )
 
 // consoleCmd represents the console command
@@ -47,6 +51,12 @@ var consoleCmd = &cobra.Command{
 		}
 		if consoleURLMode {
 			fmt.Fprintln(os.Stdout, url)
+		} else if machineReadAble{
+			hostIP, err := cluster.GetHostIP(api)
+			if err != nil {
+				glog.Errorln("Cannot get Host IP. Verify that Minishift is running. Error: ", err)
+			}
+			displayConsoleInMachineReadable(hostIP, url)
 		} else {
 			fmt.Fprintln(os.Stdout, "Opening the OpenShift Web console in the default browser...")
 			browser.OpenURL(url)
@@ -54,7 +64,13 @@ var consoleCmd = &cobra.Command{
 	},
 }
 
+func displayConsoleInMachineReadable(hostIP string, url string) {
+	machineDetails = fmt.Sprintf(machineDetails, hostIP, constants.APIServerPort, url)
+	fmt.Fprintln(os.Stdout, machineDetails)
+}
+
 func init() {
 	consoleCmd.Flags().BoolVar(&consoleURLMode, "url", false, "Prints the OpenShift Web Console URL to the console.")
+	consoleCmd.Flags().BoolVar(&machineReadAble, "machine-readable", false, "Prints OpenShift's IP, port and Web Console URL in Machine readable format")
 	RootCmd.AddCommand(consoleCmd)
 }

--- a/cmd/minikube/cmd/console_test.go
+++ b/cmd/minikube/cmd/console_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright (C) 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+	"os"
+	"io/ioutil"
+	"strings"
+)
+
+func TestDisplayConsoleInMachineReadable(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "minishift-config-")
+	if err != nil {
+		t.Error()
+	}
+	defer os.RemoveAll(testDir)
+
+	f, err := os.Create(testDir + "out.txt")
+	if err != nil {
+		t.Fatalf("Error creating test file", err)
+	}
+	defer f.Close()
+
+	os.Stdout = f
+
+	expectedStdout := `HOST=192.168.1.1
+PORT=8443
+CONSOLE_URL=https://192.168.99.103:8443`
+
+	displayConsoleInMachineReadable("192.168.1.1", "https://192.168.99.103:8443")
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatalf("Error setting offset back", err)
+	}
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Error reading file", err)
+	}
+
+	if strings.TrimSpace(string(data)) != expectedStdout {
+		t.Fatalf("expected hello got %s", string(data))
+	}
+}

--- a/docs/minishift_console.md
+++ b/docs/minishift_console.md
@@ -14,7 +14,8 @@ minishift console
 ### Options
 
 ```
-      --url   Prints the OpenShift Web Console URL to the console.
+      --machine-readable   Prints OpenShift's IP, port and Web Console URL in Machine readable format
+      --url                Prints the OpenShift Web Console URL to the console.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -402,6 +402,19 @@ func GetConsoleURL(api libmachine.API) (string, error) {
 	return fmt.Sprintf("https://%s:%d", ip, constants.APIServerPort), nil
 }
 
+func GetHostIP(api libmachine.API) (string, error) {
+	host, err := checkIfApiExistsAndLoad(api)
+	if err != nil {
+		return "", err
+	}
+
+	ip, err := host.Driver.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return ip, nil
+}
+
 type ipPort struct {
 	IP   string
 	Port int


### PR DESCRIPTION
This patch will enable get machine readable data from minishift cli.

```
10:54 $ ./minikube console --url
https://192.168.99.103:8443

✔ ~/work/github/go_practice 
10:57 $ ./minikube console --machine-readable
HOST=https://192.168.99.103
PORT=8443
CONSOLE_URL=https://192.168.99.103:8443
```