### PR TITLE
Issue #249 Adding links to generic openshift content in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ You can now install the latest beta version of minishift.
 1. Last but not least, use your hypervisor management tool to confirm that there are no remaining
    artifacts related to the Minishift VM (eg use `virsh` in the KVM case).
 
+For more information about OpenShift cluster architecture,
+see [Architecture Overview](https://docs.openshift.org/latest/architecture/index.html) in the
+OpenShift documentation.
+
 <a name="quickstart"></a>
 ## Quickstart
 
@@ -163,6 +167,9 @@ with the KVM hypervisor driver.
   to use a different command to add `oc` to the _PATH_ environment variable.
   To verify the `oc` version, check the contents of the `~/.minishift/cache/oc` directory.
 
+For more information about interacting with OpenShift with the command-line interface and
+the Web console, see [Interacting with OpenShift](/docs/using.md#interacting-with-openshift)
+
 <a name="deploying-a-sample-application"></a>
 ### Deploying a sample application
 
@@ -193,6 +200,10 @@ To deploy the Node.js sample application from the command-line:
         $ minishift stop
         Stopping local OpenShift cluster...
         Stopping "minishift"...
+
+For more information about creating applications in OpenShift,
+see [Creating New Applications](https://docs.openshift.org/latest/dev_guide/application_lifecycle/new_app.html) in
+the OpenShift documentation.
 
 <a name="reusing-the-docker-daemon"></a>
 ### Reusing the Docker daemon


### PR DESCRIPTION
Fixes issue #249 

Added a few relevant links for further information on the OpenShift docs site, mainly for architecture and getting started with cluster administration.

Also reviewed using.md, and it seems that there are already some links to OpenShift docs so no need to add there.