### PR TITLE
Issue #338 added troubleshooting info about passwords with special chars

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,6 +13,8 @@ while using Minishift.
   - [Error: could not create vmnet interface, permission denied or no entitlement](#error-could-not-create-vmnet-interface-permission-denied-or-no-entitlement)
 - [VirtualBox driver](#virtualbox-driver)
   - [Error: getting state for host: machine does not exist](#error-getting-state-for-host-machine-does-not-exist)
+- [Users and authentication](#users-authentication)
+  - [Some special characters cause passwords to fail](#some-special-characters-cause-passwords-to-fail)
 
 <!-- /MarkdownTOC -->
 
@@ -99,3 +101,14 @@ If you are using Windows, the problem is likely to be either an outdated version
 of Virtual Box or you forgot to use `--vm-driver virtualbox` option when starting minishift.
 
 We recommend to use `Virtualbox >= 5.1.12` to avoid this issue.
+
+<a name="users-authentication"></a>
+## Users and authentication
+
+### Some special characters cause passwords to fail
+
+Depending on your operating system and shell environment, certain special characters
+can trigger variable interpolation and therefore cause passwords to fail.
+
+Workaround: When creating and entering passwords, wrap the string with single quotes in
+the following format: '&lt;password>'


### PR DESCRIPTION
Fixes issue #338 

This PR aims to provide troubleshooting info about why passwords with certain special characters fail and how to workaround.

Note: I'm basing this content on the info provided in the issue, although I'm aware that there might be some inaccuracies, let's resolve any gaps together :)