### PR TITLE
Fix #302 minishift logs doesn't work

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -47,7 +47,7 @@ import (
 )
 
 var (
-	certs = []string{"apiserver.crt", "apiserver.key"}
+	logsCmd = "docker logs origin"
 )
 
 const (
@@ -343,7 +343,7 @@ func GetHostLogs(api libmachine.API) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	s, err := host.RunSSHCommand(logsCommand)
+	s, err := host.RunSSHCommand(logsCmd)
 	if err != nil {
 		return "", nil
 	}


### PR DESCRIPTION
I didn't edited https://github.com/minishift/minishift/blob/master/pkg/minikube/cluster/commands.go#L49 because eventually we can get rid of this file completely. 