### PR TITLE
Issue #434 Resurrecting call to machine.StartDriver()

### DIFF
--- a/cmd/minishift/main.go
+++ b/cmd/minishift/main.go
@@ -18,8 +18,10 @@ package main
 
 import (
 	"github.com/minishift/minishift/cmd/minishift/cmd"
+	"github.com/minishift/minishift/pkg/minikube/machine"
 )
 
 func main() {
+	machine.StartDriver()
 	cmd.Execute()
 }


### PR DESCRIPTION
Fix for issue #434. 

This should make the driver selection work again.