### PR TITLE
Issue #570 Add steps to handle shell special variables

### DIFF
--- a/docs/source/using/troubleshooting.adoc
+++ b/docs/source/using/troubleshooting.adoc
@@ -113,6 +113,15 @@ cause passwords to fail.
 Workaround: When creating and entering passwords, wrap the string with
 single quotes in the following format: `<password>`
 
+NOTE: The characters `", $, ` and \` are still interpreted by the shell,
+even when you wrap the string with single quotes. If your password contain
+these special characters, make sure you escape them using the
+`backslash (\)` character.
+
+----
+Pass$$wd" => 'Pass\$\$d\"'
+----
+
 [[troubleshooting-snapshots]]
 == Snapshots with virsh
 


### PR DESCRIPTION
Around spending around a day time that I came up with for handing the shell specific characters and tested in all 3 platforms (windows/Linux/OSx).