### PR TITLE
Issue #370 Showing internal errors on missing commands

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -92,7 +92,7 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		glog.Exitln(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
This will fix the issue for unwanted error message if user try a missing command.

```
06:15 $ ./minishift adfja
Error: unknown command "adfja" for "minishift"
Run 'minishift --help' for usage.

06:15 $ ./minishift ssp
Error: unknown command "ssp" for "minishift"

Did you mean this?
	ip
	ssh
	stop

Run 'minishift --help' for usage.
```