### PR TITLE
Issue #578 - Add tag support for godog tests into make integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ifeq ($(GOOS),windows)
 	IS_EXE := .exe
 endif
 MINISHIFT_BINARY ?= $(GOPATH)/bin/minishift$(IS_EXE)
+GODOG_OPTS ?= ""
 PACKAGES := go list ./... | grep -v /vendor
 SOURCE_DIRS = cmd pkg test
 
@@ -143,7 +144,7 @@ test: vendor $(ADDON_ASSET_FILE)
 
 .PHONY: integration
 integration: $(MINISHIFT_BINARY)
-	go test -timeout 3600s $(REPOPATH)/test/integration --tags=integration -v -args --binary $(MINISHIFT_BINARY)
+	go test -timeout 3600s $(REPOPATH)/test/integration --tags=integration -v -args --binary $(MINISHIFT_BINARY) $(GODOG_OPTS)
 
 .PHONY: fmt
 fmt:

--- a/docs/source/developing/developing.adoc
+++ b/docs/source/developing/developing.adoc
@@ -209,11 +209,39 @@ For more information about test options, run the `go test --help` command and re
 ==== Integration Tests
 
 Integration tests utilize https://github.com/DATA-DOG/godog[`godog`], which uses Gherkin (Cucumber)
-to define test cases. The test cases are defined in `test/integration/*.feature`, and can be run with:
+to define test cases. The test cases are defined in `test/integration/*.feature`. To execute them on binary created by `make build` you 
+can simply run:
 
 ----
 $ make integration
 ----
+
+To run integration tests on minishift binary in different location you can use `MINISHIFT_BINARY` argument:
+
+----
+$ make integration MINISHIFT_BINARY=<path-to-custom-binary>
+----
+
+Additional properties for Godog runner can be specified with `GODOG_OPTS` argument. Following options are available:
+
+- `tags`: when used only scenarios and features containing at least one of selected tags will be executed.
+- `paths`: defines paths to different feature files or folders containing feature files. This can be used to run feature files
+outside of `test/integration/features` folder.
+- `format`:  you can change format of Godog's output, for example you can use `pretty` format instead of native `progress`.
+- `stop-on-failure`: set to true to stop integration tests on failure.
+- `no-colors`: set to true to disable ansi colors of Godog's output.
+- `definitions`: set to true to print all available step definitions.
+
+For example to run integration tests on two specific feature files, using only `@basic` and `@openshift` tags and without ansi colors, 
+following command can be used:
+
+----
+$ make integration GODOG_OPTS="-paths ~/tests/custom.feature,~/my.feature -tags basic,openshift -no-colors true"
+----
+
+Please note that when multiple values are used for options in GODOG_OPTS, then those have to be separated with comma without a whitespace.
+While `-tags basic,openshift` will be parsed properly by make, from `-tags basic, openshift` only `@basic` tag will be used.  
+
 
 [[format-source]]
 === Formatting the source

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -1,3 +1,4 @@
+@basic
 Feature: Basic
   In order to use Minishift
   As a user


### PR DESCRIPTION
To run integration tests on only specified features and scenarios, one can run e.g.: `make integration TEST_TAGS="openshift docker proxy"`.
When TEST_TAGS is not specified, then tests run with native tag: `basic`, which is bind to smoke test in basic.feature file. This means that when we add more time consuming feature files , one will be still able to run quick check with just `make integration`. Or run smoke test and feature close to specific issue he is dealing with. For example `make integration TEST_TAGS="smoke proxy"` when one is dev dealing with proxy stuff.