### PR TITLE
Issue #252 Retrieve Docker API version dynamically

### DIFF
--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -97,7 +97,7 @@ func shellCfgSet(api libmachine.API) (*ShellConfig, error) {
 		DockerCertPath:   envMap["DOCKER_CERT_PATH"],
 		DockerHost:       envMap["DOCKER_HOST"],
 		DockerTLSVerify:  envMap["DOCKER_TLS_VERIFY"],
-		DockerAPIVersion: constants.DockerAPIVersion,
+		DockerAPIVersion: envMap["DOCKER_API_VERSION"],
 		UsageHint:        generateUsageHint(userShell),
 	}
 

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// sshCmd represents the docker-ssh command
+// sshCmd represents the docker-machine ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Log in to or run a command on a Minishift VM with SSH.",

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -48,6 +48,7 @@ import (
 
 var (
 	logsCmd = "docker logs origin"
+	dockerAPIVersionCmd = "docker version --format '{{.Server.APIVersion}}'"
 )
 
 const (
@@ -320,6 +321,10 @@ func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	dockerAPIVersion, err := host.RunSSHCommand(dockerAPIVersionCmd)
+	if err != nil {
+		return  nil, err
+	}
 	ip, err := host.Driver.GetIP()
 	if err != nil {
 		return nil, err
@@ -333,6 +338,7 @@ func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
 		"DOCKER_TLS_VERIFY": "1",
 		"DOCKER_HOST":       tcpPrefix + ip + portDelimiter + port,
 		"DOCKER_CERT_PATH":  constants.MakeMiniPath("certs"),
+		"DOCKER_API_VERSION": strings.TrimRight(dockerAPIVersion, "\n"),
 	}
 	return envMap, nil
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -60,9 +60,6 @@ var ConfigFile = MakeMiniPath("config", "config.json")
 var TmpFilePath = MakeMiniPath("tmp")
 var OcCachePath = MakeMiniPath("cache", "oc")
 
-// DockerAPIVersion is the API version implemented by Docker running in the minishift VM.
-const DockerAPIVersion = "1.23"
-
 // MakeMiniPath is a utility to calculate a relative path to our directory.
 func MakeMiniPath(fileName ...string) string {
 	args := []string{Minipath}


### PR DESCRIPTION
Fix #252 

### Inside VM
```
$ minishift ssh
[docker@minishift ~]$ docker version
Client:
 Version:         1.12.5
 API version:     1.24
 Package version: docker-common-1.12.5-14.el7.centos.x86_64
 Go version:      go1.7.4
 Git commit:      047e51b/1.12.5
 Built:           Mon Jan 23 15:35:13 2017
 OS/Arch:         linux/amd64

Server:
 Version:         1.12.5
 API version:     1.24
 Package version: docker-common-1.12.5-14.el7.centos.x86_64
 Go version:      go1.7.4
 Git commit:      047e51b/1.12.5
 Built:           Mon Jan 23 15:35:13 2017
 OS/Arch:         linux/amd64
```
### From Host
```
$ minishift docker-env
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.42.99:2376"
export DOCKER_CERT_PATH="/home/budhram/.minishift/certs"
export DOCKER_API_VERSION="1.24"
# Run this command to configure your shell: 
# eval $(minishift docker-env)
``