### PR TITLE
Issue #614 Use the new command to list the OpenShift versions.

### DIFF
--- a/docs/source/using/managing-minishift.adoc
+++ b/docs/source/using/managing-minishift.adoc
@@ -192,7 +192,7 @@ and OpenShift to use the specified proxies.
 NOTE: Using the proxy options requires that you run OpenShift version 1.5.0-alpha.2 or later.
 Use the `openshift-version` option to request a specific version of OpenShift. You can list
 all Minishift-compatible OpenShift versions with
-the link:../command-ref/minishift_get-openshift-versions{outfilesuffix}[`minishift get-openshift-versions`] command.
+the link:../command-ref/minishift_openshift_list-versions{outfilesuffix}[`minishift openshift list-versions`] command.
 
 [[mounted-host-folders]]
 == Mounted host folders


### PR DESCRIPTION
Fix [#614](https://github.com/minishift/minishift/issues/614) 
The command info finally link this page: [minishift_openshift_list-versions](https://minishift.io/docs/minishift_openshift_list-versions.html)