### PR TITLE
Issue #346 improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ provisioning VMs, and [OpenShift Origin](https://github.com/openshift/origin) fo
 - [Installation](#installation)
   - [Prerequisites](#prerequisites)
   - [Installing Minishift](#installing-minishift)
-    - [Installing via Homebrew](#installing-via-homebrew)
+    - [Installing with Homebrew](#installing-with-homebrew)
 - [Quickstart](#quickstart)
   - [Starting Minishift](#starting-minishift)
   - [Deploying a sample application](#deploying-a-sample-application)
   - [Reusing the Docker daemon](#reusing-the-docker-daemon)
 - [Documentation](#documentation)
-- [Known Issues](#known-issues)
+- [Limitations](#limitations)
 - [Community](#community)
 
 <!-- /MarkdownTOC -->
@@ -41,40 +41,44 @@ Minishift requires a hypervisor to run the virtual machine containing OpenShift.
 host OS, you have the choice of the following hypervisors:
 
 * OS X
-    * [xhyve](https://github.com/mist64/xhyve), [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [VMware Fusion](https://www.vmware.com/products/fusion)
-* Linux
-    * [KVM](./docs/docker-machine-drivers.md#kvm-driver) or [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+    * [xhyve](https://github.com/mist64/xhyve) (default), [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [VMware Fusion](https://www.vmware.com/products/fusion)
+* GNU/Linux
+    * [KVM](./docs/docker-machine-drivers.md#kvm-driver) (default) or [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 * Windows
-    * [Hyper-V](https://technet.microsoft.com/en-us/library/mt169373.aspx) or [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+    * [Hyper-V](https://technet.microsoft.com/en-us/library/mt169373.aspx) (default) or [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
-Minishift ships with drivers for VirtualBox and VMware Fusion out of the box. Other drivers
-require manual installation, see [docker machine drivers installation](./docs/docker-machine-drivers.md) for more details.
+Make sure that the hypervisor is installed and enabled on your system before you install Minishift.
 
-Drivers can be selected via the `--vm-driver=xxx` flag of `minishift start` as mentioned in the [Starting Minishift](#starting-minishift) section below. See the [Troubleshooting](/docs/troubleshooting.md#kvm-drivers) guide, in case you encounter any issues.
+**Important:**
 
-**Note:**
-- For most hypervisors, VT-x/AMD-v virtualization must be enabled in the BIOS. For Hyper-V, however,
-it needs to be disabled.
-- We recommend that you use `Virtualbox >= 5.1.12` on Windows to avoid the issue
+- KVM and xhyve might require specific installation and configuration steps.
+For more information, see [docker machine drivers installation](./docs/docker-machine-drivers.md).
+- For most hypervisors, you must enable VT-x/AMD-v virtualization in the BIOS. However, if you want
+to use Hyper-V you must disable this.
+- It is recommended to use `Virtualbox 5.1.12` or later on Windows to avoid the issue
 [Error: getting state for host: machine does not exist](./docs/troubleshooting.md#error-getting-state-for-host-machine-does-not-exist)
+
+If you encounter driver issues, see the [Troubleshooting](/docs/troubleshooting.md) guide.
 
 <a name="installing-minishift"></a>
 ### Installing Minishift
 
-Download the archive matching your host OS from the Minishift [releases page](https://github.com/minishift/minishift/releases) and unpack it. Copy the contained binary to your preferred
-location and optionally ensure it is added to your _PATH_.
+1. Download the archive for your operating system from the Minishift [releases page](https://github.com/minishift/minishift/releases) and unpack it.
+1. Copy the contents of the directory to your preferred location.
+1. (Optional) Add the path to your _PATH_ environment variable.
 
 **Note:**
-- Due to issue [#236](https://github.com/minishift/minishift/issues/236), you need to execute the minishift binary on Windows OS from the drive containing your %USERPROFILE% directory.
-- Automatic update of minishift binary and virtual machine ISO is currently disabled, due to issues
- [#204](https://github.com/minishift/minishift/issues/204),
- [#178](https://github.com/minishift/minishift/issues/178),
- [#112](https://github.com/minishift/minishift/issues/112) and
- [#192](https://github.com/minishift/minishift/issues/192). We will take a comprehensive look at
- these issues in an upcoming release and provide an improved solution for automatic updates.
 
-<a name="installing-via-homebrew"></a>
-#### Installing via Homebrew
+- On Windows operating system, due to issue [#236](https://github.com/minishift/minishift/issues/236), you need to execute the minishift binary
+from the drive containing your %USERPROFILE% directory.
+- Automatic update of the Minishift binary and the virtual machine ISO is currently disabled, due to the following issues:
+  - [#204](https://github.com/minishift/minishift/issues/204)
+  - [#178](https://github.com/minishift/minishift/issues/178)
+  - [#112](https://github.com/minishift/minishift/issues/112)
+  - [#192](https://github.com/minishift/minishift/issues/192)
+
+<a name="installing-with-homebrew"></a>
+#### Installing Minishift with Homebrew
 
 ##### Stable
 On OS X you can also use [Homebrew Cask](https://caskroom.github.io) to install the stable version of Minishift:
@@ -99,17 +103,20 @@ You can now install the latest beta version of minishift.
 <a name="quickstart"></a>
 ## Quickstart
 
-This section contains a brief demo of Minishift and the provisioned OpenShift instance.
+This section contains a brief demo of Minishift and the provisioned OpenShift cluster.
 For details on the usage of Minishift refer to the [Using Minishift](/docs/using.md) guide.
 The interaction with OpenShift is via the command line tool _oc_ which is copied to your host.
+
+The following steps describe how to get started with Minishift on a GNU/Linux operating system
+with the KVM hypervisor driver.
 
 <a name="starting-minishift"></a>
 ### Starting Minishift
 
-1. Assuming you have put _minishift_  on the _PATH_ as described in [Installing Minishift](#installing-minishift) you can start Minishift via:
+1. Run the `minishift start` command.
 
         $ minishift start
-        Starting local OpenShift instance using 'kvm' hypervisor...
+        Starting local OpenShift cluster using 'kvm' hypervisor...
         ...
            OpenShift server started.
            The server is accessible via web console at:
@@ -122,28 +129,28 @@ The interaction with OpenShift is via the command line tool _oc_ which is copied
            To login as administrator:
                oc login -u system:admin
 
-    Note that, the IP seen above is dynamic and can change. It can be retrieved with `minishift ip`. Also,
-    instead of 'kvm', you will see 'xhyve' on Mac OS and 'hyperv' on Windows.
+  **Note**:
 
-    **Note:** By default Minishift uses the driver most relevant to the host OS.
-To use a driver of choice for Minishift, use the `--vm-driver=xxx` flag with `minishift start`. For example, to use VirtualBox instead of KVM for Fedora, use `minishift start --vm-driver=virtualbox`.
+  - The IP is dynamically generated for each OpenShift cluster. To check the IP, run the `minishift ip` command.
+  - By default Minishift uses the driver most relevant to the host OS. To use a different driver, set the `--vm-driver` flag in `minishift start`. For example, to use VirtualBox instead of KVM on GNU/Linux operating systems, run `minishift start --vm-driver=virtualbox`. For more information about `minishift start` options,
+  see the [minishift start command reference](/docs/minishift_start.md).
 
-1. Add `oc` binary to the _PATH_:
-
-     **Note:** How to modify the _PATH_ varies depending on host OS, version of the OC binary and
-     other variables. In case of doubt, you can check the content of the
-     `~/.minishift/cache/oc` directory.
+1. Add the `oc` binary to the _PATH_ environment variable.
 
         $ export PATH=$PATH:~/.minishift/cache/oc/v1.3.1
 
-1. Login to your OpenShift account and authenticate yourself:
-
-        $ oc login https://192.168.99.128:8443 -u developer -p developer
+  **Note:** Depending on the operating system and the `oc` version, you might need
+  to use a different command to add the path to the _PATH_ environment variable.
+  To verify the `oc` version, check the contents of the `~/.minishift/cache/oc` directory.
 
 <a name="deploying-a-sample-application"></a>
 ### Deploying a sample application
 
-You can use Minishift to run a sample Node.js application on OpenShift as follows:
+OpenShift provides various sample applications, such as templates, builder applications,
+and quickstarts. The following steps describe how to deploy a sample Node.js application
+from the command-line.
+
+To deploy the Node.js sample application from the command-line:
 
 1. Create a Node.js example app:
 
@@ -174,7 +181,7 @@ When running OpenShift in a single VM, it is recommended to reuse the Docker dae
 for pure Docker use-cases as well.
 By using the same docker daemon as Minishift, you can speed up your local experiments.
 
-To be able to work with the docker daemon on your Mac/Linux host use the
+To be able to work with the docker daemon on your Mac or GNU/Linux host use the
 [`docker-env command`](./docs/minishift_docker-env.md) in your shell:
 
 ```
@@ -192,14 +199,15 @@ docker ps
 
 The following documentation is available:
 
+* [Releases Notes](https://github.com/minishift/minishift/releases).
 * [Using Minishift](./docs/using.md)
 * [Command reference](./docs/minishift.md)
 * [Troubleshooting](./docs/troubleshooting.md)
 * [Installing docker-machine drivers](./docs/docker-machine-drivers.md)
 * [Developing Minishift](./docs/developing.md)
 
-<a name="known-issues"></a>
-## Known Issues
+<a name="limitations"></a>
+## Limitations
 
 The following features are not supported in Minishift.
 


### PR DESCRIPTION
Fixes #346 

This PR restructures and tweaks the installation instructions to (hopefully) clarify where manual steps might be required, point better to additional information, and generally clean up the flow of information to help users get started more easily. 

Related to issue #215 