### PR TITLE
Issue #647 Make include directive work for Middleman and AsciiBinder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ _testmain.go
 docs/build
 docs/source/_tmp/*.md
 docs/source/command-ref/*.adoc
+docs/source/variables.adoc
 docs/.bundle/
 docs/.sass-cache/

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -1,11 +1,12 @@
 require 'bundler'
+require 'rubygems/package'
 
 task :default => :gen
 
 BUILD_DIR          = "build"
 MARKDOWN_FILES     = Rake::FileList.new("source/_tmp/*.md")
 TOPIC_MAP          = "#{BUILD_DIR}/_topic_map.yml"
-ADOC_VARIABLES     = "#{BUILD_DIR}/variables.adoc"
+ADOC_VARIABLES     = "source/variables.adoc"
 GENERATED_ADOC_DIR = "source/command-ref"
 ADOC_FILES = Rake::FileList.new do |list|
 	MARKDOWN_FILES.each do |f|
@@ -23,6 +24,7 @@ end
 task :clean do
   rm_f Rake::FileList.new("#{GENERATED_ADOC_DIR}/*.adoc")
   rm_rf BUILD_DIR
+  rm ADOC_VARIABLES
 end
 
 file TOPIC_MAP => [:init, 'source/_topic_map.yml'] do
@@ -71,7 +73,21 @@ end
 desc 'Create adoc tar bundle'
 task :adoc_tar => [:init, :adoc_variables, :markdown_to_asciidoc] do
   file_list = FileList.new('source/**/*.adoc', TOPIC_MAP, ADOC_VARIABLES)
-  sh "tar -cvf #{BUILD_DIR}/minishift-adoc.tar #{file_list}"
+  File.open("#{BUILD_DIR}/minishift-adoc.tar", "wb") do |file|
+    Gem::Package::TarWriter.new(file) do |tar|
+      file_list.each { |f|
+        tar.add_file(f, 0444) { |io|
+          if File.extname(f) == ".adoc" then
+            adoc_content = File.read(f)
+            adoc_content = adoc_content.gsub(/include::.*variables\.adoc\[\]/, "include::minishift/variables.adoc[]")
+            io.write(adoc_content)
+          else
+            io.write(File.read(f))
+          end
+        }
+      }
+    end
+  end
 end
 
 desc 'Create adoc variables'

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -17,55 +17,27 @@ page '/*.txt', layout: false
 #  which_fake_page: "Rendering a fake page with a local variable" }
 
 # General configuration
-activate :asciidoc
+activate :asciidoc, attributes: {"icons" => "font"}
 
-set :asciidoc_attributes, %w(icons=font)
+class AsciidoctorTweaks < Middleman::Extension
+  def initialize app, options_hash = {}, &block
+    super
+    app.before do
+      app.config[:asciidoc][:base_dir] = app.source_dir
+      true
+    end
+  end
+end
+
+::Middleman::Extensions.register :asciidoctor_tweaks, AsciidoctorTweaks
+
+activate :asciidoctor_tweaks
 
 # Reload the browser automatically whenever files change
 configure :development do
   activate :livereload
 end
 
-class CustomMarkdown < Middleman::Extension
-  $markdown_options = {
-    autolink:           true,
-    fenced_code_blocks: true,
-    no_intra_emphasis:  true,
-    strikethrough:      true,
-    tables:             true,
-    hard_wrap:          false,
-    with_toc_data:      true
-  }
-
-  # Markdown files
-  def initialize(app, options_hash={}, &block)
-    super
-    app.set :markdown_engine, :redcarpet
-    app.set :markdown, $markdown_options
-  end
-
-  # TOC helper
-  helpers do
-    # Based on https://github.com/vmg/redcarpet/pull/186#issuecomment-22783188
-    def toc(page)
-      html_toc = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC)
-      file = ::File.read(page.source_file)
-
-      # remove YAML frontmatter
-      file = file.gsub(/^(---\s*\n.*?\n?)^(---\s*$\n?)/m,'')
-
-      # quick fix for HAML: remove :markdown filter and indentation
-      file = file.gsub(/:markdown\n/,'')
-      file = file.gsub(/\t/,'')
-
-      html_toc.render file
-    end
-  end
-end
-
-::Middleman::Extensions.register(:custom_markdown, CustomMarkdown)
-
-activate :custom_markdown
 activate :syntax, :line_numbers => true
 
 # Build-specific configuration

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -1,6 +1,4 @@
-// Need to add 'minishift' prefix to keep Asciibinder happy. This fails on local build
-// https://github.com/redhataccess/ascii_binder/issues/60
-include::minishift/variables.adoc[]
+include::variables.adoc[]
 
 [[quickstart]]
 = Quickstart

--- a/docs/source/index.adoc
+++ b/docs/source/index.adoc
@@ -1,6 +1,4 @@
-// Need to add 'minishift' prefix to keep Asciibinder happy. This fails on local build
-// https://github.com/redhataccess/ascii_binder/issues/60
-include::minishift/variables.adoc[]
+include::variables.adoc[]
 
 [[minishift-index]]
 = Minishift
@@ -20,5 +18,5 @@ extend Minishift:
 
 - link:./getting-started/index{outfilesuffix}[Getting started]
 - link:./using/index{outfilesuffix}[Using Minishift]
+- link:./developing/index{outfilesuffix}[Developing Minishift]
 - link:./command-ref/minishift{outfilesuffix}[Command reference]
-- link:./developing/index{outfilesuffix}[Contributing]

--- a/docs/source/layouts/layout.erb
+++ b/docs/source/layouts/layout.erb
@@ -82,9 +82,7 @@
                   <li><a class="" href="/getting-started/index.html">Overview</a></li>
 
                   <li><a class="" href="/getting-started/docker-machine-drivers.html">Installing Docker Machine drivers</a></li>
-
                   <li><a class="" href="/getting-started/installing.html">Installing Minishift</a></li>
-
                   <li><a class="" href="/getting-started/quickstart.html">Quickstart</a></li>
               </ul>
             </li>

--- a/docs/source/using/interacting-with-openshift.adoc
+++ b/docs/source/using/interacting-with-openshift.adoc
@@ -1,7 +1,4 @@
-// Need to add 'minishift' prefix to keep Asciibinder happy. This fails on local build
-// https://github.com/redhataccess/ascii_binder/issues/60
-include::minishift/variables.adoc[]
-
+include::variables.adoc[]
 
 [[interacting-with-openshift]]
 = Interacting with OpenShift


### PR DESCRIPTION
Based on pull request #712.

This will make variable interpolation work for local development as well as the AsciiBinder build as part of docs.openshift.org. There will be an initial warning for the local site, but it works when rendering the page.