### PR TITLE
Issue #318 Incomplete handling of VM status for un-registration

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -21,11 +21,8 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/docker/machine/libmachine/drivers"
-	"github.com/docker/machine/libmachine/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/minishift/registration"
 	"github.com/spf13/cobra"
 )
 
@@ -38,19 +35,6 @@ var deleteCmd = &cobra.Command{
 		fmt.Println("Deleting the Minishift VM...")
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
-		host, err := api.Load(constants.MachineName)
-		if err != nil {
-			fmt.Println("Error occurred while deleting the VM: ", err)
-			os.Exit(1)
-		}
-
-		if !drivers.MachineInState(host.Driver, state.Stopped)() {
-			// Unregister Host VM
-			if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
-				fmt.Printf("Error unregistring the VM: %s", err)
-				os.Exit(1)
-			}
-		}
 
 		if err := cluster.DeleteHost(api); err != nil {
 			fmt.Println("Error deleting the VM: ", err)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -29,9 +29,9 @@ import (
 	"github.com/spf13/viper"
 
 	configCmd "github.com/minishift/minishift/cmd/minikube/cmd/config"
+	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/config"
 	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/minishift/registration"
 )
 
 var dirs = [...]string{
@@ -51,10 +51,6 @@ const (
 	showLibmachineLogs = "show-libmachine-logs"
 	username           = "username"
 	password           = "password"
-)
-
-var (
-	RegistrationParameters = new(registration.RegistrationParameters)
 )
 
 var viperWhiteList = []string{
@@ -153,8 +149,8 @@ func setupViper() {
 }
 
 func setRegistrationParameters() {
-	RegistrationParameters.Username = viper.GetString("username")
-	RegistrationParameters.Password = viper.GetString("password")
+	cluster.RegistrationParameters.Username = viper.GetString("username")
+	cluster.RegistrationParameters.Password = viper.GetString("password")
 }
 
 func ensureConfigFileExists(configPath string) {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -30,7 +30,6 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/cache"
 	"github.com/minishift/minishift/pkg/minishift/provisioner"
-	"github.com/minishift/minishift/pkg/minishift/registration"
 	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
 	"github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/version"
@@ -164,12 +163,6 @@ func runStart(cmd *cobra.Command, args []string) {
 			fmt.Printf("Error setting proxy to VM: %s", err)
 			os.Exit(1)
 		}
-	}
-
-	// Register Host VM
-	if err := registration.RegisterHostVM(host, RegistrationParameters); err != nil {
-		fmt.Printf("Error registering the VM: %s", err)
-		os.Exit(1)
 	}
 
 	// Making sure the required Docker environment variables are set to make 'cluster up' work

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -21,11 +21,8 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/docker/machine/libmachine/drivers"
-	"github.com/docker/machine/libmachine/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/minishift/registration"
 	"github.com/spf13/cobra"
 )
 
@@ -39,20 +36,6 @@ VM but does not delete any associated files. To start the cluster again, use the
 		fmt.Println("Stopping local OpenShift cluster...")
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
-
-		host, err := api.Load(constants.MachineName)
-		if err != nil {
-			fmt.Println("Error occurred while stopping the VM: ", err)
-			os.Exit(1)
-		}
-
-		if !drivers.MachineInState(host.Driver, state.Stopped)() {
-			// Unregister Host VM
-			if err := registration.UnregisterHostVM(host, RegistrationParameters); err != nil {
-				fmt.Printf("Error unregistring the VM: %s", err)
-				os.Exit(1)
-			}
-		}
 
 		if err := cluster.StopHost(api); err != nil {
 			fmt.Println("Error stopping cluster: ", err)

--- a/pkg/minikube/cluster/credentials.go
+++ b/pkg/minikube/cluster/credentials.go
@@ -19,12 +19,14 @@ package cluster
 import (
 	"net"
 
+	"github.com/minishift/minishift/pkg/minishift/registration"
 	"github.com/minishift/minishift/pkg/util"
 )
 
 var (
 	// This is the internalIP the the API server and other components communicate on.
-	internalIP = net.ParseIP(util.DefaultServiceClusterIP)
+	internalIP             = net.ParseIP(util.DefaultServiceClusterIP)
+	RegistrationParameters = new(registration.RegistrationParameters)
 )
 
 func GenerateCerts(pub, priv string, ip net.IP) error {

--- a/pkg/minishift/registration/utils.go
+++ b/pkg/minishift/registration/utils.go
@@ -42,6 +42,7 @@ func RegisterHostVM(host *host.Host, param *RegistrationParameters) error {
 	}
 
 	if registrator != nil {
+		fmt.Println("Registering machine using subscription-manager")
 		if param.Username == "" || param.Password == "" {
 			return errors.New("This virutal machine requires registration. " +
 				"Credentials must either be passed via the environment variables " +


### PR DESCRIPTION
This patch is mostly refactor registration/unregistration, now those capability is part of cluster pkg instead of cmd. Another change is we are now using `state.Running` as condition for register and unregister task so it will handle all different state of VM (not only stopped).