### PR TITLE
Issue #480 Mount CIFS shares

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -100,6 +100,14 @@ var settings []Setting = []Setting{
 		callbacks:   []setFn{RequiresRestartMsg},
 	},
 	{
+		name: "hostfolders-automount",
+		set:  SetBool,
+	},
+	{
+		name: "hostfolders-mountpath",
+		set:  SetString,
+	},
+	{
 		name: config.WantUpdateNotification,
 		set:  SetBool,
 	},

--- a/cmd/minishift/cmd/hostfolder/hostfolder.go
+++ b/cmd/minishift/cmd/hostfolder/hostfolder.go
@@ -1,0 +1,159 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostfolder
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"os"
+
+	"github.com/docker/machine/libmachine"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	hostfolderActions "github.com/minishift/minishift/pkg/minishift/hostfolder"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/cobra"
+)
+
+var (
+	mountAll bool
+)
+
+// HostfolderCmd represents the resource command for host folders
+var HostfolderCmd = &cobra.Command{
+	Use:   "hostfolder SUBCOMMAND [flags]",
+	Short: "Manage and control host folders for use by the OpenShift cluster.",
+	Long:  `Manage and control host folders for use by the OpenShift cluster.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var hostfolderMountCmd = &cobra.Command{
+	Use:   "mount HOSTFOLDER_NAME",
+	Short: "Mount a host folder to the running cluster",
+	Long:  `Mount a host folder to the running cluster`,
+	Run: func(cmd *cobra.Command, args []string) {
+		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
+		defer api.Close()
+		host, _ := api.Load(constants.MachineName)
+
+		var err error = nil
+		if mountAll {
+			err = hostfolderActions.MountHostfolders(host.Driver)
+		} else {
+			if len(args) < 1 {
+				fmt.Fprintln(os.Stderr, "usage: minishift hostfolder mount [HOSTFOLDER_NAME|--all]")
+				atexit.Exit(1)
+			}
+			err = hostfolderActions.Mount(host.Driver, args[0])
+		}
+
+		if err != nil {
+			glog.Errorln(err)
+			atexit.Exit(1)
+		}
+
+	},
+}
+
+// TODO: refactor; lot of repetition with previous command
+var hostfolderUmountCmd = &cobra.Command{
+	Use:   "umount HOSTFOLDER_NAME",
+	Short: "Unmount a host folder from the running cluster",
+	Long:  `Unmount a host folder from the running cluster`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			fmt.Fprintln(os.Stderr, "usage: minishift hostfolder umount HOSTFOLDER_NAME")
+			atexit.Exit(1)
+		}
+
+		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
+		defer api.Close()
+		host, _ := api.Load(constants.MachineName)
+
+		err := hostfolderActions.Umount(host.Driver, args[0])
+		if err != nil {
+			glog.Errorln(err)
+			atexit.Exit(1)
+		}
+	},
+}
+
+var hostfolderListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List an overview of defined host folders",
+	Long:  `List an overview of defined host folders that can be mounted to a running cluster`,
+	Run: func(cmd *cobra.Command, args []string) {
+		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
+		defer api.Close()
+		host, _ := api.Load(constants.MachineName)
+
+		hostfolderActions.List(host.Driver)
+	},
+}
+
+var hostfolderAddCmd = &cobra.Command{
+	Use:   "add HOSTFOLDER_NAME",
+	Short: "Add a host folder definition",
+	Long:  `Add a host folder definition that can be mounted to a running cluster`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			fmt.Fprintln(os.Stderr, "usage: minishift hostfolder add HOSTFOLDER_NAME")
+			atexit.Exit(1)
+		}
+
+		hostfolderActions.Add(args[0])
+	},
+}
+
+var hostfolderSetupUsersCmd = &cobra.Command{
+	Use:   "setup-users",
+	Short: "Setup credentials for the Users share on a Windows host",
+	Long:  `Setup credentials for the Users share on a Windows host`,
+	Run: func(cmd *cobra.Command, args []string) {
+		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
+		defer api.Close()
+
+		hostfolderActions.SetupUsers()
+	},
+}
+
+var hostfolderRemoveCmd = &cobra.Command{
+	Use:   "remove HOSTFOLDER_NAME",
+	Short: "Remove a host folder definition",
+	Long:  `Remove a host folder definition`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			fmt.Fprintln(os.Stderr, "usage: minishift hostfolder remove HOSTFOLDER_NAME")
+			atexit.Exit(1)
+		}
+
+		hostfolderActions.Remove(args[0])
+	},
+}
+
+func init() {
+	// parent set in root.go (RootCmd)
+	//HostfolderCmd.PersistentFlags().Bool(hostfolderActions.AutoMountHostfolders, false, "Auto-mount hostfolders on startup")
+	HostfolderCmd.AddCommand(hostfolderMountCmd)
+	hostfolderMountCmd.Flags().BoolVarP(&mountAll, "all", "a", false, "Mount all defined host folders to the cluster instance.")
+	HostfolderCmd.AddCommand(hostfolderUmountCmd)
+	HostfolderCmd.AddCommand(hostfolderListCmd)
+	HostfolderCmd.AddCommand(hostfolderAddCmd)
+	HostfolderCmd.AddCommand(hostfolderRemoveCmd)
+	HostfolderCmd.AddCommand(hostfolderSetupUsersCmd)
+}

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/machine/libmachine/log"
 	"github.com/golang/glog"
 	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	hostfolderCmd "github.com/minishift/minishift/cmd/minishift/cmd/hostfolder"
 	openShiftCmd "github.com/minishift/minishift/cmd/minishift/cmd/openshift"
 	"github.com/minishift/minishift/pkg/minikube/config"
 	"github.com/minishift/minishift/pkg/minikube/constants"
@@ -123,6 +124,8 @@ func init() {
 	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Show logs from libmachine.")
 	RootCmd.AddCommand(configCmd.ConfigCmd)
 	RootCmd.AddCommand(openShiftCmd.OpenShiftConfigCmd)
+	RootCmd.AddCommand(hostfolderCmd.HostfolderCmd)
+
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	logDir := pflag.Lookup("log_dir")
 	if !logDir.Changed {

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -23,6 +23,7 @@ import (
 
 	units "github.com/docker/go-units"
 	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/golang/glog"
@@ -31,6 +32,7 @@ import (
 	"github.com/minishift/minishift/pkg/minishift/cache"
 	"github.com/minishift/minishift/pkg/minishift/clusterup"
 	instanceState "github.com/minishift/minishift/pkg/minishift/config"
+	"github.com/minishift/minishift/pkg/minishift/hostfolder"
 	"github.com/minishift/minishift/pkg/minishift/openshift"
 	"github.com/minishift/minishift/pkg/minishift/provisioner"
 	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
@@ -187,10 +189,18 @@ func runStart(cmd *cobra.Command, args []string) {
 		atexit.Exit(1)
 	}
 
+	automountHostfolders(host.Driver)
+
 	clusterUp(&config, ip)
 	if err := openshift.AddSudoersRoleForUser("developer"); err != nil {
 		glog.Errorln("Error adding developer user to sudoers", err)
 		atexit.Exit(1)
+	}
+}
+
+func automountHostfolders(driver drivers.Driver) {
+	if hostfolder.IsAutoMount() && hostfolder.IsHostfoldersDefined(false) {
+		hostfolder.MountHostfolders(driver)
 	}
 }
 

--- a/pkg/minishift/config/config.go
+++ b/pkg/minishift/config/config.go
@@ -27,12 +27,14 @@ var Config *InstanceConfig
 type InstanceConfig struct {
 	FilePath string `json:"-"`
 	OcPath   string
+
+	HostFolders []HostFolder
 }
 
 // Create new object with data if file exists or
 // Create json file and return object if doesn't exists
 func NewInstanceConfig(path string) (*InstanceConfig, error) {
-	cfg := new(InstanceConfig)
+	cfg := &InstanceConfig{HostFolders: []HostFolder{}}
 	cfg.FilePath = path
 
 	// Check json file existence

--- a/pkg/minishift/config/hostfolder.go
+++ b/pkg/minishift/config/hostfolder.go
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+type HostFolder struct {
+	Name    string
+	Type    string
+	Options map[string]string
+}
+
+const (
+	HostfoldersDefaultPath  = "/mnt/sda1"
+	HostfoldersMountPathKey = "hostfolders-mountpath"
+)
+
+func GetHostfoldersMountPath(name string) string {
+	overrideMountPath := viper.GetString(HostfoldersMountPathKey)
+	if len(overrideMountPath) > 0 {
+		return fmt.Sprintf("%s/%s", overrideMountPath, name)
+	}
+
+	return fmt.Sprintf("%s/%s", HostfoldersDefaultPath, name)
+}
+
+func (hf *HostFolder) Mountpoint() string {
+	overrideMountPoint := hf.Options["mountpoint"]
+	if len(overrideMountPoint) > 0 {
+		return overrideMountPoint
+	}
+
+	return GetHostfoldersMountPath(hf.Name)
+}

--- a/pkg/minishift/hostfolder/hostfolder.go
+++ b/pkg/minishift/hostfolder/hostfolder.go
@@ -1,0 +1,423 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostfolder
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/state"
+	"github.com/spf13/viper"
+
+	instanceState "github.com/minishift/minishift/pkg/minishift/config"
+	"github.com/minishift/minishift/pkg/minishift/util"
+)
+
+const (
+	HostfoldersAutoMountKey = "hostfolders-automount"
+)
+
+func IsAutoMount() bool {
+	return viper.GetBool(HostfoldersAutoMountKey)
+}
+
+func isHostRunning(driver drivers.Driver) bool {
+	return drivers.MachineInState(driver, state.Running)()
+}
+
+func IsHostfoldersDefined(printMessage bool) bool {
+	if len(instanceState.Config.HostFolders) == 0 {
+		if printMessage {
+			println("No host folders defined")
+		}
+		return false
+	}
+	return true
+}
+
+func isHostfolderDefinedByName(name string, printMessage bool) bool {
+	hostfolder := getHostfolderByName(name)
+	if hostfolder != nil {
+		if printMessage {
+			println(fmt.Sprintf("Already have a host folder defined for: %s", name))
+		}
+		return true
+	}
+	return false
+}
+
+func List(driver drivers.Driver) {
+	if !IsHostfoldersDefined(true) {
+		return
+	}
+
+	procMounts := ""
+	isRunning := isHostRunning(driver)
+	if isRunning {
+		cmd := fmt.Sprintf("cat /proc/mounts")
+		procMounts, _ = drivers.RunSSHCommandFromDriver(driver, cmd)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 4, 8, 3, ' ', 0)
+	fmt.Fprintln(w, "Name\tMountpoint\tRemote path\tMounted")
+
+	hostfolders := instanceState.Config.HostFolders
+	for i := range hostfolders {
+		hostfolder := hostfolders[i]
+
+		remotePath := ""
+		switch hostfolder.Type {
+		case "cifs":
+			remotePath = hostfolder.Options["uncpath"]
+		}
+
+		mounted := "N"
+		if isRunning && strings.Contains(procMounts, hostfolder.Mountpoint()) {
+			mounted = "Y"
+		}
+
+		fmt.Fprintln(w,
+			(fmt.Sprintf("%s\t%s\t%s\t%s",
+				hostfolder.Name,
+				hostfolder.Mountpoint(),
+				remotePath,
+				mounted)))
+	}
+
+	w.Flush()
+}
+
+func readInputForMountpoint(name string) string {
+	defaultMountpoint := instanceState.GetHostfoldersMountPath(name)
+	mountpointText := fmt.Sprintf("Mountpoint [%s]", defaultMountpoint)
+	return util.ReadInputFromStdin(mountpointText)
+}
+
+func SetupUsers() {
+	name := "Users"
+	if !isHostfolderDefinedByName(name, true) {
+		mountpoint := readInputForMountpoint(name)
+		username := util.ReadInputFromStdin("Username")
+		password := util.ReadPasswordFromStdin("Password")
+		domain := util.ReadInputFromStdin("Domain")
+
+		// We only store this record for credentials purpose
+		addToConfig(newCifsHostFolder(
+			name,
+			"[determined on startup]",
+			mountpoint,
+			username, password, domain))
+	}
+}
+
+func Add(name string) {
+	if !isHostfolderDefinedByName(name, true) {
+		mountpoint := readInputForMountpoint(name)
+		uncpath := util.ReadInputFromStdin("UNC path")
+		username := util.ReadInputFromStdin("Username")
+		password := util.ReadPasswordFromStdin("Password")
+		domain := util.ReadInputFromStdin("Domain")
+
+		addToConfig(newCifsHostFolder(
+			name,
+			uncpath,
+			mountpoint,
+			username, password, domain))
+	}
+}
+
+func newCifsHostFolder(name string, uncpath string, mountpoint string, username string, password string, domain string) instanceState.HostFolder {
+	return instanceState.HostFolder{
+		Name: name,
+		Type: "cifs",
+		Options: map[string]string{
+			"mountpoint": mountpoint,
+			"uncpath":    convertSlashes(uncpath),
+			"username":   username,
+			"password":   password,
+			"domain":     domain,
+		},
+	}
+}
+
+func addToConfig(hostfolder instanceState.HostFolder) {
+	instanceState.Config.HostFolders = append(instanceState.Config.HostFolders, hostfolder)
+	instanceState.Config.Write()
+
+	println(fmt.Sprintf("Added: %s", hostfolder.Name))
+}
+
+func Remove(name string) {
+	if isHostfolderDefinedByName(name, false) {
+		hostfolders := instanceState.Config.HostFolders
+
+		for i := range hostfolders {
+
+			hostfolder := hostfolders[i]
+
+			if hostfolder.Name == name {
+				hostfolders = append(hostfolders[:i], hostfolders[i+1:]...)
+				break
+			}
+		}
+
+		instanceState.Config.HostFolders = hostfolders
+		instanceState.Config.Write()
+		println(fmt.Sprintf("Removed: %s", name))
+	}
+}
+
+func Mount(driver drivers.Driver, name string) error {
+	if !isHostRunning(driver) {
+		return errors.New("Host is in the wrong state.")
+	}
+
+	if !IsHostfoldersDefined(true) {
+		return errors.New("No host folders defined.")
+	}
+
+	hostfolder := getHostfolderByName(name)
+	if hostfolder == nil {
+		return fmt.Errorf("No host folder defined as: %s", name)
+	} else {
+		ensureMountPointExists(driver, hostfolder)
+		mountHostfolder(driver, hostfolder)
+	}
+	return nil
+}
+
+// Performs mounting of host folders
+func MountHostfolders(driver drivers.Driver) error {
+	if !isHostRunning(driver) {
+		return errors.New("Host is in the wrong state.")
+	}
+
+	if !IsHostfoldersDefined(true) {
+		return errors.New("No host folders defined.")
+	}
+
+	println("-- Mounting hostfolders")
+
+	hostfolders := instanceState.Config.HostFolders
+	for i := range hostfolders {
+		// Ignore individual errors or aggregate
+		mountHostfolder(driver, &hostfolders[i])
+	}
+
+	return nil
+}
+
+func Umount(driver drivers.Driver, name string) error {
+	if !isHostRunning(driver) {
+		return errors.New("Host is in the wrong state.")
+	}
+
+	if !IsHostfoldersDefined(true) {
+		return errors.New("No host folders defined")
+	}
+
+	hostfolder := getHostfolderByName(name)
+	if hostfolder == nil {
+		return fmt.Errorf("No host folder defined as: %s", name)
+	} else {
+		umountHostfolder(driver, hostfolder)
+	}
+	return nil
+}
+
+func mountHostfolder(driver drivers.Driver, hostfolder *instanceState.HostFolder) error {
+	if hostfolder == nil {
+		return errors.New("Host folder not defined")
+	}
+
+	switch hostfolder.Type {
+	case "cifs":
+		if err := mountCifsHostfolder(driver, hostfolder); err != nil {
+			return err
+		}
+	default:
+		return errors.New("Unsupported host folder type")
+	}
+
+	return nil
+}
+
+func determineHostIp(driver drivers.Driver) (string, error) {
+	instanceip, err := driver.GetIP()
+	if err != nil {
+		return "", err
+	}
+
+	for _, hostaddr := range util.HostIPs() {
+
+		if util.NetworkContains(hostaddr, instanceip) {
+			hostip, _, _ := net.ParseCIDR(hostaddr)
+			if util.IsIPReachable(driver, hostip.String(), false) {
+				return hostip.String(), nil
+			} else {
+				return "", errors.New("Unreachable")
+			}
+		}
+	}
+
+	return "", errors.New("Unknown error occured")
+}
+
+func mountCifsHostfolder(driver drivers.Driver, hostfolder *instanceState.HostFolder) error {
+	// If "Users" is used as name, determine the IP of host for UNC path on startup
+	if hostfolder.Name == "Users" {
+		hostip, _ := determineHostIp(driver)
+		hostfolder.Options["uncpath"] = fmt.Sprintf("//%s/Users", hostip)
+	}
+
+	print(fmt.Sprintf("   Mounting '%s': '%s' as '%s' ... ",
+		hostfolder.Name,
+		hostfolder.Options["uncpath"],
+		hostfolder.Mountpoint()))
+
+	if isMounted, err := isHostfolderMounted(driver, hostfolder); isMounted {
+		println("Already mounted")
+		return fmt.Errorf("Host folder is already mounted. %s", err)
+	}
+
+	if !isCifsHostReachable(driver, hostfolder.Options["uncpath"]) {
+		print("Unreachable\n")
+		return errors.New("Host folder is unreachable")
+	}
+
+	cmd := fmt.Sprintf(
+		"sudo mount -t cifs %s %s -o username=%s,password=%s",
+		hostfolder.Options["uncpath"],
+		hostfolder.Mountpoint(),
+		hostfolder.Options["username"],
+		hostfolder.Options["password"])
+
+	if len(hostfolder.Options["domain"]) > 0 { // != ""
+		cmd = fmt.Sprintf("%s,domain=%s", cmd, hostfolder.Options["domain"])
+	}
+
+	if err := ensureMountPointExists(driver, hostfolder); err != nil {
+		println("FAIL")
+		return fmt.Errorf("Error occured while creating mountpoint. %s", err)
+	}
+
+	if _, err := drivers.RunSSHCommandFromDriver(driver, cmd); err != nil {
+		println("FAIL")
+		return fmt.Errorf("Error occured while mounting host folder.", err)
+	} else {
+		println("OK")
+	}
+
+	return nil
+}
+
+func umountHostfolder(driver drivers.Driver, hostfolder *instanceState.HostFolder) error {
+	if hostfolder == nil {
+		errors.New("Host folder not defined")
+	}
+
+	print(fmt.Sprintf("   Unmounting '%s' ... ", hostfolder.Name))
+
+	if isMounted, err := isHostfolderMounted(driver, hostfolder); !isMounted {
+		print("Not mounted\n")
+		return fmt.Errorf("Host folder not mounted. %s", err)
+	}
+
+	cmd := fmt.Sprintf(
+		"sudo umount %s",
+		hostfolder.Mountpoint())
+
+	if _, err := drivers.RunSSHCommandFromDriver(driver, cmd); err != nil {
+		println("FAIL")
+		return fmt.Errorf("Error occured while unmounting host folder.", err)
+	} else {
+		println("OK")
+	}
+
+	return nil
+}
+
+func isHostfolderMounted(driver drivers.Driver, hostfolder *instanceState.HostFolder) (bool, error) {
+	cmd := fmt.Sprintf(
+		"if grep -qs %s /proc/mounts; then echo '1'; else echo '0'; fi",
+		hostfolder.Mountpoint())
+
+	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
+
+	if err != nil {
+		return false, err
+	}
+	if strings.Trim(out, "\n") == "0" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func convertSlashes(input string) string {
+	return strings.Replace(input, "\\", "/", -1)
+}
+
+func isCifsHostReachable(driver drivers.Driver, uncpath string) bool {
+	host := ""
+
+	splithost := strings.Split(uncpath, "/")
+	if len(splithost) > 2 {
+		host = splithost[2]
+	}
+
+	if host == "" {
+		return false
+	}
+
+	return util.IsIPReachable(driver, host, false)
+}
+
+func ensureMountPointExists(driver drivers.Driver, hostfolder *instanceState.HostFolder) error {
+	if hostfolder == nil {
+		errors.New("Host folder is not defined")
+	}
+
+	cmd := fmt.Sprintf(
+		"sudo mkdir -p %s",
+		hostfolder.Mountpoint())
+
+	if _, err := drivers.RunSSHCommandFromDriver(driver, cmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getHostfolderByName(name string) *instanceState.HostFolder {
+	hostfolders := instanceState.Config.HostFolders
+	for i := range hostfolders {
+
+		hostfolder := hostfolders[i]
+
+		if hostfolder.Name == name {
+			return &hostfolder
+		}
+	}
+
+	return nil
+}

--- a/pkg/minishift/util/hostip.go
+++ b/pkg/minishift/util/hostip.go
@@ -1,0 +1,92 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/docker/machine/libmachine/drivers"
+)
+
+// IsIPReachable returns true is IP address is reachable from the virtual instance
+func IsIPReachable(driver drivers.Driver, ip string, printOutput bool) bool {
+	cmd := fmt.Sprintf(
+		"sudo ping -c1 -w1 %s",
+		ip)
+
+	if printOutput {
+		print(fmt.Sprintf("   Checking if '%s' is reachable ... ", ip))
+	}
+	if _, err := drivers.RunSSHCommandFromDriver(driver, cmd); err != nil {
+		if printOutput {
+			print("FAIL\n")
+		}
+		return false
+	}
+
+	if printOutput {
+		print("OK\n")
+	}
+	return true
+}
+
+// NetworkContains returns true if the IP address belongs to the network given
+func NetworkContains(network string, ip string) bool {
+	_, ipnet, _ := net.ParseCIDR(network)
+	address := net.ParseIP(ip)
+	return ipnet.Contains(address)
+}
+
+// HostIPs returns the IP addresses assigned to the host
+func HostIPs() []string {
+	ips := []string{}
+
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue // interface down
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue // loopback interface
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			ip = ip.To4()
+			if ip == nil {
+				continue // not an ipv4 address
+			}
+
+			ips = append(ips, addr.String())
+		}
+	}
+
+	return ips
+}

--- a/pkg/minishift/util/input.go
+++ b/pkg/minishift/util/input.go
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func ReadInputFromStdin(fieldlabel string) string {
+	var value string
+	print(fmt.Sprintf("%s: ", fieldlabel))
+	fmt.Scanln(&value)
+	return value
+}
+
+func ReadPasswordFromStdin(fieldlabel string) string {
+	var value string
+	print(fmt.Sprintf("%s: ", fieldlabel))
+	pwinput, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err == nil {
+		println("[HIDDEN]")
+		value = string(pwinput)
+	}
+	return value
+}


### PR DESCRIPTION
Related to #480 


~~Sharing for feedback/sync related to sshfs and config
I do read the instance config, but do not write it yet.
I have a type variable, but do not enforce it just yet in code.
This also means, the mount code for cifs is generally named and not moved into a separate file just yet.~~

~~Still a lot of duplication to be removed as a refactor, so do not look at newlines/whitelines, missing boilerplate, docs, but functionality...~~

```
    "HostFolders": [
        {
            "Name": "Users",
            "Type": "cifs",
            "Options": {
                "password": "********",
                "domain": "RHGBWIN10",
                "uncpath": "//RHGBWIN10/Users",
                "username": "gbraad@redhat.com"
            }
        },
        {
            "Name": "unreachable",
            "Type": "cifs",
            "Options": {
                "domain": "",
                "password": "********",
                "uncpath": "//unreachable/disks",
                "username": "root"
            }
        },
        {
            "Name": "Disks",
            "Type": "cifs",
            "Options": {
                "domain": "",
                "password": "********",
                "uncpath": "//10.0.21.33/disks",
                "username": "root"
            }
        }
    ],
```