### PR TITLE
Issue #562 - Adding BINPATH argument to 'make integration'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ REPOPATH ?= $(ORG)/minishift
 ifeq ($(GOOS),windows)
 	IS_EXE := .exe
 endif
+MINISHIFT_BINARY ?= $(GOPATH)/src/$(REPOPATH)/out/$(GOOS)-$(GOARCH)/minishift$(IS_EXE)
 
 LDFLAGS := -X $(REPOPATH)/pkg/version.version=$(VERSION) \
 	-X $(REPOPATH)/pkg/version.isoVersion=$(ISO_VERSION) \
@@ -103,8 +104,8 @@ test: vendor $(GOPATH)/src/$(ORG)
 	@go test -v $(shell $(PACKAGES))
 
 .PHONY: integration
-integration: $(BUILD_DIR)/$(GOOS)-$(GOARCH)/minishift$(IS_EXE)
-	go test -timeout 3600s $(REPOPATH)/test/integration --tags=integration -v
+integration: $(MINISHIFT_BINARY)
+	go test -timeout 3600s $(REPOPATH)/test/integration --tags=integration -v -args --binary $(MINISHIFT_BINARY)
 
 .PHONY: fmt
 fmt:

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -151,7 +150,8 @@ func (m *Minishift) commandReturnShouldBeEmpty(commandField string) error {
 
 func FeatureContext(s *godog.Suite) {
 	var givenArgs = flag.String("minishift-args", "", "Arguments to pass to minishift")
-	var givenPath = flag.String("binary", fmt.Sprintf("../../out/%s-amd64/minishift", runtime.GOOS), "Path to minishift binary")
+	var givenPath = flag.String("binary", "", "Path to minishift binary")
+	flag.Parse()
 
 	runner := util.MinishiftRunner{
 		CommandArgs: *givenArgs,
@@ -171,7 +171,8 @@ func FeatureContext(s *godog.Suite) {
 
 	s.BeforeSuite(func() {
 		testDir := setUp()
-		fmt.Println("Running Integration test in : ", testDir)
+		fmt.Println("Running Integration test in: ", testDir)
+		fmt.Println("using binary: ", *givenPath)
 	})
 
 	s.AfterSuite(func() {


### PR DESCRIPTION
To be able to select custom binary on which tests will be started there is BINPATH argument for make created. To run make integration on already existing binary, run "make integration BINPATH=<path-to-binary>". In this case new build will not be triggered. When no BINPATH is selected, integration will build new binary and run on it as it is currently implemented.

Fixes #562.