### PR TITLE
Issue #692 edited doc strings for addons command

### DIFF
--- a/cmd/minishift/cmd/addon/addon.go
+++ b/cmd/minishift/cmd/addon/addon.go
@@ -22,8 +22,8 @@ import (
 
 var AddonsCmd = &cobra.Command{
 	Use:   "addons SUBCOMMAND [flags]",
-	Short: "Manage Minishift addons",
-	Long:  "Install, list, enable or disable Minishift addons",
+	Short: "Manages Minishift add-ons",
+	Long:  "Manages Minishift add-ons. You can install, list, enable or disable Minishift add-ons.",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/minishift/cmd/addon/addon_disable.go
+++ b/cmd/minishift/cmd/addon/addon_disable.go
@@ -24,14 +24,14 @@ import (
 )
 
 const (
-	emptyDisableError       = "An addon name needs to be specified. Use `minishift addons list` to view installed addons."
-	noAddOnToDisableMessage = "No addon with name %s installed"
+	emptyDisableError       = "You must specify an add-on name. Use `minishift addons list` to view installed add-ons."
+	noAddOnToDisableMessage = "No add-on with the name %s is installed."
 )
 
 var addonsDisableCmd = &cobra.Command{
 	Use:   "disable ADDON_NAME",
-	Short: "Disables the specified addon.",
-	Long:  "Disables the specified addon from being run after cluster creation.",
+	Short: "Disables the specified add-on.",
+	Long:  "Disables the specified add-on and prevents applying the add-on the next time a cluster is created.",
 	Run:   runDisableAddon,
 }
 
@@ -55,7 +55,7 @@ func runDisableAddon(cmd *cobra.Command, args []string) {
 
 	addOnConfig, err := addOnManager.Disable(addonName)
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Unable to disable plugin %s: %s", addonName, err.Error()))
+		fmt.Println(fmt.Sprintf("Unable to disable add-on %s: %s", addonName, err.Error()))
 		atexit.Exit(1)
 	}
 

--- a/cmd/minishift/cmd/addon/addon_enable.go
+++ b/cmd/minishift/cmd/addon/addon_enable.go
@@ -27,21 +27,21 @@ const (
 	priorityFlag   = "priority"
 	addOnConfigKey = "addons"
 
-	emptyEnableError       = "An addon name needs to be specified. Use `minishift addons list` to view installed addons."
-	noAddOnToEnableMessage = "No addon with name %s installed"
+	emptyEnableError       = "You must specify an add-on name. Use `minishift addons list` to view installed add-ons."
+	noAddOnToEnableMessage = "No add-on with the name %s is installed."
 )
 
 var priority int
 
 var addonsEnableCmd = &cobra.Command{
 	Use:   "enable ADDON_NAME",
-	Short: "Enables the specified addon.",
-	Long:  "Enables the specified addon to be run after cluster creation.",
+	Short: "Enables the specified add-on.",
+	Long:  "Enables the specified add-on and applies the add-on the next time a cluster is created.",
 	Run:   runEnableAddon,
 }
 
 func init() {
-	addonsEnableCmd.Flags().IntVar(&priority, priorityFlag, 0, "The priority of this addon during addon execution.")
+	addonsEnableCmd.Flags().IntVar(&priority, priorityFlag, 0, "The priority of the add-on when it is applied.")
 	AddonsCmd.AddCommand(addonsEnableCmd)
 }
 
@@ -65,7 +65,7 @@ func runEnableAddon(cmd *cobra.Command, args []string) {
 func enableAddon(addOnManager *manager.AddOnManager, addonName string, priority int) {
 	addOnConfig, err := addOnManager.Enable(addonName, priority)
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Unable to enable plugin %s: %s", addonName, err.Error()))
+		fmt.Println(fmt.Sprintf("Unable to enable add-on %s: %s", addonName, err.Error()))
 		atexit.Exit(1)
 	}
 

--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	unspecifiedSourceError   = "You need to specify the source for the addon."
-	failedPluginInstallation = "Addon installation failed with error: %s"
+	unspecifiedSourceError   = "You need to specify the source for the add-on."
+	failedPluginInstallation = "Add-on installation failed with the error: %s"
 
 	forceFlag    = "force"
 	enableFlag   = "enable"
@@ -43,15 +43,15 @@ var (
 
 var addonsInstallCmd = &cobra.Command{
 	Use:   "install [SOURCE]",
-	Short: "Installs the specified addon",
-	Long:  "Verifies and installs the addon given by a file path",
+	Short: "Installs the specified add-on.",
+	Long:  "Installs the add-on from the specified file path and verifies the installation.",
 	Run:   runInstallAddon,
 }
 
 func init() {
-	addonsInstallCmd.Flags().BoolVar(&force, forceFlag, false, "Forces the installation of the addon even if the addon already has been installed before.")
-	addonsInstallCmd.Flags().BoolVar(&enable, enableFlag, false, "If set to true installs and enables the specified addon using the default priority.")
-	addonsInstallCmd.Flags().BoolVar(&defaults, defaultsFlag, false, "If set to true installs Minishift's default addons.")
+	addonsInstallCmd.Flags().BoolVar(&force, forceFlag, false, "Forces the installation of the add-on even if the add-on was previously installed.")
+	addonsInstallCmd.Flags().BoolVar(&enable, enableFlag, false, "If true, installs and enables the specified add-on with the default priority.")
+	addonsInstallCmd.Flags().BoolVar(&defaults, defaultsFlag, false, "If true, installs all Minishift default add-ons.")
 	AddonsCmd.AddCommand(addonsInstallCmd)
 }
 
@@ -59,7 +59,7 @@ func runInstallAddon(cmd *cobra.Command, args []string) {
 	addOnManager := GetAddOnManager()
 	if defaults {
 		unpackAddons(addOnManager.BaseDir())
-		fmt.Println(fmt.Sprintf("Default addons %s installed", strings.Join(defaultAssets, ", ")))
+		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(defaultAssets, ", ")))
 		return
 	}
 
@@ -86,7 +86,7 @@ func unpackAddons(dir string) {
 	for _, asset := range defaultAssets {
 		err := bindata.RestoreAssets(dir, asset)
 		if err != nil {
-			fmt.Println(fmt.Sprintf("Unable to install default addons: %s", err.Error()))
+			fmt.Println(fmt.Sprintf("Unable to install default add-ons: %s", err.Error()))
 			atexit.Exit(1)
 		}
 	}

--- a/cmd/minishift/cmd/addon/addons_list.go
+++ b/cmd/minishift/cmd/addon/addons_list.go
@@ -51,13 +51,13 @@ type DisplayAddOn struct {
 
 var addonsListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Lists all installed Minishift addons",
-	Long:  "Lists all installed Minishift addons as well as there current status (enabled/disabled)",
+	Short: "Lists all installed Minishift add-ons.",
+	Long:  "Lists all installed Minishift add-ons and their current status, such as enabled/disabled.",
 	Run:   runListCommand,
 }
 
 func init() {
-	addonsListCmd.Flags().BoolVar(&verbose, "verbose", false, "A more verbose format of the output including the addon description.")
+	addonsListCmd.Flags().BoolVar(&verbose, "verbose", false, "Prints the add-on list with a more verbose format of the output that includes the add-on description.")
 	AddonsCmd.AddCommand(addonsListCmd)
 
 	var err error

--- a/cmd/minishift/cmd/addon/util.go
+++ b/cmd/minishift/cmd/addon/util.go
@@ -38,7 +38,7 @@ func GetAddOnManager() *manager.AddOnManager {
 	addOnConfigs := getAddOnConfiguration()
 	m, err := manager.NewAddOnManager(constants.MakeMiniPath("addons"), addOnConfigs)
 	if err != nil {
-		glog.Errorln("Unable to initialise addon manager.", err)
+		glog.Errorln("Unable to initialize the add-on manager.", err)
 		atexit.Exit(1)
 	}
 
@@ -48,7 +48,7 @@ func GetAddOnManager() *manager.AddOnManager {
 func GetExecutionContext(ip string, routingSuffix string, ocPath string, kubeConfigPath string, sshCommander provision.SSHCommander) *command.ExecutionContext {
 	context, err := command.NewExecutionContext(ocPath, kubeConfigPath, sshCommander)
 	if err != nil {
-		glog.Errorln("Unable to initialise execution context.", err)
+		glog.Errorln("Unable to initialize the execution context.", err)
 		atexit.Exit(1)
 	}
 
@@ -61,7 +61,7 @@ func GetExecutionContext(ip string, routingSuffix string, ocPath string, kubeCon
 func writeAddOnConfig(addOnConfigMap map[string]*addon.AddOnConfig) {
 	c, err := config.ReadConfig()
 	if err != nil {
-		glog.Errorln("Unable to read Minishift configuration.", err)
+		glog.Errorln("Unable to read the Minishift configuration.", err)
 		atexit.Exit(1)
 	}
 
@@ -69,7 +69,7 @@ func writeAddOnConfig(addOnConfigMap map[string]*addon.AddOnConfig) {
 
 	err = config.WriteConfig(c)
 	if err != nil {
-		glog.Errorln("Unable to write Minishift configuration.", err)
+		glog.Errorln("Unable to write the Minishift configuration.", err)
 		atexit.Exit(1)
 	}
 }
@@ -79,7 +79,7 @@ func writeAddOnConfig(addOnConfigMap map[string]*addon.AddOnConfig) {
 func getAddOnConfiguration() map[string]*addon.AddOnConfig {
 	c, err := config.ReadConfig()
 	if err != nil {
-		glog.Errorln("Unable to read Minishift configuration.", err)
+		glog.Errorln("Unable to read the Minishift configuration.", err)
 		atexit.Exit(1)
 	}
 


### PR DESCRIPTION
Fixes #692 

This PR includes proofreading for doc strings of the addons command and sub-commands.

NOTES:

1. Intentionally left out the *_test.go files since they will not be user-facing texts.

2. In the addons_list sub-command there is a mention of "template" but only in the error message, and it's not controlled or described anywhere. I'm wondering if we should write something about it before the users get hit with an error?