### PR TITLE
Issue #339 Fix 'minishift ssh' help message

### DIFF
--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -28,7 +28,7 @@ import (
 
 // sshCmd represents the docker-machine ssh command
 var sshCmd = &cobra.Command{
-	Use:   "ssh",
+	Use:   "ssh [-- COMMAND]",
 	Short: "Log in to or run a command on a Minishift VM with SSH.",
 	Long:  "Log in to or run a command on a Minishift VM with SSH. This command is similar to 'docker-machine ssh'.",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/docs/minishift_ssh.md
+++ b/docs/minishift_ssh.md
@@ -8,7 +8,7 @@ Log in to or run a command on a Minishift VM with SSH.
 Log in to or run a command on a Minishift VM with SSH. This command is similar to 'docker-machine ssh'.
 
 ```
-minishift ssh
+minishift ssh [-- COMMAND]
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Fix #339 

Now, we can run `minishift ssh 'COMMAND'` or `minishift ssh -- COMMAND`:

```
minishift ssh 'df -h'
Filesystem                Size      Used Available Use% Mounted on
tmpfs                     1.8G    196.6M      1.6G  11% /
tmpfs                  1001.0M    172.0K   1000.9M   0% /dev/shm
/dev/sda1                17.9G    785.1M     16.2G   5% /mnt/sda1
cgroup                 1001.0M         0   1001.0M   0% /sys/fs/cgroup
/dev/sda1                17.9G    785.1M     16.2G   5% /mnt/sda1/var/lib/docker/aufs
tmpfs                     1.8G    196.6M      1.6G  11% /var/lib/origin/openshift.local.volumes
.....
```
### Or
```
minishift ssh -- df -h                             
Filesystem                Size      Used Available Use% Mounted on
tmpfs                     1.8G    196.6M      1.6G  11% /
tmpfs                  1001.0M    172.0K   1000.9M   0% /dev/shm
/dev/sda1                17.9G    785.1M     16.2G   5% /mnt/sda1
cgroup                 1001.0M         0   1001.0M   0% /sys/fs/cgroup
/dev/sda1                17.9G    785.1M     16.2G   5% /mnt/sda1/var/lib/docker/aufs
tmpfs                     1.8G    196.6M      1.6G  11% /var/lib/origin/openshift.local.volumes
........
```