### PR TITLE
Issue 662: Added H2 titles to fix spacing problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ with the KVM hypervisor driver.
 
   - The IP is dynamically generated for each OpenShift cluster. To check the IP, run the `minishift ip` command.
   - By default Minishift uses the driver most relevant to the host OS. To use a different driver, set the `--vm-driver` flag in `minishift start`. For example, to use VirtualBox instead of KVM on GNU/Linux operating systems, run `minishift start --vm-driver=virtualbox`. For more information about `minishift start` options,
-  see the [minishift start command reference](https://minishift.io/docs/minishift_start.md).
+  see the [minishift start command reference](https://minishift.io/docs/minishift_start.html).
 
 1. Add the `oc` binary to the _PATH_ environment variable.
 

--- a/docs/source/developing/developing.adoc
+++ b/docs/source/developing/developing.adoc
@@ -7,6 +7,9 @@
 
 toc::[]
 
+[[developing-overview]]
+== Overview
+
 The following sections describe how to build and test Minishift.
 
 [[develop-prerequisites]]

--- a/docs/source/developing/releasing.adoc
+++ b/docs/source/developing/releasing.adoc
@@ -7,6 +7,9 @@
 
 toc::[]
 
+[[releasing-overview]]
+== Overview
+
 The following sections describe how to release Minishift.
 
 [[release-prereqs]]

--- a/docs/source/developing/writing-docs.adoc
+++ b/docs/source/developing/writing-docs.adoc
@@ -7,6 +7,9 @@
 
 toc::[]
 
+[[writing-docs-overview]]
+== Overview
+
 This section contains information about contributing to the Minishift documentation.
 
 [[section-building-minishift-docs]]
@@ -96,4 +99,3 @@ $ rake build
 ----
 
 If the build completes successfully, the site is available under _preview/openshift-origin/latest/welcome/index.html_.
-

--- a/docs/source/getting-started/docker-machine-drivers.adoc
+++ b/docs/source/getting-started/docker-machine-drivers.adoc
@@ -7,6 +7,9 @@
 
 toc::[]
 
+[[docker-machine-drivers-overview]]
+== Overview
+
 Minishift uses Docker Machine and its driver plugin architecture to
 provide a consistent way to manage the OpenShift VM. Minishift embeds
 VirtualBox and VMware Fusion drivers so no additional steps are required to use them.

--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -7,6 +7,9 @@
 
 toc::[]
 
+[[installing-overview]]
+== Overview
+
 The following section describes how to install Minishift and the required dependencies.
 
 [[install-prerequisites]]

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -11,6 +11,9 @@ include::minishift/variables.adoc[]
 
 toc::[]
 
+[[quickstart-overview]]
+== Overview
+
 This section contains a brief demo of Minishift and of the provisioned
 OpenShift cluster. For details on the usage of Minishift, see
 the link:../using/managing-minishift{outfilesuffix}[Managing Minishift] section.

--- a/docs/source/using/interacting-with-openshift.adoc
+++ b/docs/source/using/interacting-with-openshift.adoc
@@ -12,10 +12,12 @@ include::minishift/variables.adoc[]
 
 toc::[]
 
-Minishift creates a virtual machine (VM) and provisions a local,
-single-node OpenShift cluster in this VM. The following sections
-describe how Minishift can assist you in interacting with and
-configuring your local OpenShift instance.
+[[interacting-openshift-overview]]
+== Overview
+
+Minishift creates a virtual machine (VM) and provisions a local, single-node OpenShift
+cluster in this VM. The following sections describe how Minishift can assist you in
+interacting with and configuring your local OpenShift instance.
 
 For details about managing the Minishift VM, see the link:../using/managing-minishift{outfilesuffix}[Managing Minishift] section.
 

--- a/docs/source/using/managing-minishift.adoc
+++ b/docs/source/using/managing-minishift.adoc
@@ -7,8 +7,8 @@
 
 toc::[]
 
-[[managing-minishift-intro]]
-== Managing Minishift
+[[managing-minishift-overview]]
+== Overview
 
 When you use Minishift, you interact with two components:
 

--- a/docs/source/using/troubleshooting.adoc
+++ b/docs/source/using/troubleshooting.adoc
@@ -7,6 +7,9 @@
 
 toc::[]
 
+[[troubleshooting-overview]]
+== Overview
+
 This section contains solutions to common problems that you might
 encounter while using Minishift.
 


### PR DESCRIPTION
Fixes issue #662 

This PR adds "Overview" titles in the beginning of each topic so that there won't be spacing issues when the published docs are parsed. Following @budhrg reporting in a different issue (can't find it now but there are screenshots of this somewhere :) 