### PR TITLE
Issue #649 Avoid using glog.Errorln for user facing commands

### DIFF
--- a/cmd/minishift/cmd/addon/addon_disable.go
+++ b/cmd/minishift/cmd/addon/addon_disable.go
@@ -41,8 +41,7 @@ func init() {
 
 func runDisableAddon(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		fmt.Println(emptyDisableError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, emptyDisableError)
 	}
 
 	addonName := args[0]
@@ -55,8 +54,7 @@ func runDisableAddon(cmd *cobra.Command, args []string) {
 
 	addOnConfig, err := addOnManager.Disable(addonName)
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Unable to disable plugin %s: %s", addonName, err.Error()))
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to disable plugin %s: %s", addonName, err.Error()))
 	}
 
 	addOnConfigMap := getAddOnConfiguration()

--- a/cmd/minishift/cmd/addon/addon_disable_test.go
+++ b/cmd/minishift/cmd/addon/addon_disable_test.go
@@ -19,20 +19,21 @@ package addon
 import (
 	"bytes"
 	"fmt"
-	"github.com/minishift/minishift/pkg/testing/cli"
-	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/minishift/minishift/pkg/testing/cli"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
 )
 
 func Test_addon_name_must_be_specified_for_disable_command(t *testing.T) {
 	tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)
-	origStdout, stdOutWriter, stdOutReader := cli.CaptureStdOut(t)
-	defer cli.TearDown(tmpMinishiftHomeDir, origStdout)
+	origStdout, origStderr, streamWriter, streamReader := cli.CaptureStreamOut(t, 1)
+	defer cli.TearDown(tmpMinishiftHomeDir, origStdout, origStderr)
 
-	atexit.RegisterExitHandler(cli.CreateExitHandlerFunc(t, stdOutWriter, stdOutReader, 1, emptyDisableError))
+	atexit.RegisterExitHandler(cli.CreateExitHandlerFunc(t, streamWriter, streamReader, 1, emptyDisableError))
 
 	runDisableAddon(nil, nil)
 }
@@ -41,15 +42,15 @@ func Test_unkown_name_for_disable_command_returns_error(t *testing.T) {
 	tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)
 	os.Mkdir(filepath.Join(tmpMinishiftHomeDir, "addons"), 0777)
 
-	origStdout, stdOutWriter, stdOutReader := cli.CaptureStdOut(t)
-	defer cli.TearDown(tmpMinishiftHomeDir, origStdout)
+	origStdout, origStderr, streamWriter, streamReader := cli.CaptureStreamOut(t, 0)
+	defer cli.TearDown(tmpMinishiftHomeDir, origStdout, origStderr)
 
 	testAddOnName := "foo"
 	runDisableAddon(nil, []string{testAddOnName})
 
-	stdOutWriter.Close()
+	streamWriter.Close()
 	var buffer bytes.Buffer
-	io.Copy(&buffer, stdOutReader)
+	io.Copy(&buffer, streamReader)
 
 	expectedOut := fmt.Sprintf(noAddOnToDisableMessage+"\n", testAddOnName)
 	if expectedOut != buffer.String() {

--- a/cmd/minishift/cmd/addon/addon_enable.go
+++ b/cmd/minishift/cmd/addon/addon_enable.go
@@ -18,6 +18,7 @@ package addon
 
 import (
 	"fmt"
+
 	"github.com/minishift/minishift/pkg/minishift/addon/manager"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
@@ -47,8 +48,7 @@ func init() {
 
 func runEnableAddon(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		fmt.Println(emptyEnableError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, emptyEnableError)
 	}
 
 	addonName := args[0]
@@ -65,8 +65,7 @@ func runEnableAddon(cmd *cobra.Command, args []string) {
 func enableAddon(addOnManager *manager.AddOnManager, addonName string, priority int) {
 	addOnConfig, err := addOnManager.Enable(addonName, priority)
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Unable to enable plugin %s: %s", addonName, err.Error()))
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to enable plugin %s: %s", addonName, err.Error()))
 	}
 
 	addOnConfigMap := getAddOnConfiguration()

--- a/cmd/minishift/cmd/addon/addon_enable_test.go
+++ b/cmd/minishift/cmd/addon/addon_enable_test.go
@@ -19,20 +19,21 @@ package addon
 import (
 	"bytes"
 	"fmt"
-	"github.com/minishift/minishift/pkg/testing/cli"
-	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/minishift/minishift/pkg/testing/cli"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
 )
 
 func Test_addon_name_must_be_specified_for_enable_command(t *testing.T) {
 	tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)
-	origStdout, stdOutWriter, stdOutReader := cli.CaptureStdOut(t)
-	defer cli.TearDown(tmpMinishiftHomeDir, origStdout)
+	origStdout, origStderr, streamWriter, streamReader := cli.CaptureStreamOut(t, 1)
+	defer cli.TearDown(tmpMinishiftHomeDir, origStdout, origStderr)
 
-	atexit.RegisterExitHandler(cli.CreateExitHandlerFunc(t, stdOutWriter, stdOutReader, 1, emptyEnableError))
+	atexit.RegisterExitHandler(cli.CreateExitHandlerFunc(t, streamWriter, streamReader, 1, emptyEnableError))
 
 	runEnableAddon(nil, nil)
 }
@@ -41,15 +42,15 @@ func Test_unkown_name_for_enable_command_returns_error(t *testing.T) {
 	tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)
 	os.Mkdir(filepath.Join(tmpMinishiftHomeDir, "addons"), 0777)
 
-	origStdout, stdOutWriter, stdOutReader := cli.CaptureStdOut(t)
-	defer cli.TearDown(tmpMinishiftHomeDir, origStdout)
+	origStdout, origStderr, streamWriter, streamReader := cli.CaptureStreamOut(t, 0)
+	defer cli.TearDown(tmpMinishiftHomeDir, origStdout, origStderr)
 
 	testAddOnName := "foo"
 	runEnableAddon(nil, []string{testAddOnName})
 
-	stdOutWriter.Close()
+	streamWriter.Close()
 	var buffer bytes.Buffer
-	io.Copy(&buffer, stdOutReader)
+	io.Copy(&buffer, streamReader)
 
 	expectedOut := fmt.Sprintf(noAddOnToEnableMessage+"\n", testAddOnName)
 	if expectedOut != buffer.String() {

--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -19,10 +19,11 @@ package addon
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/minishift/minishift/out/bindata"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 const (
@@ -64,16 +65,14 @@ func runInstallAddon(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) != 1 {
-		fmt.Println(unspecifiedSourceError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, unspecifiedSourceError)
 	}
 
 	source := args[0]
 
 	addOnName, err := addOnManager.Install(source, force)
 	if err != nil {
-		fmt.Println(fmt.Sprintf(failedPluginInstallation, err.Error()))
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf(failedPluginInstallation, err.Error()))
 	}
 
 	if enable {
@@ -86,8 +85,7 @@ func unpackAddons(dir string) {
 	for _, asset := range defaultAssets {
 		err := bindata.RestoreAssets(dir, asset)
 		if err != nil {
-			fmt.Println(fmt.Sprintf("Unable to install default addons: %s", err.Error()))
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Unable to install default addons: %s", err.Error()))
 		}
 	}
 }

--- a/cmd/minishift/cmd/addon/addon_install_test.go
+++ b/cmd/minishift/cmd/addon/addon_install_test.go
@@ -17,17 +17,18 @@ limitations under the License.
 package addon
 
 import (
+	"testing"
+
 	"github.com/minishift/minishift/pkg/testing/cli"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
-	"testing"
 )
 
 func Test_view_commands_needs_existing_vm(t *testing.T) {
 	tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)
-	origStdout, stdOutWriter, stdOutReader := cli.CaptureStdOut(t)
-	defer cli.TearDown(tmpMinishiftHomeDir, origStdout)
+	origStdout, origStderr, streamWriter, streamReader := cli.CaptureStreamOut(t, 1)
+	defer cli.TearDown(tmpMinishiftHomeDir, origStdout, origStderr)
 
-	atexit.RegisterExitHandler(cli.CreateExitHandlerFunc(t, stdOutWriter, stdOutReader, 1, unspecifiedSourceError))
+	atexit.RegisterExitHandler(cli.CreateExitHandlerFunc(t, streamWriter, streamReader, 1, unspecifiedSourceError))
 
 	runInstallAddon(nil, nil)
 }

--- a/cmd/minishift/cmd/addon/addons_list.go
+++ b/cmd/minishift/cmd/addon/addons_list.go
@@ -20,13 +20,14 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/golang/glog"
+	"fmt"
+	"io"
+	"sort"
+
 	"github.com/minishift/minishift/pkg/minishift/addon"
 	"github.com/minishift/minishift/pkg/minishift/addon/manager"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
-	"io"
-	"sort"
 )
 
 var verbose bool
@@ -63,14 +64,12 @@ func init() {
 	var err error
 	defaultListTemplate, err = template.New("list").Parse(defaultAddonListFormat)
 	if err != nil {
-		glog.Errorln("Error creating list template:", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating list template: %s", err.Error()))
 	}
 
 	verboseListTemplate, err = template.New("list").Parse(verboseAddonListFormat)
 	if err != nil {
-		glog.Errorln("Error creating list template:", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating list template: %s", err.Error()))
 	}
 }
 
@@ -92,8 +91,7 @@ func printAddOnList(manager *manager.AddOnManager, writer io.Writer, template *t
 		addonTemplate := DisplayAddOn{addon.MetaData().Name(), addon.MetaData().Description(), stringFromStatus(addon.IsEnabled()), addon.GetPriority()}
 		err := template.Execute(writer, addonTemplate)
 		if err != nil {
-			glog.Errorln("Error executing template: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error executing template: %s", err.Error()))
 		}
 	}
 }

--- a/cmd/minishift/cmd/addon/util.go
+++ b/cmd/minishift/cmd/addon/util.go
@@ -17,15 +17,16 @@ limitations under the License.
 package addon
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/docker/machine/libmachine/provision"
-	"github.com/golang/glog"
 	"github.com/minishift/minishift/cmd/minishift/cmd/config"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/addon"
 	"github.com/minishift/minishift/pkg/minishift/addon/command"
 	"github.com/minishift/minishift/pkg/minishift/addon/manager"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
-	"reflect"
 )
 
 const (
@@ -38,8 +39,7 @@ func GetAddOnManager() *manager.AddOnManager {
 	addOnConfigs := getAddOnConfiguration()
 	m, err := manager.NewAddOnManager(constants.MakeMiniPath("addons"), addOnConfigs)
 	if err != nil {
-		glog.Errorln("Unable to initialise addon manager.", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to initialise addon manager: %s", err.Error()))
 	}
 
 	return m
@@ -48,8 +48,7 @@ func GetAddOnManager() *manager.AddOnManager {
 func GetExecutionContext(ip string, routingSuffix string, ocPath string, kubeConfigPath string, sshCommander provision.SSHCommander) *command.ExecutionContext {
 	context, err := command.NewExecutionContext(ocPath, kubeConfigPath, sshCommander)
 	if err != nil {
-		glog.Errorln("Unable to initialise execution context.", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to initialise execution context: %s", err.Error()))
 	}
 
 	context.AddToContext(ip_key, ip)
@@ -61,16 +60,14 @@ func GetExecutionContext(ip string, routingSuffix string, ocPath string, kubeCon
 func writeAddOnConfig(addOnConfigMap map[string]*addon.AddOnConfig) {
 	c, err := config.ReadConfig()
 	if err != nil {
-		glog.Errorln("Unable to read Minishift configuration.", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to read Minishift configuration: %s", err.Error()))
 	}
 
 	c[addOnConfigKey] = addOnConfigMap
 
 	err = config.WriteConfig(c)
 	if err != nil {
-		glog.Errorln("Unable to write Minishift configuration.", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to write Minishift configuration: %s", err.Error()))
 	}
 }
 
@@ -79,8 +76,7 @@ func writeAddOnConfig(addOnConfigMap map[string]*addon.AddOnConfig) {
 func getAddOnConfiguration() map[string]*addon.AddOnConfig {
 	c, err := config.ReadConfig()
 	if err != nil {
-		glog.Errorln("Unable to read Minishift configuration.", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to read Minishift configuration: %s", err.Error()))
 	}
 
 	var configSlice map[string]interface{}

--- a/cmd/minishift/cmd/config/get.go
+++ b/cmd/minishift/cmd/config/get.go
@@ -30,8 +30,7 @@ var configGetCmd = &cobra.Command{
 	Long:  "Gets the value of a configuration property from the minishift configuration file. This value can be overwritten at runtime by flags or environmental variables.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
-			fmt.Fprintln(os.Stderr, "usage: minishift config get PROPERTY_NAME")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "usage: minishift config get PROPERTY_NAME")
 		}
 
 		val, err := get(args[0])

--- a/cmd/minishift/cmd/config/set.go
+++ b/cmd/minishift/cmd/config/set.go
@@ -17,9 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -31,13 +28,11 @@ var configSetCmd = &cobra.Command{
 These values can be overwritten by flags or environment variables at runtime.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 2 {
-			fmt.Fprintln(os.Stderr, "usage: minishift config set PROPERTY_NAME PROPERTY_VALUE")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "usage: minishift config set PROPERTY_NAME PROPERTY_VALUE")
 		}
 		err := set(args[0], args[1])
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 	},
 }

--- a/cmd/minishift/cmd/config/unset.go
+++ b/cmd/minishift/cmd/config/unset.go
@@ -30,8 +30,7 @@ var configUnsetCmd = &cobra.Command{
 	Long:  "Clears the value of a configuration property in the Minishift configuration file. The value can be overwritten at runtime by flags or environment variables",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
-			fmt.Fprintf(os.Stdout, "usage: minishift config unset PROPERTY_NAME")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "usage: minishift config unset PROPERTY_NAME")
 		}
 		err := unset(args[0])
 		if err != nil {

--- a/cmd/minishift/cmd/config/view.go
+++ b/cmd/minishift/cmd/config/view.go
@@ -18,16 +18,15 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"text/template"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"bytes"
-	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"sort"
 	"strings"
+
+	"github.com/minishift/minishift/pkg/util/os/atexit"
 )
 
 const (
@@ -49,8 +48,7 @@ var configViewCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := configView()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 	},
 }
@@ -77,14 +75,12 @@ func configView() error {
 
 		tmpl, err := template.New("view").Parse(configViewFormat)
 		if err != nil {
-			glog.Errorln("Error creating view template:", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error creating view template: %s", err.Error()))
 		}
 		viewTmplt := ConfigViewTemplate{k, v}
 		err = tmpl.Execute(&buffer, viewTmplt)
 		if err != nil {
-			glog.Errorln("Error executing view template:", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error executing view template: %s", err.Error()))
 		}
 	}
 

--- a/cmd/minishift/cmd/console.go
+++ b/cmd/minishift/cmd/console.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/golang/glog"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -65,8 +64,8 @@ func displayConsoleInMachineReadable(hostIP string, url string) {
 func getHostUrl(api *libmachine.Client) string {
 	url, err := cluster.GetConsoleURL(api)
 	if err != nil {
-		glog.Errorln("Cannot access the OpenShift console. Verify that Minishift is running. Error: ", err)
-		atexit.Exit(1)
+
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot access the OpenShift console. Verify that Minishift is running. Error: %s", err.Error()))
 	}
 	return url
 }
@@ -74,7 +73,7 @@ func getHostUrl(api *libmachine.Client) string {
 func getHostIp(api *libmachine.Client) string {
 	hostIP, err := cluster.GetHostIP(api)
 	if err != nil {
-		glog.Errorln("Cannot get Host IP. Verify that Minishift is running. Error: ", err)
+		fmt.Println("Cannot get Host IP. Verify that Minishift is running. Error: ", err)
 	}
 	return hostIP
 }

--- a/cmd/minishift/cmd/delete.go
+++ b/cmd/minishift/cmd/delete.go
@@ -19,6 +19,8 @@ package cmd
 import (
 	"fmt"
 
+	"os"
+
 	"github.com/docker/machine/libmachine"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
@@ -27,7 +29,6 @@ import (
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
 )
 
 // deleteCmd represents the delete command
@@ -50,20 +51,17 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 	fmt.Println("Deleting the Minishift VM...")
 	if err := cluster.DeleteHost(api); err != nil {
-		fmt.Println("Error deleting the VM: ", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error deleting the VM: %s", err.Error()))
 	}
 
 	if err := minishiftConfig.InstanceConfig.Delete(); err != nil {
-		fmt.Println(fmt.Sprintf("Error deleting %s: ", minishiftConfig.InstanceConfig.FilePath), err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintln(fmt.Sprintf("Error deleting %s: ", minishiftConfig.InstanceConfig.FilePath), err))
 	}
 
 	exists = filehelper.Exists(constants.KubeConfigPath)
 	if exists {
 		if err := os.Remove(constants.KubeConfigPath); err != nil {
-			fmt.Println(fmt.Sprintf("Error deleting '%s'", constants.KubeConfigPath))
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error deleting '%s'", constants.KubeConfigPath))
 		}
 	}
 

--- a/cmd/minishift/cmd/env.go
+++ b/cmd/minishift/cmd/env.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/shell"
-	"github.com/golang/glog"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -240,14 +239,12 @@ var dockerEnvCmd = &cobra.Command{
 		if unset {
 			shellCfg, err = shellCfgUnset(api)
 			if err != nil {
-				glog.Errorln("Error unsetting environment variables:", err)
-				atexit.Exit(1)
+				atexit.ExitWithMessage(1, fmt.Sprintf("Error unsetting environment variables: %s", err.Error()))
 			}
 		} else {
 			shellCfg, err = shellCfgSet(api)
 			if err != nil {
-				glog.Errorln("Error setting environment variables:", err)
-				atexit.Exit(1)
+				atexit.ExitWithMessage(1, fmt.Sprintf("Error setting environment variables: %s", err.Error()))
 			}
 		}
 

--- a/cmd/minishift/cmd/hostfolder/add.go
+++ b/cmd/minishift/cmd/hostfolder/add.go
@@ -18,8 +18,6 @@ package hostfolder
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-	"os"
 	"runtime"
 
 	hostfolderActions "github.com/minishift/minishift/pkg/minishift/hostfolder"
@@ -44,15 +42,13 @@ var hostfolderAddCmd = &cobra.Command{
 			err = hostfolderActions.SetupUsers(true)
 		} else {
 			if len(args) < 1 {
-				fmt.Fprintln(os.Stderr, "usage: minishift hostfolder add HOSTFOLDER_NAME")
-				atexit.Exit(1)
+				atexit.ExitWithMessage(1, "usage: minishift hostfolder add HOSTFOLDER_NAME")
 			}
 			err = hostfolderActions.Add(args[0], !instanceOnly)
 		}
 
 		if err != nil {
-			glog.Errorln(err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Failed to mount host folder: %s", err.Error()))
 		}
 	},
 }

--- a/cmd/minishift/cmd/hostfolder/list.go
+++ b/cmd/minishift/cmd/hostfolder/list.go
@@ -17,8 +17,6 @@ limitations under the License.
 package hostfolder
 
 import (
-	"github.com/golang/glog"
-
 	"github.com/docker/machine/libmachine"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	hostfolderActions "github.com/minishift/minishift/pkg/minishift/hostfolder"
@@ -35,15 +33,13 @@ var hostfolderListCmd = &cobra.Command{
 		defer api.Close()
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			glog.Errorln("Error: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 
 		isRunning := isHostRunning(host.Driver)
 		err = hostfolderActions.List(host.Driver, isRunning)
 		if err != nil {
-			glog.Errorln("Error: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 	},
 }

--- a/cmd/minishift/cmd/hostfolder/mount.go
+++ b/cmd/minishift/cmd/hostfolder/mount.go
@@ -18,8 +18,6 @@ package hostfolder
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-	"os"
 
 	"github.com/docker/machine/libmachine"
 	"github.com/minishift/minishift/pkg/minikube/constants"
@@ -41,13 +39,11 @@ var hostfolderMountCmd = &cobra.Command{
 		defer api.Close()
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			glog.Errorln("Error: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 
 		if !isHostRunning(host.Driver) {
-			fmt.Fprintln(os.Stderr, "Host is not running.")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "Host is not running.")
 		}
 
 		err = nil
@@ -55,15 +51,13 @@ var hostfolderMountCmd = &cobra.Command{
 			err = hostfolderActions.MountHostfolders(host.Driver)
 		} else {
 			if len(args) < 1 {
-				fmt.Fprintln(os.Stderr, "Usage: minishift hostfolder mount [HOSTFOLDER_NAME|--all]")
-				atexit.Exit(1)
+				atexit.ExitWithMessage(1, "Usage: minishift hostfolder mount [HOSTFOLDER_NAME|--all]")
 			}
 			err = hostfolderActions.Mount(host.Driver, args[0])
 		}
 
 		if err != nil {
-			glog.Errorln(err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error to mount host folder: %s", err.Error()))
 		}
 
 	},

--- a/cmd/minishift/cmd/hostfolder/remove.go
+++ b/cmd/minishift/cmd/hostfolder/remove.go
@@ -17,10 +17,6 @@ limitations under the License.
 package hostfolder
 
 import (
-	"fmt"
-	"github.com/golang/glog"
-	"os"
-
 	hostfolderActions "github.com/minishift/minishift/pkg/minishift/hostfolder"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
@@ -32,14 +28,12 @@ var hostfolderRemoveCmd = &cobra.Command{
 	Long:  `Remove a host folder definition`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			fmt.Fprintln(os.Stderr, "usage: minishift hostfolder remove HOSTFOLDER_NAME")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "usage: minishift hostfolder remove HOSTFOLDER_NAME")
 		}
 
 		err := hostfolderActions.Remove(args[0])
 		if err != nil {
-			glog.Errorln(err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 	},
 }

--- a/cmd/minishift/cmd/hostfolder/umount.go
+++ b/cmd/minishift/cmd/hostfolder/umount.go
@@ -18,8 +18,6 @@ package hostfolder
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-	"os"
 
 	"github.com/docker/machine/libmachine"
 	"github.com/minishift/minishift/pkg/minikube/constants"
@@ -34,27 +32,23 @@ var hostfolderUmountCmd = &cobra.Command{
 	Long:  `Unmount a host folder from the running cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			fmt.Fprintln(os.Stderr, "Usage: minishift hostfolder umount HOSTFOLDER_NAME")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "Usage: minishift hostfolder umount HOSTFOLDER_NAME")
 		}
 
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			glog.Errorln("Error: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 
 		if !isHostRunning(host.Driver) {
-			fmt.Fprintln(os.Stderr, "Host is not running.")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "Host is not running.")
 		}
 
 		err = hostfolderActions.Umount(host.Driver, args[0])
 		if err != nil {
-			glog.Errorln(err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error to unmount host folder: %s", err.Error()))
 		}
 	},
 }

--- a/cmd/minishift/cmd/ip.go
+++ b/cmd/minishift/cmd/ip.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/golang/glog"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -37,13 +36,11 @@ var ipCmd = &cobra.Command{
 		defer api.Close()
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			glog.Errorln("Error getting IP: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error getting IP: %s", err.Error()))
 		}
 		ip, err := host.Driver.GetIP()
 		if err != nil {
-			glog.Errorln("Error getting IP: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error getting IP: %s", err.Error()))
 		}
 		fmt.Println(ip)
 	},

--- a/cmd/minishift/cmd/logs.go
+++ b/cmd/minishift/cmd/logs.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/docker/machine/libmachine"
@@ -38,8 +37,7 @@ var logsCmd = &cobra.Command{
 		defer api.Close()
 		s, err := cluster.GetHostLogs(api)
 		if err != nil {
-			log.Println("Error getting logs:", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error getting logs: %s", err.Error()))
 		}
 		fmt.Fprintln(os.Stdout, s)
 	},

--- a/cmd/minishift/cmd/openshift/restart.go
+++ b/cmd/minishift/cmd/openshift/restart.go
@@ -17,10 +17,10 @@ limitations under the License.
 package openshift
 
 import (
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"fmt"
+
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
@@ -47,15 +47,13 @@ func runRestart(cmd *cobra.Command, args []string) {
 
 	host, err := cluster.CheckIfApiExistsAndLoad(api)
 	if err != nil {
-		fmt.Println(nonExistentMachineError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, nonExistentMachineError)
 	}
 
 	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
 	dockerCommander := docker.NewVmDockerCommander(sshCommander)
 	_, err = openshift.RestartOpenShift(dockerCommander)
 	if err != nil {
-		glog.Errorln("Error restarting OpenShift cluster: ", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error restarting OpenShift cluster: %s", err.Error()))
 	}
 }

--- a/cmd/minishift/cmd/openshift/service.go
+++ b/cmd/minishift/cmd/openshift/service.go
@@ -40,16 +40,14 @@ var serviceCmd = &cobra.Command{
 	Long:  `Opens the URL for the specified service and namespace in the browser or prints it to the console. If no namespace is provided, 'default' is assumed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 || len(args) > 1 {
-			fmt.Fprintln(os.Stderr, "You must specify the name of the service.")
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, "You must specify the name of the service.")
 		}
 
 		service := args[0]
 
 		url, err := openshift.GetServiceURL(service, namespace, https)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 
 		if urlMode {

--- a/cmd/minishift/cmd/openshift/service_list.go
+++ b/cmd/minishift/cmd/openshift/service_list.go
@@ -17,13 +17,12 @@ limitations under the License.
 package openshift
 
 import (
-	"fmt"
+	"os"
 
 	"github.com/minishift/minishift/pkg/minishift/openshift"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var serviceListNamespace string
@@ -36,8 +35,7 @@ var serviceListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		urls, err := openshift.GetServiceURLs(serviceListNamespace)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, err.Error())
 		}
 
 		var data [][]string

--- a/cmd/minishift/cmd/openshift/set.go
+++ b/cmd/minishift/cmd/openshift/set.go
@@ -17,13 +17,13 @@ limitations under the License.
 package openshift
 
 import (
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/machine/libmachine"
 
 	"encoding/json"
 	"fmt"
+
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
@@ -62,8 +62,7 @@ func init() {
 func runPatch(cmd *cobra.Command, args []string) {
 	patchTarget := determineTarget(target)
 	if patchTarget == openshift.UNKNOWN {
-		fmt.Println(unknownPatchTargetError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, unknownPatchTargetError)
 	}
 
 	validatePatch(patch)
@@ -73,14 +72,12 @@ func runPatch(cmd *cobra.Command, args []string) {
 
 	host, err := cluster.CheckIfApiExistsAndLoad(api)
 	if err != nil {
-		fmt.Println(nonExistentMachineError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, nonExistentMachineError)
 	}
 
 	ip, err := host.Driver.GetIP()
 	if err != nil {
-		fmt.Println(unableToRetrieveIpError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, unableToRetrieveIpError)
 	}
 	patchTarget.SetIp(ip)
 
@@ -89,8 +86,7 @@ func runPatch(cmd *cobra.Command, args []string) {
 
 	_, err = openshift.Patch(patchTarget, patch, dockerCommander)
 	if err != nil {
-		glog.Errorln("Error patching OpenShift configuration: ", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error patching OpenShift configuration: %s", err.Error()))
 	}
 }
 
@@ -107,13 +103,11 @@ func determineTarget(target string) openshift.OpenShiftPatchTarget {
 
 func validatePatch(patch string) {
 	if len(patch) == 0 {
-		fmt.Println(emptyPatchError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, emptyPatchError)
 	}
 
 	if !isJSON(patch) {
-		fmt.Println(invalidJSONError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, invalidJSONError)
 	}
 
 }

--- a/cmd/minishift/cmd/openshift/set_test.go
+++ b/cmd/minishift/cmd/openshift/set_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 
 	"bytes"
-	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/util/os/atexit"
-	"github.com/spf13/viper"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/viper"
 )
 
 var testDir string
@@ -93,7 +94,7 @@ func setup(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	os.Stdout = w
+	os.Stderr = w
 
 	constants.Minipath = testDir
 }

--- a/cmd/minishift/cmd/openshift/version.go
+++ b/cmd/minishift/cmd/openshift/version.go
@@ -18,15 +18,15 @@ package openshift
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/provision"
-	"github.com/golang/glog"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/docker"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // version command represent current running openshift version and available one.
@@ -43,15 +43,13 @@ func runVersion(cmd *cobra.Command, args []string) {
 
 	host, err := cluster.CheckIfApiExistsAndLoad(api)
 	if err != nil {
-		fmt.Println(nonExistentMachineError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, nonExistentMachineError)
 	}
 	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
 	dockerCommander := docker.NewVmDockerCommander(sshCommander)
 	version, err := dockerCommander.Exec(" ", "origin", "openshift", "version")
 	if err != nil {
-		glog.Errorln("Error restarting OpenShift cluster: ", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error restarting OpenShift cluster: %s", err.Error()))
 	}
 	fmt.Fprintln(os.Stdout, version)
 }

--- a/cmd/minishift/cmd/openshift/view.go
+++ b/cmd/minishift/cmd/openshift/view.go
@@ -17,12 +17,12 @@ limitations under the License.
 package openshift
 
 import (
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/machine/libmachine"
 
 	"fmt"
+
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
@@ -55,8 +55,7 @@ func init() {
 func runViewConfig(cmd *cobra.Command, args []string) {
 	configFileTarget := determineTarget(configTarget)
 	if configFileTarget == openshift.UNKNOWN {
-		fmt.Println(unknownConfigTargetError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, unknownConfigTargetError)
 	}
 
 	api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
@@ -64,14 +63,12 @@ func runViewConfig(cmd *cobra.Command, args []string) {
 
 	host, err := cluster.CheckIfApiExistsAndLoad(api)
 	if err != nil {
-		fmt.Println(nonExistentMachineError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, nonExistentMachineError)
 	}
 
 	ip, err := host.Driver.GetIP()
 	if err != nil {
-		fmt.Println(unableToRetrieveIpError)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, unableToRetrieveIpError)
 	}
 	configFileTarget.SetIp(ip)
 
@@ -80,8 +77,7 @@ func runViewConfig(cmd *cobra.Command, args []string) {
 
 	out, err := openshift.ViewConfig(configFileTarget, dockerCommander)
 	if err != nil {
-		glog.Errorln("Unable to display OpenShift configuration: ", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to display OpenShift configuration: %s", err.Error()))
 	}
 
 	fmt.Println(out)

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -18,9 +18,12 @@ package cmd
 
 import (
 	goflag "flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"path/filepath"
 
 	"github.com/docker/machine/libmachine/log"
 	"github.com/golang/glog"
@@ -35,7 +38,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"path/filepath"
 )
 
 var dirs = [...]string{
@@ -81,8 +83,7 @@ var RootCmd = &cobra.Command{
 		minishiftConfig.AllInstancesConfig, err = minishiftConfig.NewAllInstancesConfig(allInstanceConfigPath)
 
 		if err != nil {
-			glog.Errorln("Error creating config for all instances: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error creating config for all instances: %s", err.Error()))
 		}
 
 		// Create MACHINE_NAME.json
@@ -90,8 +91,7 @@ var RootCmd = &cobra.Command{
 		minishiftConfig.InstanceConfig, err = minishiftConfig.NewInstanceConfig(instanceConfigPath)
 
 		if err != nil {
-			glog.Errorln("Error creating config for VM: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error creating config for VM: %s", err.Error()))
 		}
 
 		shouldShowLibmachineLogs := viper.GetBool(showLibmachineLogs)
@@ -109,7 +109,7 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, err.Error())
 	}
 }
 

--- a/cmd/minishift/cmd/ssh.go
+++ b/cmd/minishift/cmd/ssh.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/docker/machine/libmachine"
-	"github.com/golang/glog"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -35,8 +36,7 @@ var sshCmd = &cobra.Command{
 		defer api.Close()
 		err := cluster.CreateSSHShell(api, args)
 		if err != nil {
-			glog.Errorln("Cannot establish SSH connection to the VM: ", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Cannot establish SSH connection to the VM: %s", err.Error()))
 		}
 	},
 }

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -173,7 +173,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 	err = util.Retry(3, start)
 	if err != nil {
-		glog.Errorln("Error starting the VM: ", err)
+		fmt.Println("Error starting the VM: ", err)
 		atexit.Exit(1)
 	}
 
@@ -187,13 +187,13 @@ func runStart(cmd *cobra.Command, args []string) {
 	hostDirs := []string{viper.GetString(hostConfigDir), viper.GetString(hostDataDir), viper.GetString(hostVolumesDir)}
 	err = clusterup.EnsureHostDirectoriesExist(libMachineClient, hostDirs)
 	if err != nil {
-		glog.Errorln("Error creating required host directories: ", err)
+		fmt.Println("Error creating required host directories: ", err)
 		atexit.Exit(1)
 	}
 
 	ip, err := host.Driver.GetIP()
 	if err != nil {
-		glog.Errorln("Error determining host ip", err)
+		fmt.Println("Error determining host ip: ", err)
 		atexit.Exit(1)
 	}
 
@@ -210,23 +210,23 @@ func runStart(cmd *cobra.Command, args []string) {
 // postClusterUp runs the Minishift specific provisioning after cluster up has run
 func postClusterUp(machineName string, ip string, port int, routingSuffix string, ocPath string, kubeConfigPath string, user string, project string, sshCommander provision.SSHCommander) {
 	if err := kubeconfig.CacheSystemAdminEntries(kubeConfigPath, getConfigClusterName(ip, port)); err != nil {
-		glog.Errorln("Error creating Minishift kubeconfig", err)
+		fmt.Println("Error creating Minishift kubeconfig: ", err)
 		atexit.Exit(1)
 	}
 
 	ocRunner, err := oc.NewOcRunner(ocPath, kubeConfigPath)
 	if err != nil {
-		glog.Errorln("Error configuring OpenShift", err)
+		fmt.Println("Error configuring OpenShift: ", err)
 		atexit.Exit(1)
 	}
 
 	if err := ocRunner.AddSudoerRoleForUser(user); err != nil {
-		glog.Error(fmt.Sprintf("Error giving %s sudoer privileges", user))
+		glog.Error(fmt.Sprintf("Error giving %s sudoer privileges: ", user))
 		atexit.Exit(1)
 	}
 
 	if err := ocRunner.AddCliContext(machineName, ip, user, project); err != nil {
-		glog.Errorln("Error adding OpenShift context")
+		fmt.Println("Error adding OpenShift context: ", err)
 		atexit.Exit(1)
 	}
 
@@ -237,7 +237,7 @@ func applyAddOns(ip string, routingSuffix string, ocPath string, kubeConfigPath 
 	addOnManager := addon.GetAddOnManager()
 	err := addOnManager.Apply(addon.GetExecutionContext(ip, routingSuffix, ocPath, kubeConfigPath, sshCommander))
 	if err != nil {
-		glog.Errorln("Error executing addon commands", err)
+		fmt.Println("Error executing addon commands: ", err)
 		atexit.Exit(1)
 	}
 }
@@ -374,14 +374,14 @@ func clusterUp(config *cluster.MachineConfig, ip string) {
 		MinishiftCacheDir: filepath.Join(constants.Minipath, "cache"),
 	}
 	if err := oc.EnsureIsCached(); err != nil {
-		glog.Errorln("Error starting the cluster: ", err)
+		fmt.Println("Error starting the cluster: ", err)
 		atexit.Exit(1)
 	}
 
 	// Update MACHINE_NAME.json for oc path
 	minishiftConfig.InstanceConfig.OcPath = filepath.Join(oc.GetCacheFilepath(), constants.OC_BINARY_NAME)
 	if err := minishiftConfig.InstanceConfig.Write(); err != nil {
-		glog.Errorln("Error updating oc path in config of VM: ", err)
+		fmt.Println("Error updating oc path in config of VM: ", err)
 		atexit.Exit(1)
 	}
 
@@ -414,8 +414,8 @@ func clusterUp(config *cluster.MachineConfig, ip string) {
 
 	exitCode := runner.Run(os.Stdout, os.Stderr, cmdName, cmdArgs...)
 	if exitCode != 0 {
-		// TODO glog is probably not right here. Need some sort of logging wrapper
-		glog.Errorln("Error starting the cluster.")
+		// TODO Println is probably not right here. Need some sort of logging wrapper
+		fmt.Println("Error starting the cluster.")
 		atexit.Exit(1)
 	}
 }

--- a/cmd/minishift/cmd/status.go
+++ b/cmd/minishift/cmd/status.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/minishift/minishift/pkg/minikube/cluster"
@@ -39,8 +38,7 @@ var statusCmd = &cobra.Command{
 		defer api.Close()
 		s, err := cluster.GetHostStatus(api)
 		if err != nil {
-			glog.Errorln("Error getting cluster status:", err)
-			atexit.Exit(1)
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error getting cluster status: %s", err.Error()))
 		}
 		fmt.Fprintln(os.Stdout, s)
 	},

--- a/cmd/minishift/cmd/stop.go
+++ b/cmd/minishift/cmd/stop.go
@@ -43,7 +43,7 @@ func runStop(cmd *cobra.Command, args []string) {
 
 	if err := cluster.StopHost(api); err != nil {
 		fmt.Println("Error stopping cluster: ", err)
-		atexit.Exit(1)
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error stopping cluster: %s", err.Error()))
 	}
 	fmt.Println("Cluster stopped.")
 }

--- a/pkg/minikube/tests/ssh_mock.go
+++ b/pkg/minikube/tests/ssh_mock.go
@@ -24,7 +24,8 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/golang/glog"
+	"fmt"
+
 	"golang.org/x/crypto/ssh"
 )
 
@@ -104,7 +105,7 @@ func (s *SSHServer) Start() (int, error) {
 					//Note: string(req.Payload) adds additional characters to start of input, execRequest used to solve this issue
 					var cmd execRequest
 					if err := ssh.Unmarshal(req.Payload, &cmd); err != nil {
-						glog.Errorln("Unmarshall encountered error: %s", err)
+						fmt.Println("Unmarshall encountered error: ", err)
 						return
 					}
 					s.Commands[cmd.Command] = 1

--- a/pkg/util/os/atexit/atexit.go
+++ b/pkg/util/os/atexit/atexit.go
@@ -17,8 +17,10 @@ limitations under the License.
 package atexit
 
 import (
-	"github.com/golang/glog"
+	"fmt"
 	"os"
+
+	"github.com/golang/glog"
 )
 
 var exitHandlers = []func(code int) int{}
@@ -27,6 +29,16 @@ var exitHandlers = []func(code int) int{}
 func Exit(code int) {
 	code = runHandlers(code)
 	os.Exit(code)
+}
+
+// ExitWithMessage exit and print the error message.
+func ExitWithMessage(code int, msg string) {
+	if code == 0 {
+		fmt.Fprintln(os.Stdout, msg)
+	} else {
+		fmt.Fprintln(os.Stderr, msg)
+	}
+	Exit(code)
 }
 
 // Register registers an exit handler function which is run when Exit is called


### PR DESCRIPTION
This patch remove glog.Errorln from user facing commands so user don't get something like `E0331 21:38:02.699866   86851 list.go:38]` when hit a error.

Addresses issue #649 