### PR TITLE
Issue #623: Created new install, quickstart, and docker daemon topics

### DIFF
--- a/docs/source/_topic_map.yml
+++ b/docs/source/_topic_map.yml
@@ -10,6 +10,10 @@ Topics:
     Topics:
       - Name: Installing Docker Machine drivers
         File: docker-machine-drivers
+      - Name: Installing Minishift
+        File: installing
+      - Name: Quickstart
+        File: quickstart
   - Name: Using Minishift
     Dir: using
     Topics:
@@ -17,6 +21,8 @@ Topics:
         File: managing-minishift
       - Name: Interacting with Openshift
         File: interacting-with-openshift
+      - Name: Reusing the Docker daemon
+        File: reusing-docker-daemon
       - Name: Troubleshooting Minishift
         File: troubleshooting
   - Name: Developing Minishift

--- a/docs/source/getting-started/index.adoc
+++ b/docs/source/getting-started/index.adoc
@@ -11,3 +11,5 @@ This section contains information about preparing for and installing Minishift,
 quickstart steps, and sample application deployment.
 
 - link:../getting-started/docker-machine-drivers{outfilesuffix}[Installing Docker machine drivers]
+- link:../getting-started/installing{outfilesuffix}[Installing Minishift]
+- link:../getting-started/quickstart{outfilesuffix}[Quickstart]

--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -1,0 +1,128 @@
+[[installing-minishift]]
+= Installing Minishift
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+
+toc::[]
+
+The following section describes how to install Minishift and the required dependencies.
+
+[[install-prerequisites]]
+== Prerequisites
+
+Minishift requires a hypervisor to start the virtual machine containing
+OpenShift. Make sure that the hypervisor of your choice is installed and
+enabled on your system before you install Minishift.
+
+Depending on your host OS, you have the choice of the following
+hypervisors:
+
+Mac OS X::
+- https://github.com/mist64/xhyve[xhyve] (default)
+- https://www.virtualbox.org/wiki/Downloads[VirtualBox]
+- https://www.vmware.com/products/fusion[VMware Fusion]
++
+NOTE: xhyve requires specific installation and configuration steps that are described
+in the link:../getting-started/docker-machine-drivers{outfilesuffix}[Installing Docker machine drivers] section.
+
+GNU/Linux::
+- https://minishift.io/docs/docker-machine-drivers.html#kvm-driver[KVM] (default)
+- https://www.virtualbox.org/wiki/Downloads[VirtualBox]
++
+NOTE: KVM requires specific installation and configuration steps that are described
+in the link:../getting-started/docker-machine-drivers{outfilesuffix}[Installing Docker machine drivers] section.
+
+Windows::
+- https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v[Hyper-V] (default)
++
+NOTE: To enable Hyper-V ensure that, after you
+https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v[install Hyper-V], you also
+https://msdn.microsoft.com/en-us/virtualization/hyperv_on_windows/quick_start/walkthrough_virtual_switch[add a Virtual Switch]
+using the Hyper-V Manager. Make sure that you pair the virtual switch
+with a __network card (wired or wireless) that is connected to the network__.
+
+- https://www.virtualbox.org/wiki/Downloads[VirtualBox]
++
+NOTE: It is recommended to use `Virtualbox 5.1.12` or later on Windows to avoid the issue
+link:../using/troubleshooting{outfilesuffix}#machine-doesnt-exist[Error: getting state for host: machine does not exist].
+
+If you encounter issues related to the hypervisor, see
+the link:../using/troubleshooting{outfilesuffix}[Troubleshooting] section.
+
+[[installing-instructions]]
+== Installing Minishift
+
+[[manual-install]]
+=== Manually
+
+.  Download the archive for your operating system from the https://github.com/minishift/minishift/releases[Minishift releases page]
+and unpack it.
+.  Copy the contents of the directory to your preferred location.
+.  Add the `minishift` binary to your _PATH_ environment variable.
+
+[NOTE]
+====
+- On Windows operating system, due to issue
+https://github.com/minishift/minishift/issues/236[#236], you need to
+execute the minishift binary from the drive containing your `%USERPROFILE%` directory.
+- Automatic update of the Minishift binary and the virtual machine ISO
+is currently disabled. See also issue
+https://github.com/minishift/minishift/issues/204[#204]
+====
+
+[[homebrew-install]]
+=== With Homebrew
+
+[[homebrew-stable-install]]
+==== Stable
+
+On OS X you can also use https://caskroom.github.io[Homebrew Cask] to
+install the stable version of Minishift:
+
+----
+  $ brew cask install minishift
+----
+
+[[homebrew-latest-install]]
+==== Latest Beta
+
+If you want to install the latest beta version of Minishift you will
+need the homebrew-cask versions tap. After you install `homebrew-cask`,
+run the following command:
+
+----
+  $ brew tap caskroom/versions
+----
+
+You can now install the latest beta version of Minishift.
+
+----
+  $ brew cask install minishift-beta
+----
+
+[[uninstall-instructions]]
+== Uninstalling Minishift
+
+.  Delete the Minishift VM and any VM-specific files.
++
+----
+$ minishift delete
+----
++
+This command deletes everything in the
+`MINISHIFT_HOME/.minishift/machines/minishift` directory. Other cached data and
+the https://minishift.io/docs/managing-minishift.html#persistent-configuration[persistent configuration] are not removed.
+
+.  To completely uninstall Minishift, delete everything in the
+`MINISHIFT_HOME` directory (default `~/.minishift`) and `~/.kube`:
++
+----
+$ rm -rf ~/.minishift
+$ rm -rf ~/.kube
+----
+
+.  With your hypervisor management tool, confirm that there are no
+remaining artifacts related to the Minishift VM. For example, if you use
+KVM, you need to run the `virsh` command.

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -1,0 +1,114 @@
+[[quickstart]]
+= Quickstart
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+
+toc::[]
+
+This section contains a brief demo of Minishift and of the provisioned
+OpenShift cluster. For details on the usage of Minishift, see
+the link:../using/managing-minishift{outfilesuffix}[Managing Minishift] section.
+
+The interaction with OpenShift is with the command line tool _oc_ which
+is copied to your host. For more information on how Minishift can assist
+you in interacting with and configuring your local OpenShift instance
+see the link:../using/interacting-with-openshift{outfilesuffix}[Interacting with OpenShift] section.
+
+For more information about the OpenShift cluster architecture, see
+https://docs.openshift.org/latest/architecture/index.html[Architecture Overview] in the OpenShift documentation.
+
+The following steps describe how to get started with Minishift on a
+GNU/Linux operating system with the KVM hypervisor driver.
+
+[[starting-minishift]]
+== Starting Minishift
+
+.  Run the `minishift start` command.
++
+----
+$ minishift start
+Starting local OpenShift cluster using 'kvm' hypervisor...
+...
+   OpenShift server started.
+   The server is accessible via web console at:
+       https://192.168.99.128:8443
+
+   You are logged in as:
+       User:     developer
+       Password: developer
+
+   To login as administrator:
+       oc login -u system:admin
+----
++
+[NOTE]
+====
+- The IP is dynamically generated for each OpenShift cluster. To check
+the IP, run the `minishift ip` command.
+- By default, Minishift uses the driver most relevant to the host OS. To
+use a different driver, set the `--vm-driver` flag in `minishift start`.
+For example, to use VirtualBox instead of KVM on GNU/Linux operating
+systems, run `minishift start --vm-driver=virtualbox`. For more
+information about `minishift start` options, see the
+https://minishift.io/docs/minishift_start.md[minishift start command
+reference].
+====
+
+.  Add the `oc` binary to the _PATH_ environment variable.
++
+----
+$ export PATH=$PATH:~/.minishift/cache/oc/v1.4.1
+----
++
+NOTE: Depending on the operating system and the `oc` version, you
+might need to use a different command to add `oc` to the _PATH_
+environment variable. To verify the `oc` version, check the contents of
+the `~/.minishift/cache/oc` directory.
+
+For more information about interacting with OpenShift with the
+command-line interface and the Web console, see the
+link:../using/interacting-with-openshift{outfilesuffix}[Interacting with OpenShift] section.
+
+[[deploy-sample-app]]
+== Deploying a sample application
+
+OpenShift provides various sample applications, such as templates,
+builder applications, and quickstarts. The following steps describe how
+to deploy a sample Node.js application from the command-line.
+
+.  Create a Node.js example app.
++
+----
+$ oc new-app https://github.com/openshift/nodejs-ex -l name=myapp
+----
+
+.  Track the build log until the app is built and deployed.
++
+----
+$ oc logs -f bc/nodejs-ex
+----
+
+.  Expose a route to the service.
++
+----
+$ oc expose svc/nodejs-ex
+----
+
+.  Access the application.
++
+----
+$ minishift openshift service nodejs-ex -n myproject
+----
+
+.  To stop Minishift, use the following command:
++
+----
+$ minishift stop
+Stopping local OpenShift cluster...
+Stopping "minishift"...
+----
+
+For more information about creating applications in OpenShift, see
+https://docs.openshift.org/latest/dev_guide/application_lifecycle/new_app.html[Creating New Applications] in the OpenShift documentation.

--- a/docs/source/using/index.adoc
+++ b/docs/source/using/index.adoc
@@ -12,4 +12,5 @@ troubleshooting common tasks to interact with your OpenShift cluster.
 
 - link:../using/managing-minishift{outfilesuffix}[Managing Minishift]
 - link:../using/interacting-with-openshift{outfilesuffix}[Interacting with OpenShift]
+- link:../using/reusing-docker-daemon{outfilesuffix}[Reusing the Docker daemon]
 - link:../using/troubleshooting{outfilesuffix}[Troubleshooting Minishift]

--- a/docs/source/using/reusing-docker-daemon.adoc
+++ b/docs/source/using/reusing-docker-daemon.adoc
@@ -1,0 +1,38 @@
+[[reusing-docker-daemon]]
+= Reusing the Docker daemon
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+
+toc::[]
+
+When running OpenShift in a single VM, it is recommended to reuse the
+Docker daemon that Minishift uses for pure Docker use-cases as well. By
+using the same docker daemon as Minishift, you can speed up your local
+experiments.
+
+.  Make sure that you have the Docker client binary installed on your
+machine. For information about specific binary installations for your
+operating system, see the
+https://docs.docker.com/engine/installation/[Docker installation] site.
+
+.  Start Minishift with the link:../command-ref/minishift_start{outfilesuffix}[`minishift start`] command.
+
+.  Use the link:../command-ref/minishift_docker-env{outfilesuffix}[`minishift docker-env`] command
+to export the environment variables that are required to reuse the daemon.
++
+----
+eval $(minishift docker-env)
+----
++
+You should now be able to use _docker_ on the command line of your host,
+talking to the docker daemon inside the Minishift VM.
+
+.  To test the connection, run the following command:
++
+----
+docker ps
+----
++
+If successful, the shell will print a list of running containers.


### PR DESCRIPTION
Fixes issue #623 

This PR includes 3 new topic files for install, quickstart, and docker daemon, plus updated topic metadata file with TOC definitions for these files. The information is originally from the readme.

Out of scope: README version of this content will not be removed for now, until we get the docs published. Then will handle as a part of issue #533.