### PR TITLE
Issue #342 Fix service command

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ To deploy the Node.js sample application from the command-line:
 
 1. Access the app:
 
-        $ curl http://nodejs-ex-myproject.192.168.99.128.nip.io
+        $ minishift openshift service nodejs-ex -n myproject
 
 1. To stop Minishift, use:
 

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -76,7 +76,6 @@ mkdir /tmp/glide
 tar --directory=/tmp/glide -xvf glide-${GLIDE_TAG}-${GLIDE_OS_ARCH}.tar.gz
 export PATH=$PATH:/tmp/glide/${GLIDE_OS_ARCH}
 
-# Test
 make clean test cross fmtcheck prerelease
 # Run integration test with 'kvm' driver
 MINISHIFT_VM_DRIVER=kvm make integration

--- a/cmd/minishift/cmd/openshift/service.go
+++ b/cmd/minishift/cmd/openshift/service.go
@@ -19,39 +19,25 @@ package openshift
 import (
 	"fmt"
 	"os"
-	"strings"
-	"text/template"
 
-	"github.com/docker/machine/libmachine"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
-	"github.com/minishift/minishift/pkg/minikube/cluster"
-	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/openshift"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 )
 
 var (
-	namespace          string
-	serviceURLMode     bool
-	serviceURLFormat   string
-	serviceURLTemplate *template.Template
-	https              bool
+	namespace string
+	urlMode   bool
+	https     bool
 )
 
 // serviceCmd represents the service command
 var serviceCmd = &cobra.Command{
 	Use:   "service [flags] SERVICE",
-	Short: "Prints the URL for the specified service to the console.",
-	Long:  `Prints the URL for the specified service to the console.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		t, err := template.New("serviceURL").Parse(serviceURLFormat)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "The URL format specified in the --format option is not valid: \n\n", err)
-			atexit.Exit(1)
-		}
-		serviceURLTemplate = t
-	},
+	Short: "Opens the URL for the specified service in the browser or prints it to the console",
+	Long:  `Opens the URL for the specified service and namespace in the browser or prints it to the console. If no namespace is provided, 'default' is assumed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 || len(args) > 1 {
 			fmt.Fprintln(os.Stderr, "You must specify the name of the service.")
@@ -60,22 +46,13 @@ var serviceCmd = &cobra.Command{
 
 		service := args[0]
 
-		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
-		defer api.Close()
-
-		url, err := cluster.GetServiceURL(api, namespace, service, serviceURLTemplate)
+		url, err := openshift.GetServiceURL(service, namespace, https)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			if _, ok := err.(cluster.MissingNodePortError); !ok {
-				fmt.Fprintln(os.Stderr, "Verify that Minishift is running and that the correct namespace is specified in the -n option.")
-			}
 			atexit.Exit(1)
 		}
 
-		if https {
-			url = strings.Replace(url, "http", "https", 1)
-		}
-		if serviceURLMode {
+		if urlMode {
 			fmt.Fprintln(os.Stdout, url)
 		} else {
 			fmt.Fprintln(os.Stdout, "Opening the service "+namespace+"/"+service+" in the default browser...")
@@ -86,8 +63,7 @@ var serviceCmd = &cobra.Command{
 
 func init() {
 	serviceCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "The namespace of the service.")
-	serviceCmd.Flags().BoolVar(&serviceURLMode, "url", false, "Access the service in the command-line console instead of the default browser.")
-	serviceCmd.PersistentFlags().StringVar(&serviceURLFormat, "format", "http://{{.IP}}:{{.Port}}", "The URL format of the service.")
+	serviceCmd.Flags().BoolVar(&urlMode, "url", false, "Access the service in the command-line console instead of the default browser.")
 	serviceCmd.Flags().BoolVar(&https, "https", false, "Access the service with HTTPS instead of HTTP.")
 	OpenShiftConfigCmd.AddCommand(serviceCmd)
 }

--- a/cmd/minishift/cmd/openshift/service_list.go
+++ b/cmd/minishift/cmd/openshift/service_list.go
@@ -18,16 +18,12 @@ package openshift
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/docker/machine/libmachine"
+	"github.com/minishift/minishift/pkg/minishift/openshift"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"k8s.io/kubernetes/pkg/api/v1"
-
-	"github.com/minishift/minishift/pkg/minikube/cluster"
-	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"os"
 )
 
 var serviceListNamespace string
@@ -38,18 +34,15 @@ var serviceListCmd = &cobra.Command{
 	Short: "Gets the URLs of the services in your local cluster.",
 	Long:  `Gets the URLs of the services in your local cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
-		defer api.Close()
-		serviceURLs, err := cluster.GetServiceURLs(api, serviceListNamespace, serviceURLTemplate)
+		urls, err := openshift.GetServiceURLs(serviceListNamespace)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			fmt.Fprintln(os.Stderr, "Check that Minishift is running and that the correct namespace is specified in the -n option if it is required.")
 			atexit.Exit(1)
 		}
 
 		var data [][]string
-		for _, serviceURL := range serviceURLs {
-			data = append(data, []string{serviceURL.Namespace, serviceURL.Name, serviceURL.URL})
+		for _, url := range urls {
+			data = append(data, []string{url.Namespace, url.Name, url.URL})
 		}
 
 		table := tablewriter.NewWriter(os.Stdout)
@@ -62,6 +55,6 @@ var serviceListCmd = &cobra.Command{
 }
 
 func init() {
-	serviceListCmd.Flags().StringVarP(&serviceListNamespace, "namespace", "n", v1.NamespaceAll, "The namespace of the services.")
+	serviceListCmd.Flags().StringVarP(&serviceListNamespace, "namespace", "n", "", "The namespace of the services.")
 	serviceCmd.AddCommand(serviceListCmd)
 }

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -27,7 +26,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/docker/machine/drivers/virtualbox"
@@ -42,9 +40,6 @@ import (
 	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
 	"github.com/minishift/minishift/pkg/util"
 	pb "gopkg.in/cheggaaa/pb.v1"
-	kubeapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 )
 
 var (
@@ -54,10 +49,6 @@ var (
 
 const (
 	fileScheme = "file"
-
-	serviceAPIAnnotationsPrefix = "api.service.kubernetes.io/"
-	serviceAPIAnnotationScheme  = serviceAPIAnnotationsPrefix + "scheme"
-	serviceAPIAnnotationPath    = serviceAPIAnnotationsPrefix + "path"
 )
 
 //This init function is used to set the logtostderr variable to false so that INFO level log info does not clutter the CLI
@@ -455,172 +446,4 @@ func GetHostIP(api libmachine.API) (string, error) {
 		return "", err
 	}
 	return ip, nil
-}
-
-type ipPort struct {
-	IP   string
-	Port int
-}
-
-func GetServiceURL(api libmachine.API, namespace, service string, t *template.Template) (string, error) {
-	host, err := CheckIfApiExistsAndLoad(api)
-	if err != nil {
-		return "", err
-	}
-
-	ip, err := host.Driver.GetIP()
-	if err != nil {
-		return "", err
-	}
-
-	client, err := getKubernetesClient()
-	if err != nil {
-		return "", err
-	}
-
-	return getServiceURLWithClient(client, ip, namespace, service, t)
-}
-
-func getServiceURLWithClient(client *unversioned.Client, ip, namespace, service string, t *template.Template) (string, error) {
-	port, err := getServicePort(client, namespace, service)
-	if err != nil {
-		return "", err
-	}
-
-	var doc bytes.Buffer
-	err = t.Execute(&doc, ipPort{ip, port})
-	if err != nil {
-		return "", err
-	}
-
-	u, err := url.Parse(doc.String())
-	if err != nil {
-		return "", err
-	}
-
-	annotations, err := getServiceAnnotations(client, namespace, service)
-	if err != nil {
-		return "", err
-	}
-
-	if scheme, ok := annotations[serviceAPIAnnotationScheme]; ok {
-		u.Scheme = scheme
-	}
-	if path, ok := annotations[serviceAPIAnnotationPath]; ok && len(u.Path) == 0 {
-		u.Path = path
-	}
-
-	return u.String(), nil
-}
-
-type serviceGetter interface {
-	Get(name string) (*kubeapi.Service, error)
-	List(kubeapi.ListOptions) (*kubeapi.ServiceList, error)
-}
-
-func getServicePort(client *unversioned.Client, namespace, service string) (int, error) {
-	services := getKubernetesServicesWithNamespace(client, namespace)
-	return getServicePortFromServiceGetter(services, service)
-}
-
-type MissingNodePortError struct {
-	service *kubeapi.Service
-}
-
-func (e MissingNodePortError) Error() string {
-	return fmt.Sprintf("Service %s/%s does not have a node port. To assign a port automatically, the service type must be NodePort or LoadBalancer, but this service is of type %s.", e.service.Namespace, e.service.Name, e.service.Spec.Type)
-}
-
-func getServiceFromServiceGetter(services serviceGetter, service string) (*kubeapi.Service, error) {
-	svc, err := services.Get(service)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting %s service: %s", service, err)
-	}
-	return svc, nil
-}
-
-func getServicePortFromServiceGetter(services serviceGetter, service string) (int, error) {
-	svc, err := getServiceFromServiceGetter(services, service)
-	if err != nil {
-		return 0, err
-	}
-	nodePort := 0
-	if len(svc.Spec.Ports) > 0 {
-		nodePort = int(svc.Spec.Ports[0].NodePort)
-	}
-	if nodePort == 0 {
-		return 0, MissingNodePortError{svc}
-	}
-	return nodePort, nil
-}
-
-func getKubernetesClient() (*unversioned.Client, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	config, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("Error creating kubeConfig: %s", err)
-	}
-	return unversioned.New(config)
-}
-
-func getKubernetesServicesWithNamespace(client *unversioned.Client, namespace string) serviceGetter {
-	return client.Services(namespace)
-}
-
-func getServiceAnnotations(client *unversioned.Client, namespace, service string) (map[string]string, error) {
-	svc, err := getServiceFromServiceGetter(getKubernetesServicesWithNamespace(client, namespace), service)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting %s service: %s", service, err)
-	}
-	return svc.ObjectMeta.Annotations, nil
-}
-
-type ServiceURL struct {
-	Namespace string
-	Name      string
-	URL       string
-}
-
-type ServiceURLs []ServiceURL
-
-func GetServiceURLs(api libmachine.API, namespace string, t *template.Template) (ServiceURLs, error) {
-	host, err := CheckIfApiExistsAndLoad(api)
-	if err != nil {
-		return nil, err
-	}
-
-	ip, err := host.Driver.GetIP()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := getKubernetesClient()
-	if err != nil {
-		return nil, err
-	}
-
-	getter := getKubernetesServicesWithNamespace(client, namespace)
-
-	svcs, err := getter.List(kubeapi.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	var serviceURLs []ServiceURL
-
-	for _, svc := range svcs.Items {
-		url, err := getServiceURLWithClient(client, ip, svc.Namespace, svc.Name, t)
-		if err != nil {
-			if _, ok := err.(MissingNodePortError); ok {
-				serviceURLs = append(serviceURLs, ServiceURL{Namespace: svc.Namespace, Name: svc.Name, URL: "No node port"})
-				continue
-			}
-			return nil, err
-		}
-		serviceURLs = append(serviceURLs, ServiceURL{Namespace: svc.Namespace, Name: svc.Name, URL: url})
-	}
-
-	return serviceURLs, nil
 }

--- a/pkg/minikube/kubeconfig/test_kube_config
+++ b/pkg/minikube/kubeconfig/test_kube_config
@@ -1,0 +1,35 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: test_certificate-authority-data
+    server: https://10.168.99.100:8443
+  name: 10-168-99-100:8443
+contexts:
+- context:
+    cluster: 10-168-99-100:8443
+    user: developer/10-168-99-100:8443
+  name: /10-168-99-100:8443/developer
+- context:
+    cluster: 10-168-99-100:8443
+    namespace: default
+    user: system:admin/10-168-99-100:8443
+  name: default/10-168-99-100:8443/system:admin
+- context:
+    cluster: 10-168-99-100:8443
+    namespace: foo
+    user: developer/10-168-99-100:8443
+  name: foo/10-168-99-100:8443/developer
+- context:
+    cluster: 10-168-99-100:8443
+    namespace: foo
+    user: system:admin/10-168-99-100:8443
+  name: foo/10-168-99-100:8443/system:admin
+current-context: foo/10-168-99-100:8443/developer
+kind: Config
+preferences: {}
+users:
+- name: developer/10-168-99-100:8443
+  user: {}
+- name: system:admin/10-168-99-100:8443
+  user:
+    client-certificate-data: test_client-certificate-data

--- a/pkg/minishift/openshift/service.go
+++ b/pkg/minishift/openshift/service.go
@@ -1,0 +1,172 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"errors"
+	"fmt"
+	instanceState "github.com/minishift/minishift/pkg/minishift/config"
+	"regexp"
+	"strings"
+)
+
+type ServiceURL struct {
+	Namespace string
+	Name      string
+	URL       string
+}
+
+const (
+	URLCustomCol      = "-o=custom-columns=URL:.spec.host"
+	URLsCustomCol     = "-o=custom-columns=NAME:.metadata.name,HOST:.spec.host"
+	ProjectsCustomCol = "-o=custom-columns=NAME:.metadata.name"
+)
+
+// Get the route for service
+func GetServiceURL(service, namespace string, https bool) (string, error) {
+	urlScheme := "http://"
+	if https {
+		urlScheme = "https://"
+	}
+
+	if !isProjectExists(namespace) {
+		return "", errors.New(fmt.Sprintf("Namespace %s doesn't exits", namespace))
+	}
+
+	cmdArgText := fmt.Sprintf("get route/%s -n %s --config=%s %s", service, namespace, systemKubeConfigPath, URLCustomCol)
+	tokens := strings.Split(cmdArgText, " ")
+	cmdName := instanceState.Config.OcPath
+	cmdOut, err := runner.Output(cmdName, tokens...)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("No service defined/found as '%s' in namespace '%s'", service, namespace))
+	}
+
+	url := strings.Split(byteArrayToString(cmdOut), "\n")[1] // second element contain actual URL content
+	return urlScheme + url, nil
+}
+
+// Get the available routes to user
+func GetServiceURLs(serviceListNamespace string) ([]ServiceURL, error) {
+	var serviceURLs []ServiceURL
+
+	if serviceListNamespace != "" && !isProjectExists(serviceListNamespace) {
+		return serviceURLs, errors.New(fmt.Sprintf("Namespace %s doesn't exits", serviceListNamespace))
+	}
+
+	namespaces, err := getValidNamespaces(serviceListNamespace)
+	if err != nil {
+		return serviceURLs, err
+	}
+
+	// iterate over namespaces, get command output, format route in ServiceURL
+	for _, namespace := range namespaces {
+		outputData, err := getServiceURLsOutput(namespace)
+		if err != nil {
+			return serviceURLs, err
+		}
+		if !strings.Contains(outputData, "No resources found") {
+			serviceURLs = filterAndUpdateServiceURLS(outputData, namespace)
+		}
+	}
+	if len(serviceURLs) == 0 {
+		return serviceURLs, errors.New(fmt.Sprintf("No service defined/found in namespace '%s'", serviceListNamespace))
+	}
+
+	return serviceURLs, nil
+}
+
+// Check whether project exists or not
+func isProjectExists(projectName string) bool {
+	projects, err := getProjects()
+	if err != nil {
+		return false
+	}
+
+	for _, name := range projects {
+		if name == projectName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getValidNamespaces(serviceListNamespace string) ([]string, error) {
+	var (
+		namespaces []string
+		err        error
+	)
+
+	// If namespace is default then consider all namespaces user belongs to
+	if serviceListNamespace == "" {
+		namespaces, err = getProjects()
+		if err != nil {
+			return namespaces, errors.New(fmt.Sprintf("Error getting valid namespaces user belongs to", err))
+		}
+	} else {
+		namespaces = append(namespaces, serviceListNamespace)
+	}
+
+	return namespaces, nil
+}
+
+func getServiceURLsOutput(namespace string) (string, error) {
+	cmdArgText := fmt.Sprintf("get route -n %s --config=%s %s", namespace, systemKubeConfigPath, URLsCustomCol)
+	tokens := strings.Split(cmdArgText, " ")
+	cmdName := instanceState.Config.OcPath
+	cmdOut, err := runner.Output(cmdName, tokens...)
+	if err != nil {
+		return "", err
+	}
+
+	return byteArrayToString(cmdOut), nil
+}
+
+func filterAndUpdateServiceURLS(data, namespace string) []ServiceURL {
+	var serviceURLs []ServiceURL
+
+	re_whtsp_inside := regexp.MustCompile(`[\s\p{Zs}]{2,}`)
+	data = re_whtsp_inside.ReplaceAllString(data, " ") // replace all extra whitespaces
+	contents := strings.Split(data, "\n")              // split on new lines
+	contents = emptyFilter(contents[1:])               // remove the header "NAME HOST" and empty elements
+
+	for _, content := range contents {
+		// split content on white space to separate NAME and HOST
+		data := strings.Split(content, " ")
+		serviceURLs = append(serviceURLs, ServiceURL{Namespace: namespace, Name: data[0], URL: "http://" + data[1]})
+	}
+
+	return serviceURLs
+}
+
+// Discard empty elements
+func emptyFilter(data []string) []string {
+	var res []string
+
+	for _, ele := range data {
+		if ele != "" {
+			res = append(res, ele)
+		}
+	}
+
+	return res
+}
+
+// Convert byte array to string
+func byteArrayToString(data []byte) string {
+	return string(data)
+}

--- a/pkg/util/runner.go
+++ b/pkg/util/runner.go
@@ -53,7 +53,7 @@ func (r RealRunner) Output(command string, args ...string) ([]byte, error) {
 		cmdOut []byte
 		err    error
 	)
-	if cmdOut, err = exec.Command(command, args...).Output(); err != nil {
+	if cmdOut, err = exec.Command(command, args...).CombinedOutput(); err != nil {
 		return nil, err
 	}
 	return cmdOut, nil

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -15,9 +15,9 @@ Feature: Basic
      Then stderr should be empty
       And exitcode should equal 0
       And stdout should contain
-     """
-     sudoer
-     """
+      """
+      sudoer
+      """
 
   Scenario: A 'minishift' context is created for 'oc' usage
     After a successful Minishift start the user's current context is 'minishift'
@@ -25,9 +25,9 @@ Feature: Basic
     Then stderr should be empty
      And exitcode should equal 0
      And stdout should contain
-    """
-    minishift
-    """
+     """
+     minishift
+     """
 
   Scenario: User can switch the current 'oc' context and return to 'minishift' context
     Given executing "oc config set-context dummy"
@@ -39,9 +39,9 @@ Feature: Basic
      Then stderr should be empty
       And exitcode should equal 0
       And stdout should contain
-    """
-    minishift
-    """
+      """
+      minishift
+      """
 
   Scenario: User is able to do ssh into Minishift VM
     Given Minishift has state "Running"


### PR DESCRIPTION
Fix #342 

Added implementation for service command along with possible unit and integration tests.

The new changes are based on @hferentschik commente here https://github.com/minishift/minishift/pull/558#issuecomment-287703534.

- `minishift start` is executed and starts the bootstrap
- VM is created
- _cluster up_ provisions OpenShift
- we copy the system:admin entries for using the Minishift OpenShift cluster as system:admin from _~/.kube/config_ to _MINISHIFT_HOME/machines/<machine-name\>_kubeconfig
- all _oc_ commands executed from within Minishift use this internal configuration file (_--config_ flag)
- sudoer permissions are created and any other customisations run 

cc @gbraad @hferentschik 

`service list` is pending and work in progress.
