### PR TITLE
[WIP] Issue #342 Fix service command

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -76,7 +76,6 @@ mkdir /tmp/glide
 tar --directory=/tmp/glide -xvf glide-${GLIDE_TAG}-${GLIDE_OS_ARCH}.tar.gz
 export PATH=$PATH:/tmp/glide/${GLIDE_OS_ARCH}
 
-# Test
 make clean test cross fmtcheck prerelease
 # Run integration test with 'kvm' driver
 MINISHIFT_VM_DRIVER=kvm make integration

--- a/cmd/minishift/cmd/openshift/service_list.go
+++ b/cmd/minishift/cmd/openshift/service_list.go
@@ -18,16 +18,8 @@ package openshift
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/docker/machine/libmachine"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"k8s.io/kubernetes/pkg/api/v1"
-
-	"github.com/minishift/minishift/pkg/minikube/cluster"
-	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/util/os/atexit"
 )
 
 var serviceListNamespace string
@@ -38,30 +30,12 @@ var serviceListCmd = &cobra.Command{
 	Short: "Gets the URLs of the services in your local cluster.",
 	Long:  `Gets the URLs of the services in your local cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
-		defer api.Close()
-		serviceURLs, err := cluster.GetServiceURLs(api, serviceListNamespace, serviceURLTemplate)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			fmt.Fprintln(os.Stderr, "Check that Minishift is running and that the correct namespace is specified in the -n option if it is required.")
-			atexit.Exit(1)
-		}
-
-		var data [][]string
-		for _, serviceURL := range serviceURLs {
-			data = append(data, []string{serviceURL.Namespace, serviceURL.Name, serviceURL.URL})
-		}
-
-		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"Namsepace", "Name", "URL"})
-		table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
-		table.SetCenterSeparator("|")
-		table.AppendBulk(data) // Add Bulk Data
-		table.Render()
+		// TODO
+		fmt.Println("In Service List")
 	},
 }
 
 func init() {
-	serviceListCmd.Flags().StringVarP(&serviceListNamespace, "namespace", "n", v1.NamespaceAll, "The namespace of the services.")
+	serviceListCmd.Flags().StringVarP(&serviceListNamespace, "namespace", "n", "", "The namespace of the services.")
 	serviceCmd.AddCommand(serviceListCmd)
 }

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -27,7 +26,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/docker/machine/drivers/virtualbox"
@@ -42,9 +40,6 @@ import (
 	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
 	"github.com/minishift/minishift/pkg/util"
 	pb "gopkg.in/cheggaaa/pb.v1"
-	kubeapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 )
 
 var (
@@ -54,10 +49,6 @@ var (
 
 const (
 	fileScheme = "file"
-
-	serviceAPIAnnotationsPrefix = "api.service.kubernetes.io/"
-	serviceAPIAnnotationScheme  = serviceAPIAnnotationsPrefix + "scheme"
-	serviceAPIAnnotationPath    = serviceAPIAnnotationsPrefix + "path"
 )
 
 //This init function is used to set the logtostderr variable to false so that INFO level log info does not clutter the CLI
@@ -462,165 +453,8 @@ type ipPort struct {
 	Port int
 }
 
-func GetServiceURL(api libmachine.API, namespace, service string, t *template.Template) (string, error) {
-	host, err := CheckIfApiExistsAndLoad(api)
-	if err != nil {
-		return "", err
-	}
-
-	ip, err := host.Driver.GetIP()
-	if err != nil {
-		return "", err
-	}
-
-	client, err := getKubernetesClient()
-	if err != nil {
-		return "", err
-	}
-
-	return getServiceURLWithClient(client, ip, namespace, service, t)
-}
-
-func getServiceURLWithClient(client *unversioned.Client, ip, namespace, service string, t *template.Template) (string, error) {
-	port, err := getServicePort(client, namespace, service)
-	if err != nil {
-		return "", err
-	}
-
-	var doc bytes.Buffer
-	err = t.Execute(&doc, ipPort{ip, port})
-	if err != nil {
-		return "", err
-	}
-
-	u, err := url.Parse(doc.String())
-	if err != nil {
-		return "", err
-	}
-
-	annotations, err := getServiceAnnotations(client, namespace, service)
-	if err != nil {
-		return "", err
-	}
-
-	if scheme, ok := annotations[serviceAPIAnnotationScheme]; ok {
-		u.Scheme = scheme
-	}
-	if path, ok := annotations[serviceAPIAnnotationPath]; ok && len(u.Path) == 0 {
-		u.Path = path
-	}
-
-	return u.String(), nil
-}
-
-type serviceGetter interface {
-	Get(name string) (*kubeapi.Service, error)
-	List(kubeapi.ListOptions) (*kubeapi.ServiceList, error)
-}
-
-func getServicePort(client *unversioned.Client, namespace, service string) (int, error) {
-	services := getKubernetesServicesWithNamespace(client, namespace)
-	return getServicePortFromServiceGetter(services, service)
-}
-
-type MissingNodePortError struct {
-	service *kubeapi.Service
-}
-
-func (e MissingNodePortError) Error() string {
-	return fmt.Sprintf("Service %s/%s does not have a node port. To assign a port automatically, the service type must be NodePort or LoadBalancer, but this service is of type %s.", e.service.Namespace, e.service.Name, e.service.Spec.Type)
-}
-
-func getServiceFromServiceGetter(services serviceGetter, service string) (*kubeapi.Service, error) {
-	svc, err := services.Get(service)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting %s service: %s", service, err)
-	}
-	return svc, nil
-}
-
-func getServicePortFromServiceGetter(services serviceGetter, service string) (int, error) {
-	svc, err := getServiceFromServiceGetter(services, service)
-	if err != nil {
-		return 0, err
-	}
-	nodePort := 0
-	if len(svc.Spec.Ports) > 0 {
-		nodePort = int(svc.Spec.Ports[0].NodePort)
-	}
-	if nodePort == 0 {
-		return 0, MissingNodePortError{svc}
-	}
-	return nodePort, nil
-}
-
-func getKubernetesClient() (*unversioned.Client, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	config, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("Error creating kubeConfig: %s", err)
-	}
-	return unversioned.New(config)
-}
-
-func getKubernetesServicesWithNamespace(client *unversioned.Client, namespace string) serviceGetter {
-	return client.Services(namespace)
-}
-
-func getServiceAnnotations(client *unversioned.Client, namespace, service string) (map[string]string, error) {
-	svc, err := getServiceFromServiceGetter(getKubernetesServicesWithNamespace(client, namespace), service)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting %s service: %s", service, err)
-	}
-	return svc.ObjectMeta.Annotations, nil
-}
-
 type ServiceURL struct {
 	Namespace string
 	Name      string
 	URL       string
-}
-
-type ServiceURLs []ServiceURL
-
-func GetServiceURLs(api libmachine.API, namespace string, t *template.Template) (ServiceURLs, error) {
-	host, err := CheckIfApiExistsAndLoad(api)
-	if err != nil {
-		return nil, err
-	}
-
-	ip, err := host.Driver.GetIP()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := getKubernetesClient()
-	if err != nil {
-		return nil, err
-	}
-
-	getter := getKubernetesServicesWithNamespace(client, namespace)
-
-	svcs, err := getter.List(kubeapi.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	var serviceURLs []ServiceURL
-
-	for _, svc := range svcs.Items {
-		url, err := getServiceURLWithClient(client, ip, svc.Namespace, svc.Name, t)
-		if err != nil {
-			if _, ok := err.(MissingNodePortError); ok {
-				serviceURLs = append(serviceURLs, ServiceURL{Namespace: svc.Namespace, Name: svc.Name, URL: "No node port"})
-				continue
-			}
-			return nil, err
-		}
-		serviceURLs = append(serviceURLs, ServiceURL{Namespace: svc.Namespace, Name: svc.Name, URL: url})
-	}
-
-	return serviceURLs, nil
 }

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -97,7 +98,6 @@ func (m *Minishift) executingCommand(command string) error {
 }
 
 func compareExpectedWithActualContains(expected string, actual string) error {
-
 	if !strings.Contains(actual, expected) {
 		return fmt.Errorf("Output did not match. Expected: %s, Actual: %s", expected, actual)
 	}
@@ -106,9 +106,17 @@ func compareExpectedWithActualContains(expected string, actual string) error {
 }
 
 func compareExpectedWithActualEquals(expected string, actual string) error {
-
 	if actual != expected {
 		return fmt.Errorf("Output did not match. Expected: %s, Actual: %s", expected, actual)
+	}
+
+	return nil
+}
+
+func findExpectedMatchInActual(expectedMatch, actual string) error {
+	r, _ := regexp.Compile(expectedMatch)
+	if !r.MatchString(actual) {
+		return fmt.Errorf("Actual output %s doesn't contain match %s", actual, expectedMatch)
 	}
 
 	return nil
@@ -149,6 +157,10 @@ func (m *Minishift) commandReturnShouldBeEmpty(commandField string) error {
 	return compareExpectedWithActualEquals("", selectFieldFromLastOutput(commandField))
 }
 
+func (m *Minishift) commandReturnShouldMatch(commandField string, expectedMatch string) error {
+	return findExpectedMatchInActual(expectedMatch, selectFieldFromLastOutput(commandField))
+}
+
 func FeatureContext(s *godog.Suite) {
 	var givenArgs = flag.String("minishift-args", "", "Arguments to pass to minishift")
 	var givenPath = flag.String("binary", fmt.Sprintf("../../out/%s-amd64/minishift", runtime.GOOS), "Path to minishift binary")
@@ -161,13 +173,14 @@ func FeatureContext(s *godog.Suite) {
 
 	s.Step(`Minishift (?:has|should have) state "([^"]*)"`, m.shouldHaveState)
 	s.Step(`Minishift should have a valid IP address`, m.shouldHaveAValidIPAddress)
-	s.Step(`executing "minishift ([^"]*)"`, m.executingCommand)
-	s.Step(`executing "oc ([^"]*)`, m.executingOcCommand)
+	s.Step(`execut[es|ing]+ "minishift ([^"]*)"`, m.executingCommand)
+	s.Step(`execut[es|ing]+ "oc ([^"]*)`, m.executingOcCommand)
 	s.Step(`([^"]*) should contain ([^"]*)`, m.commandReturnShouldContain)
 	s.Step(`([^"]*) should contain`, m.commandReturnShouldContainContent)
 	s.Step(`([^"]*) should equal ([^"]*)`, m.commandReturnShouldEqual)
 	s.Step(`([^"]*) should equal`, m.commandReturnShouldEqualContent)
 	s.Step(`([^"]*) should be empty`, m.commandReturnShouldBeEmpty)
+	s.Step(`([^"]*) should match /([^"]*)/`, m.commandReturnShouldMatch)
 
 	s.BeforeSuite(func() {
 		testDir := setUp()

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -5,49 +5,57 @@ Feature: Basic
 
   Scenario: Starting Minishift
     Given Minishift has state "Does Not Exist"
-     When executing "minishift start --docker-env=FOO=BAR --docker-env=BAZ=BAT"
-     Then Minishift should have state "Running"
+      When executing "minishift start --docker-env=FOO=BAR --docker-env=BAZ=BAT"
+      Then Minishift should have state "Running"
       And Minishift should have a valid IP address
 
   Scenario: OpenShift developer account has sudo permissions
-     Check if developer have sudo permission then oc should output as below with other
-     cluster roles
-     sudoer   /sudoer   developer
-     When executing "oc --as system:admin get clusterrolebindings"
-     Then stderr should be empty
-     And  exitcode should equal 0
-     And  stdout should contain
-     """
-     sudoer
-     """
+    Check if developer have sudo permission then oc should output as below with other
+    cluster roles
+    sudoer   /sudoer   developer
+    Given Minishift has state "Running"
+    When executing "oc --as system:admin get clusterrolebindings"
+    Then stderr should be empty
+    And  exitcode should equal 0
+    And  stdout should contain
+    """
+    sudoer
+    """
 
   Scenario: User is able to do ssh into machine via Minishift
     Given Minishift has state "Running"
-     When executing "minishift ssh echo hello"
-     Then stderr should be empty
-      And exitcode should equal 0
-      And stdout should contain
-      """
-      hello
-      """
+    When executing "minishift ssh echo hello"
+    Then stderr should be empty
+    And exitcode should equal 0
+    And stdout should contain
+    """
+    hello
+    """
 
   Scenario: User is able to set custom Docker specific environment variables
     Given Minishift has state "Running"
-     When executing "minishift ssh cat /var/lib/boot2docker/profile"
-     Then stderr should be empty
-      And exitcode should equal 0
-      And stdout should contain
-      """
-      export "FOO=BAR"
-      export "BAZ=BAT"
-      """
+    When executing "minishift ssh cat /var/lib/boot2docker/profile"
+    Then stderr should be empty
+    And exitcode should equal 0
+    And stdout should contain
+    """
+    export "FOO=BAR"
+    export "BAZ=BAT"
+    """
+
+  Scenario: User is able to get url on running service command
+    Given Minishift has state "Running"
+    When executing "oc new-app https://github.com/openshift/nodejs-ex"
+    And executes "oc expose svc/nodejs-ex"
+    And executes "minishift openshift service nodejs-ex --url"
+    And stdout should match /nodejs-ex-myproject.(.*).nip.io/
 
   Scenario: Stopping Minishift
     Given Minishift has state "Running"
-     When executing "minishift stop"
-     Then Minishift should have state "Stopped"
+    When executing "minishift stop"
+    Then Minishift should have state "Stopped"
 
   Scenario: Deleting Minishift
     Given Minishift has state "Stopped"
-     When executing "minishift delete"
-     Then Minishift should have state "Does Not Exist"
+    When executing "minishift delete"
+    Then Minishift should have state "Does Not Exist"


### PR DESCRIPTION
- Use oc binary to fetch route and open it in browser
- Remove k8s dependency in service and service list files

#### Tests are being worked on

### Execution log
```
$ minishift openshift service nationalparks-katacoda
Opening the service /nationalparks-katacoda in the default browser...

$ minishift openshift service nationalparks-katacoda -n myproject
Opening the service myproject/nationalparks-katacoda in the default browser...

$ minishift openshift service nationalparks-katacoda -n foo      
Namespace foo doesn't exits
```

Early feedback/review appreciated.

cc @hferentschik @LalatenduMohanty 