### PR TITLE
Issue #693 edited doc strings for hostfolder command

### DIFF
--- a/cmd/minishift/cmd/hostfolder/add.go
+++ b/cmd/minishift/cmd/hostfolder/add.go
@@ -34,8 +34,8 @@ var (
 
 var hostfolderAddCmd = &cobra.Command{
 	Use:   "add HOSTFOLDER_NAME",
-	Short: "Add a host folder definition",
-	Long:  `Add a host folder definition that can be mounted to a running cluster`,
+	Short: "Adds a host folder definition.",
+	Long:  `Adds a host folder definition. The defined host folder can be mounted to a running OpenShift cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		var err error = nil
@@ -44,7 +44,7 @@ var hostfolderAddCmd = &cobra.Command{
 			err = hostfolderActions.SetupUsers(true)
 		} else {
 			if len(args) < 1 {
-				fmt.Fprintln(os.Stderr, "usage: minishift hostfolder add HOSTFOLDER_NAME")
+				fmt.Fprintln(os.Stderr, "Usage: minishift hostfolder add HOSTFOLDER_NAME")
 				atexit.Exit(1)
 			}
 			err = hostfolderActions.Add(args[0], !instanceOnly)
@@ -59,10 +59,10 @@ var hostfolderAddCmd = &cobra.Command{
 
 func init() {
 	HostfolderCmd.AddCommand(hostfolderAddCmd)
-	hostfolderAddCmd.Flags().BoolVarP(&instanceOnly, "instance-only", "", false, "Define host folder only for the current cluster instance.")
+	hostfolderAddCmd.Flags().BoolVarP(&instanceOnly, "instance-only", "", false, "Defines the host folder only for the current OpenShift cluster.")
 
 	// Windows-only
 	if runtime.GOOS == "windows" {
-		hostfolderAddCmd.Flags().BoolVarP(&usersShare, "users-share", "", false, "Define host folder for the Users share on a Windows host.")
+		hostfolderAddCmd.Flags().BoolVarP(&usersShare, "users-share", "", false, "Defines the shared Users folder as the host folder on a Windows host.")
 	}
 }

--- a/cmd/minishift/cmd/hostfolder/hostfolder.go
+++ b/cmd/minishift/cmd/hostfolder/hostfolder.go
@@ -29,8 +29,8 @@ func isHostRunning(driver drivers.Driver) bool {
 
 var HostfolderCmd = &cobra.Command{
 	Use:   "hostfolder SUBCOMMAND [flags]",
-	Short: "Manage and control host folders for use by the OpenShift cluster.",
-	Long:  `Manage and control host folders for use by the OpenShift cluster.`,
+	Short: "Manages host folders for use by the OpenShift cluster.",
+	Long:  `Manages host folders for use by the OpenShift cluster. Use the sub-commands to define, mount, unmount, and list host folders.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/minishift/cmd/hostfolder/list.go
+++ b/cmd/minishift/cmd/hostfolder/list.go
@@ -28,8 +28,8 @@ import (
 
 var hostfolderListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List an overview of defined host folders",
-	Long:  `List an overview of defined host folders that can be mounted to a running cluster`,
+	Short: "Lists the defined host folders.",
+	Long:  `Lists an overview of the defined host folders that can be mounted to a running OpenShift cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()

--- a/cmd/minishift/cmd/hostfolder/mount.go
+++ b/cmd/minishift/cmd/hostfolder/mount.go
@@ -34,8 +34,8 @@ var (
 
 var hostfolderMountCmd = &cobra.Command{
 	Use:   "mount HOSTFOLDER_NAME",
-	Short: "Mount a host folder to the running cluster",
-	Long:  `Mount a host folder to the running cluster`,
+	Short: "Mounts a host folder to the running OpenShift cluster.",
+	Long:  `Mounts a host folder to the running OpenShift cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
@@ -71,5 +71,5 @@ var hostfolderMountCmd = &cobra.Command{
 
 func init() {
 	HostfolderCmd.AddCommand(hostfolderMountCmd)
-	hostfolderMountCmd.Flags().BoolVarP(&mountAll, "all", "a", false, "Mount all defined host folders to the cluster instance.")
+	hostfolderMountCmd.Flags().BoolVarP(&mountAll, "all", "a", false, "Mounts all defined host folders to the OpenShift cluster.")
 }

--- a/cmd/minishift/cmd/hostfolder/remove.go
+++ b/cmd/minishift/cmd/hostfolder/remove.go
@@ -28,11 +28,11 @@ import (
 
 var hostfolderRemoveCmd = &cobra.Command{
 	Use:   "remove HOSTFOLDER_NAME",
-	Short: "Remove a host folder definition",
-	Long:  `Remove a host folder definition`,
+	Short: "Removes the specified host folder definition.",
+	Long:  `Removes the specified host folder definition. This command does not remove the host folder or any data.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			fmt.Fprintln(os.Stderr, "usage: minishift hostfolder remove HOSTFOLDER_NAME")
+			fmt.Fprintln(os.Stderr, "Usage: minishift hostfolder remove HOSTFOLDER_NAME")
 			atexit.Exit(1)
 		}
 

--- a/cmd/minishift/cmd/hostfolder/umount.go
+++ b/cmd/minishift/cmd/hostfolder/umount.go
@@ -30,8 +30,8 @@ import (
 
 var hostfolderUmountCmd = &cobra.Command{
 	Use:   "umount HOSTFOLDER_NAME",
-	Short: "Unmount a host folder from the running cluster",
-	Long:  `Unmount a host folder from the running cluster`,
+	Short: "Unmount a host folder from the running OpenShift cluster.",
+	Long:  `Unmount a host folder from the running OpenShift cluster. This command does not remove the host folder definition or the host folder itself.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			fmt.Fprintln(os.Stderr, "Usage: minishift hostfolder umount HOSTFOLDER_NAME")


### PR DESCRIPTION
Fixes #693 

This PR provides proofreading of the doc strings for the hostfolder command and sub-commands.

NOTE: Unlike other commands (i.e. addon, config), the actual file names for the sub-commands don't include the parent command in the file name (i.e. "hostfolder_add.go" vs. "add.go"). Not sure if this is a problem but it isn't consistent.

cc @gbraad @hferentschik  @LalatenduMohanty 

