### PR TITLE
Issue #724 Fix Minishift config view output and format string

### DIFF
--- a/cmd/minishift/cmd/config/view.go
+++ b/cmd/minishift/cmd/config/view.go
@@ -17,20 +17,20 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
-	"text/template"
-
-	"github.com/spf13/cobra"
-
 	"bytes"
+	"fmt"
+	"io"
+	"os"
 	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/cobra"
 )
 
 const (
-	DefaultConfigViewFormat = "- {{.ConfigKey | printf \"%-21s\"}}: {{.ConfigValue}}\n"
+	DefaultConfigViewFormat = "- {{.ConfigKey | printf \"%-21s\"}}: {{.ConfigValue}}"
 )
 
 var configViewFormat string
@@ -46,10 +46,15 @@ var configViewCmd = &cobra.Command{
 	Short: "Display the properties and values of the Minishift configuration file.",
 	Long:  "Display the properties and values of the Minishift configuration file. You can set the output format from one of the available Go templates.",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := configView()
+		cfg, err := ReadConfig()
 		if err != nil {
 			atexit.ExitWithMessage(1, err.Error())
 		}
+		template := determineTemplate(configViewFormat)
+		if err = configView(cfg, template, os.Stdout); err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		}
+
 	},
 }
 
@@ -61,33 +66,29 @@ func init() {
 	ConfigCmd.AddCommand(configViewCmd)
 }
 
-func configView() error {
-	cfg, err := ReadConfig()
+func determineTemplate(tempFormat string) (tmpl *template.Template) {
+	tmpl, err := template.New("view").Parse(tempFormat)
 	if err != nil {
-		return err
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating view template: %s", err.Error()))
 	}
-	var buffer bytes.Buffer
+	return tmpl
+}
+
+func configView(cfg MinishiftConfig, tmpl *template.Template, writer io.Writer) error {
+	var lines []string
 	for k, v := range cfg {
 		_, excluded := excludedConfigKeys[k]
 		if excluded {
 			continue
 		}
-
-		tmpl, err := template.New("view").Parse(configViewFormat)
-		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Error creating view template: %s", err.Error()))
-		}
 		viewTmplt := ConfigViewTemplate{k, v}
-		err = tmpl.Execute(&buffer, viewTmplt)
-		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Error executing view template: %s", err.Error()))
+		var buffer bytes.Buffer
+		if err := tmpl.Execute(&buffer, viewTmplt); err != nil {
+			return err
 		}
+		lines = append(lines, buffer.String())
 	}
-
-	lines := strings.Split(buffer.String(), "\n")
-	// remove empy line at end
-	lines = lines[:len(lines)-1]
 	sort.Strings(lines)
-	fmt.Print(strings.Join(lines, "\n"))
+	fmt.Fprintln(writer, strings.Join(lines, "\n"))
 	return nil
 }

--- a/cmd/minishift/cmd/config/view_test.go
+++ b/cmd/minishift/cmd/config/view_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/minishift/minishift/pkg/testing/cli"
+)
+
+type templateExpectedOutputTest struct {
+	expectedString string
+	template       string
+}
+
+var (
+	configTest = map[string]interface{}{
+		"iso-url":   "http://foo.bar/minishift-centos.iso",
+		"vm-driver": "kvm",
+		"cpus":      4,
+		"disk-size": "20g",
+		"v":         5,
+		"show-libmachine-logs":      true,
+		"log_dir":                   "/etc/hosts",
+		"ReminderWaitPeriodInHours": 99,
+	}
+
+	templateExpectedOutputTestList = []templateExpectedOutputTest{
+		{
+			expectedString: "- ReminderWaitPeriodInHours: 99\n" +
+				"- cpus                 : 4\n" +
+				"- disk-size            : 20g\n" +
+				"- iso-url              : http://foo.bar/minishift-centos.iso\n" +
+				"- log_dir              : /etc/hosts\n" +
+				"- show-libmachine-logs : true\n" +
+				"- v                    : 5\n" +
+				"- vm-driver            : kvm\n",
+			template: "- {{.ConfigKey | printf \"%-21s\"}}: {{.ConfigValue}}",
+		},
+		{
+			expectedString: "- ReminderWaitPeriodInHours: 99\n" +
+				"- cpus: 4\n" +
+				"- disk-size: 20g\n" +
+				"- iso-url: http://foo.bar/minishift-centos.iso\n" +
+				"- log_dir: /etc/hosts\n" +
+				"- show-libmachine-logs: true\n" +
+				"- v: 5\n" +
+				"- vm-driver: kvm\n",
+			template: "- {{.ConfigKey}}: {{.ConfigValue}}",
+		},
+	}
+)
+
+func TestConfigView(t *testing.T) {
+	for _, tt := range templateExpectedOutputTestList {
+		tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)
+		tee := cli.CreateTee(t, true)
+		defer cli.TearDown(tmpMinishiftHomeDir, tee)
+
+		template := determineTemplate(tt.template)
+		configView(configTest, template, tee.StdoutBuffer)
+		if tee.StdoutBuffer.String() != tt.expectedString {
+			t.Fatalf("Expected '%s'. Got '%s'.", tt.expectedString, tee.StdoutBuffer.String())
+		}
+	}
+}


### PR DESCRIPTION
This patch will fix config view output and format string changes.

```
$ ./minishift config view --format '- {{.ConfigKey | printf "%-2s"}}: {{.ConfigValue}}'
- vm-driver: kvm
$ ./minishift config view 
- vm-driver            : kvm
$ ./minishift config view --format '- {{.ConfigKey}}:{{.ConfigValue}}'
- vm-driver:kvm
```