### PR TITLE
Issue #511 Add a version command as openshift subcommand

### DIFF
--- a/cmd/minishift/cmd/openshift/version.go
+++ b/cmd/minishift/cmd/openshift/version.go
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/golang/glog"
+	"github.com/minishift/minishift/pkg/minikube/cluster"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/docker"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// version command represent current running openshift version and available one.
+var versionCmd = &cobra.Command{
+	Use:   "version [command] [flags]",
+	Short: "Print the current running openshift version to stdout",
+	Long:  `Print the current running openshift version to stdout`,
+	Run:   runVersion,
+}
+
+func runVersion(cmd *cobra.Command, args []string) {
+	api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
+	defer api.Close()
+
+	host, err := cluster.CheckIfApiExistsAndLoad(api)
+	if err != nil {
+		fmt.Println(nonExistentMachineError)
+		atexit.Exit(1)
+	}
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+	dockerCommander := docker.NewVmDockerCommander(sshCommander)
+	version, err := dockerCommander.Exec(" ", "origin", "openshift", "version")
+	if err != nil {
+		glog.Errorln("Error restarting OpenShift cluster: ", err)
+		atexit.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, version)
+}
+
+func init() {
+	OpenShiftConfigCmd.AddCommand(versionCmd)
+}

--- a/cmd/minishift/cmd/openshift/version_test.go
+++ b/cmd/minishift/cmd/openshift/version_test.go
@@ -17,22 +17,15 @@ limitations under the License.
 package openshift
 
 import (
-	openshiftVersions "github.com/minishift/minishift/pkg/minishift/openshift/version"
-	"github.com/minishift/minishift/pkg/version"
-	"github.com/spf13/cobra"
-	"os"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"testing"
 )
 
-// getVersionsCmd represents the ip command
-var getVersionsCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Gets the list of OpenShift versions available for Minishift.",
-	Long:  `Gets the list of OpenShift versions available for Minishift.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		openshiftVersions.PrintUpStreamVersions(os.Stdout, version.GetOpenShiftVersion())
-	},
-}
+func TestVersionCommandNeedsExistingVm(t *testing.T) {
+	setup(t)
+	defer tearDown()
 
-func init() {
-	versionCmd.AddCommand(getVersionsCmd)
+	atexit.RegisterExitHandler(createExitHandlerFunc(t, 1, nonExistentMachineError))
+
+	runVersion(nil, nil)
 }

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -421,9 +421,10 @@ func setDefaultRoutingPrefix(ip string) {
 
 func validateOpenshiftVersion() {
 	if viper.IsSet(openshiftVersion) {
-		if !minishiftUtil.ValidateOpenshiftMinVersion(viper.GetString(openshiftVersion)) {
-			fmt.Printf("Minishift does not support Openshift version %s. "+
-				"You need to use a version >= 1.3.1.", viper.GetString(openshiftVersion))
+		if !minishiftUtil.ValidateOpenshiftMinVersion(viper.GetString(openshiftVersion), version.GetOpenShiftVersion()) {
+			fmt.Printf("Minishift does not support Openshift version %s ."+
+				"You need to use a version >=%s\n", viper.GetString(openshiftVersion),
+				version.GetOpenShiftVersion())
 			atexit.Exit(1)
 		}
 	}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -38,7 +38,6 @@ const MiniShiftEnvPrefix = "MINISHIFT"
 // MiniShiftHomeEnv is the environment variable used to change the Minishift home directory
 const MiniShiftHomeEnv = "MINISHIFT_HOME"
 
-const MinSupportedOpenshiftVersion = ">=1.3.1"
 const VersionPrefix = "v"
 
 const (

--- a/pkg/minishift/openshift/version/openshift_versions.go
+++ b/pkg/minishift/openshift/version/openshift_versions.go
@@ -17,48 +17,113 @@ limitations under the License.
 package version
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/minishift/minishift/pkg/util"
 	"io"
-
-	"github.com/google/go-github/github"
-	"github.com/minishift/minishift/pkg/minishift/util"
-	githubutil "github.com/minishift/minishift/pkg/util/github"
-	"github.com/pkg/errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
 )
 
-const githubOwner = "openshift"
-const githubRepo = "origin"
-
-func PrintOpenShiftVersionsFromGitHub(output io.Writer) {
-	PrintOpenShiftVersions(output)
+type ImageTags struct {
+	Count    int         `json:"count"`
+	Next     string      `json:"next"`
+	Previous interface{} `json:"previous"`
+	Results  []Results   `json:"results"`
 }
 
-func PrintOpenShiftVersions(output io.Writer) {
-	versions, err := getVersions()
+type Results struct {
+	Name        string      `json:"name"`
+	FullSize    int         `json:"full_size"`
+	Images      []ImageInfo `json:"images"`
+	ID          int         `json:"id"`
+	Repository  int         `json:"repository"`
+	Creator     int         `json:"creator"`
+	LastUpdater int         `json:"last_updater"`
+	LastUpdated time.Time   `json:"last_updated"`
+	ImageID     interface{} `json:"image_id"`
+	V2          bool        `json:"v2"`
+}
+
+type ImageInfo struct {
+	Size         int         `json:"size"`
+	Architecture string      `json:"architecture"`
+	Variant      interface{} `json:"variant"`
+	Features     interface{} `json:"features"`
+	Os           interface{} `json:"os"`
+	OsVersion    interface{} `json:"os_version"`
+	OsFeatures   interface{} `json:"os_features"`
+}
+
+func PrintDownStreamVersions(output io.Writer, minSupportedVersion string) {
+	resp, err := getResponseBody("https://registry.access.redhat.com/v1/repositories/openshift3/ose/tags")
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println("Error Occured", err)
 		return
 	}
-	fmt.Fprint(output, "The following OpenShift versions are available: \n")
-
-	for _, version := range versions {
-		if util.ValidateOpenshiftMinVersion(*version.TagName) {
-			fmt.Fprintf(output, "\t- %s\n", *version.TagName)
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	var data map[string]string
+	err = decoder.Decode(&data)
+	if err != nil {
+		fmt.Printf("%T\n%s\n%#v\n", err, err, err)
+		return
+	}
+	fmt.Fprintf(output, "The following OpenShift versions are available: \n")
+	var tagsList []string
+	for version := range data {
+		if util.VersionOrdinal(version) >= util.VersionOrdinal(minSupportedVersion) {
+			if strings.Contains(version, "latest") {
+				continue
+			}
+			if strings.Contains(version, "-") {
+				continue
+			}
+			tagsList = append(tagsList, version)
 		}
+	}
+	sort.Strings(tagsList)
+	for _, tag := range tagsList {
+		fmt.Fprintf(output, "\t- %s\n", tag)
 	}
 }
 
-func getVersions() ([]*github.RepositoryRelease, error) {
-	client := githubutil.Client()
+func PrintUpStreamVersions(output io.Writer, minSupportedVersion string) {
+	resp, err := getResponseBody("https://registry.hub.docker.com/v2/repositories/openshift/origin/tags/")
+	if err != nil {
+		fmt.Fprintf(output, "Error Occured %s", err)
+		return
+	}
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	var data ImageTags
+	err = decoder.Decode(&data)
+	if err != nil {
+		fmt.Printf("%T\n%s\n%#v\n", err, err, err)
+		return
+	}
+	fmt.Fprintf(output, "The following OpenShift versions are available: \n")
+	var tagsList []string
+	for _, imageinfo := range data.Results {
+		if strings.Contains(imageinfo.Name, "latest") {
+			continue
+		}
+		if util.VersionOrdinal(imageinfo.Name) >= util.VersionOrdinal(minSupportedVersion) {
+			tagsList = append(tagsList, imageinfo.Name)
+		}
+	}
+	sort.Strings(tagsList)
+	for _, tag := range tagsList {
+		fmt.Fprintf(output, "\t- %s\n", tag)
+	}
+}
 
-	releases, resp, err := client.Repositories.ListReleases(githubOwner, githubRepo, nil)
+func getResponseBody(url string) (resp *http.Response, err error) {
+	resp, err = http.Get(url)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if len(releases) == 0 {
-		return nil, errors.New("There are no OpenShift versions available.")
-	}
-	return releases, nil
+	return resp, nil
 }

--- a/pkg/minishift/util/openshift.go
+++ b/pkg/minishift/util/openshift.go
@@ -17,14 +17,20 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"github.com/blang/semver"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"strings"
 )
 
-func ValidateOpenshiftMinVersion(ver string) bool {
+func ValidateOpenshiftMinVersion(ver string, minVersion string) bool {
 	v, _ := semver.Parse(strings.TrimPrefix(ver, constants.VersionPrefix))
-	r, _ := semver.ParseRange(constants.MinSupportedOpenshiftVersion)
+	minSupportedVersion := strings.TrimPrefix(minVersion, constants.VersionPrefix)
+	r, err := semver.ParseRange(fmt.Sprintf(">=%s", minSupportedVersion))
+	if err != nil {
+		fmt.Println("Not able to parse version info", err)
+		return false
+	}
 	if r(v) {
 		return true
 	}

--- a/pkg/minishift/util/openshift_test.go
+++ b/pkg/minishift/util/openshift_test.go
@@ -23,16 +23,17 @@ func TestValidateOpenshiftMinVersion(t *testing.T) {
 		"v1.1.0":         false,
 		"v1.2.2":         false,
 		"v1.2.3-beta":    false,
-		"v1.3.1":         true,
-		"v1.3.5-alpha":   true,
+		"v1.3.1":         false,
+		"v1.3.5-alpha":   false,
 		"v1.4.1":         true,
 		"v1.5.0-alpha.0": true,
 		"v1.5.1-beta.0":  true,
 		"v1.6.0":         true,
 	}
+	minVer := "v1.4.1"
 	for ver, val := range verList {
-		if ValidateOpenshiftMinVersion(ver) != val {
-			t.Fatalf("Expected '%t' Got '%t' for %s", val, ValidateOpenshiftMinVersion(ver), ver)
+		if ValidateOpenshiftMinVersion(ver, minVer) != val {
+			t.Fatalf("Expected '%t' Got '%t' for %s", val, ValidateOpenshiftMinVersion(ver, minVer), ver)
 		}
 	}
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -106,3 +106,36 @@ func (m MultiError) ToError() error {
 	}
 	return fmt.Errorf(strings.Join(errStrings, "\n"))
 }
+
+func VersionOrdinal(version string) string {
+	// ISO/IEC 14651:2011
+	// https://www.iso.org/standard/57976.html
+	// This method is applicable for 255 characters string
+	// to determine their collating order in a sorted list.
+	// It create a collating sorted list and return the string.
+	const maxByte = 1<<8 - 1
+	vo := make([]byte, 0, len(version)+8)
+	j := -1
+	for i := 0; i < len(version); i++ {
+		b := version[i]
+		if '0' > b || b > '9' {
+			vo = append(vo, b)
+			j = -1
+			continue
+		}
+		if j == -1 {
+			vo = append(vo, 0x00)
+			j = len(vo) - 1
+		}
+		if vo[j] == 1 && vo[j+1] == '0' {
+			vo[j+1] = b
+			continue
+		}
+		if vo[j]+1 > maxByte {
+			panic("VersionOrdinal: invalid version")
+		}
+		vo = append(vo, b)
+		vo[j]++
+	}
+	return string(vo)
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -94,3 +94,9 @@ Error 2`
 		t.Fatalf("Unexpected error: %s", err)
 	}
 }
+
+func TestVersionOrdinal(t *testing.T) {
+	if VersionOrdinal("v3.4.1.10") < VersionOrdinal("v3.4.1.2") {
+		t.Fatalf("Expected 'false' Got 'true'")
+	}
+}


### PR DESCRIPTION
This patch will enable what we wanted to achieve with `version` and `version list`.

```
17:48 $ ./minishift start --openshift-version v1.5.0-alpha-0
Minishift does not support Openshift version v1.5.0-alpha-0 You need to use a version >=v1.5.0-rc.0

17:52 $ ./minishift openshift version
openshift v1.5.0-rc.0+49a4a7a
kubernetes v1.5.2+43a9be4
etcd 3.1.0

17:54 $ ./minishift openshift version list
The following OpenShift versions are available:
	- v3.6.0-alpha.0
	- v1.5.0-rc.0
```