### PR TITLE
Issue #487 Introduce minishift-data.json to store oc path

### DIFF
--- a/cmd/minishift/cmd/delete.go
+++ b/cmd/minishift/cmd/delete.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
+	instanceState "github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -44,6 +45,12 @@ func runDelete(cmd *cobra.Command, args []string) {
 		fmt.Println("Error deleting the VM: ", err)
 		atexit.Exit(1)
 	}
+
+	if err := instanceState.Config.Delete(); err != nil {
+		fmt.Println("Error deleting config for VM: ", err)
+		atexit.Exit(1)
+	}
+
 	fmt.Println("Minishift VM deleted.")
 }
 

--- a/cmd/minishift/cmd/root_test.go
+++ b/cmd/minishift/cmd/root_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/testing/cli"
 	"io/ioutil"
+	"path/filepath"
 )
 
 var configTests = []cli.TestOption{
@@ -79,6 +80,8 @@ var configTests = []cli.TestOption{
 func TestPreRunDirectories(t *testing.T) {
 	// Make sure we create the required directories.
 	testDir, err := ioutil.TempDir("", "minishift-test-start-cmd-")
+	// Need to create since MACHINE_NAME.json get created in root command
+	os.Mkdir(filepath.Join(testDir, "machines"), 0755)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/minishift/cmd/start_test.go
+++ b/cmd/minishift/cmd/start_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/tests"
+	instanceState "github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/util"
 	"github.com/spf13/viper"
 	"io/ioutil"
@@ -362,6 +363,16 @@ func setUp(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// Need to create instanceState.Config since it is being used in clusterUp.
+	// TODO: Need to separate clusterUp with oc installation
+	machinesDirPath := filepath.Join(testDir, "machines")
+	os.Mkdir(machinesDirPath, 0755)
+	instanceState.Config, err = instanceState.NewInstanceConfig(filepath.Join(machinesDirPath, "fake-machines.json"))
+	if err != nil {
+		t.Error(err)
+	}
+
 	constants.Minipath = testDir
 
 	client := http.DefaultClient

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -218,7 +218,7 @@ func createVirtualboxHost(config MachineConfig) drivers.Driver {
 func (m *MachineConfig) CacheMinikubeISOFromURL() error {
 	fmt.Println(fmt.Sprintf("Downloading ISO '%s'", m.MinikubeISO))
 
-	// store the miniube-iso inside the .minikube dir
+	// store the iso inside the MINISHIFT_HOME dir
 	response, err := http.Get(m.MinikubeISO)
 	if err != nil {
 		return err
@@ -253,8 +253,6 @@ func (m *MachineConfig) CacheMinikubeISOFromURL() error {
 }
 
 func (m *MachineConfig) ShouldCacheMinikubeISO() bool {
-	// store the miniube-iso inside the .minikube dir
-
 	urlObj, err := url.Parse(m.MinikubeISO)
 	if err != nil {
 		return false

--- a/pkg/minishift/config/config.go
+++ b/pkg/minishift/config/config.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+var Config *InstanceConfig
+
+type InstanceConfig struct {
+	FilePath string `json:"-"`
+	OcPath   string
+}
+
+// Create new object with data if file exists or
+// Create json file and return object if doesn't exists
+func NewInstanceConfig(path string) (*InstanceConfig, error) {
+	cfg := new(InstanceConfig)
+	cfg.FilePath = path
+
+	// Check json file existence
+	_, err := os.Stat(cfg.FilePath)
+	if os.IsNotExist(err) {
+		if errWrite := cfg.Write(); errWrite != nil {
+			return nil, errWrite
+		}
+	} else {
+		if errRead := cfg.read(); errRead != nil {
+			return nil, errRead
+		}
+	}
+
+	return cfg, nil
+}
+
+func (cfg *InstanceConfig) Write() error {
+	jsonData, err := json.MarshalIndent(cfg, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(cfg.FilePath, jsonData, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cfg *InstanceConfig) Delete() error {
+	if err := os.Remove(cfg.FilePath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cfg *InstanceConfig) read() error {
+	raw, err := ioutil.ReadFile(cfg.FilePath)
+	if err != nil {
+		return err
+	}
+
+	json.Unmarshal(raw, &cfg)
+	return nil
+}

--- a/pkg/minishift/config/config_test.go
+++ b/pkg/minishift/config/config_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var testDir string
+
+func TestNewInstanceConfig(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	expectedFilePath := filepath.Join(testDir, "fake-machine.json")
+	cfg, _ := NewInstanceConfig(expectedFilePath)
+
+	if cfg.FilePath != expectedFilePath {
+		t.Errorf("Expected path '%s'. Received '%s'", expectedFilePath, cfg.FilePath)
+	}
+
+	if _, err := os.Stat(cfg.FilePath); os.IsNotExist(err) {
+		t.Errorf("File %s should exists", cfg.FilePath)
+	}
+}
+
+func TestConfigOnFileExists(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	filePath := filepath.Join(testDir, "fake-machine.json")
+	expectedOcPath := filepath.Join(testDir, "fakeOc")
+	cfg := &InstanceConfig{
+		FilePath: filePath,
+		OcPath:   expectedOcPath,
+	}
+
+	jsonData, _ := json.MarshalIndent(cfg, "", "\t")
+	// create config file before NewInstanceConfig
+	ioutil.WriteFile(cfg.FilePath, jsonData, 0644)
+
+	newCfg, _ := NewInstanceConfig(filePath)
+	if newCfg.OcPath != expectedOcPath {
+		t.Errorf("Expected oc path '%s'. Received '%s'", expectedOcPath, cfg.OcPath)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	path := filepath.Join(testDir, "fake-machine.json")
+	cfg, _ := NewInstanceConfig(path)
+
+	expectedOcPath := filepath.Join(testDir, "fakeOc")
+	cfg.OcPath = expectedOcPath
+	cfg.Write()
+
+	// read config file and verify content
+	var testCfg *InstanceConfig
+	raw, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Errorf("Error reading config file %s", path)
+	}
+
+	json.Unmarshal(raw, &testCfg)
+	if testCfg.OcPath != cfg.OcPath {
+		t.Errorf("Expected oc path '%s'. Received '%s'", expectedOcPath, cfg.OcPath)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	path := filepath.Join(testDir, "fake-machine.json")
+	cfg, _ := NewInstanceConfig(path)
+
+	cfg.Delete()
+
+	if _, err := os.Stat(cfg.FilePath); err == nil {
+		t.Errorf("Expected file '%s' to be deleted", path)
+	}
+}
+
+func setup(t *testing.T) {
+	var err error
+	testDir, err = ioutil.TempDir("", "minishift-test-config-")
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// teardown remove the temp directory
+func teardown() {
+	os.RemoveAll(testDir)
+}


### PR DESCRIPTION
Adding *WIP* as tests are remaininig.

Others things looks fine as per my opinion except the naming part (which I always find hard :smile: ). Suggestions are welcome.

```
$ cat ~/.minishift/machines/minishift/instance-data.json
{
  "OcPath": "/home/budhram/.minishift/cache/oc/v1.4.1/oc"
}%
```

#### Able to fetch data by simply calling read method
```
$ minishift delete   
ocPath in delete  /home/budhram/.minishift/cache/oc/v1.4.1/oc
Deleting the Minishift VM...
Minishift VM deleted.
```