### PR TITLE
Issue #629 Changing the default OpenShift Origin version as 1.5.0-rc.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 # Various versions - Minishift, default OpenShift, default B2D ISO
 MINISHIFT_VERSION = 1.0.0-beta.5
-OPENSHIFT_VERSION = v1.4.1
+OPENSHIFT_VERSION = v1.5.0-rc.0
 ISO_VERSION = v1.0.2
 
 # Go and compliation related variables

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -423,7 +423,7 @@ func validateOpenshiftVersion() {
 	if viper.IsSet(openshiftVersion) {
 		if !minishiftUtil.ValidateOpenshiftMinVersion(viper.GetString(openshiftVersion)) {
 			fmt.Printf("Minishift does not support Openshift version %s. "+
-				"You need to use a version >= 1.3.1.", viper.GetString(openshiftVersion))
+				"You need to use a version >= v1.5.0-rc.0.", viper.GetString(openshiftVersion))
 			atexit.Exit(1)
 		}
 	}

--- a/cmd/minishift/cmd/start_test.go
+++ b/cmd/minishift/cmd/start_test.go
@@ -117,7 +117,7 @@ func (r *RecordingRunner) Output(command string, args ...string) ([]byte, error)
 var testDir string
 var testRunner *RecordingRunner
 var testMachineConfig = cluster.MachineConfig{
-	OpenShiftVersion: "v1.3.1",
+	OpenShiftVersion: "v1.5.0-rc.0",
 }
 var testIp = "192.168.99.42"
 

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -38,7 +38,7 @@ const MiniShiftEnvPrefix = "MINISHIFT"
 // MiniShiftHomeEnv is the environment variable used to change the Minishift home directory
 const MiniShiftHomeEnv = "MINISHIFT_HOME"
 
-const MinSupportedOpenshiftVersion = ">=1.3.1"
+const MinSupportedOpenshiftVersion = ">=1.5.0-rc.0"
 const VersionPrefix = "v"
 
 const (

--- a/pkg/minishift/cache/oc_caching_test.go
+++ b/pkg/minishift/cache/oc_caching_test.go
@@ -34,7 +34,7 @@ func TestIsCached(t *testing.T) {
 	setUp(t)
 	defer os.RemoveAll(testDir)
 
-	ocDir := filepath.Join(testDir, "cache", "oc", "v1.3.1")
+	ocDir := filepath.Join(testDir, "cache", "oc", "v1.5.0-rc.0")
 	os.MkdirAll(ocDir, os.ModePerm)
 
 	if testOc.isCached() != false {
@@ -61,7 +61,7 @@ func TestCacheOc(t *testing.T) {
 	client.Transport = minitesting.NewMockRoundTripper()
 	defer minitesting.ResetDefaultRoundTripper()
 
-	ocDir := filepath.Join(testDir, "cache", "oc", "v1.3.1")
+	ocDir := filepath.Join(testDir, "cache", "oc", "v1.5.0-rc.0")
 	os.MkdirAll(ocDir, os.ModePerm)
 
 	err := testOc.cacheOc()
@@ -76,7 +76,7 @@ func setUp(t *testing.T) {
 	if err != nil {
 		t.Error()
 	}
-	testOc = Oc{"v1.3.1", filepath.Join(testDir, "cache")}
+	testOc = Oc{"v1.5.0-rc.0", filepath.Join(testDir, "cache")}
 }
 
 func EnsureGitHubApiAccessTokenSet(t *testing.T) {

--- a/pkg/minishift/util/openshift_test.go
+++ b/pkg/minishift/util/openshift_test.go
@@ -23,11 +23,13 @@ func TestValidateOpenshiftMinVersion(t *testing.T) {
 		"v1.1.0":         false,
 		"v1.2.2":         false,
 		"v1.2.3-beta":    false,
-		"v1.3.1":         true,
-		"v1.3.5-alpha":   true,
-		"v1.4.1":         true,
-		"v1.5.0-alpha.0": true,
-		"v1.5.1-beta.0":  true,
+		"v1.3.1":         false,
+		"v1.3.5-alpha":   false,
+		"v1.4.1":         false,
+		"v1.5.0-alpha.0": false,
+		"v1.5.1-beta.0":  false,
+		"v1.5.0-rc.0":    true,
+		"v1.5.0":         true,
 		"v1.6.0":         true,
 	}
 	for ver, val := range verList {


### PR DESCRIPTION
Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>