### PR TITLE
Issue #298 Removing docker environment variables

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -113,6 +113,11 @@ func runStart(cmd *cobra.Command, args []string) {
 	libMachineClient := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 	defer libMachineClient.Close()
 
+	if _, err := shellCfgUnset(libMachineClient); err != nil {
+		glog.Errorln("Error unsetting existing docker environment variables:", err)
+		os.Exit(1)
+	}
+
 	config := cluster.MachineConfig{
 		MinikubeISO:      viper.GetString(isoURL),
 		Memory:           viper.GetInt(memory),


### PR DESCRIPTION
Removing existing docker environment variables before
setting them by minishift.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>