### PR TITLE
[WIP] Issue #590 Allow hyperv virtual switch as start option and env variable

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -109,6 +109,10 @@ var settings []Setting = []Setting{
 		set:  SetString,
 	},
 	{
+		name: "hyperv-virtual-switch",
+		set:  SetString,
+	},
+	{
 		name: config.WantUpdateNotification,
 		set:  SetBool,
 	},

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -59,6 +59,7 @@ const (
 	vmDriver              = "vm-driver"
 	openshiftVersion      = "openshift-version"
 	hostOnlyCIDR          = "host-only-cidr"
+	hypervVirtualSwitch   = "hyperv-virtual-switch"
 
 	// cluster up
 	skipRegistryCheck = "skip-registry-check"
@@ -154,6 +155,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		HostOnlyCIDR:     viper.GetString(hostOnlyCIDR),
 		OpenShiftVersion: viper.GetString(openshiftVersion),
 		ShellProxyEnv:    shellProxyEnv,
+		HypervVirtualSwitch: viper.GetString(hypervVirtualSwitch),
 	}
 
 	fmt.Printf("Starting local OpenShift cluster using '%s' hypervisor...\n", config.VMDriver)
@@ -337,6 +339,7 @@ func initStartFlags() {
 	startFlagSet.StringSliceVar(&insecureRegistry, "insecure-registry", []string{"172.30.0.0/16"}, "Non-secure Docker registries to pass to the Docker daemon.")
 	startFlagSet.StringSliceVar(&registryMirror, "registry-mirror", nil, "Registry mirrors to pass to the Docker daemon.")
 	startFlagSet.String(openshiftVersion, version.GetOpenShiftVersion(), fmt.Sprintf("The OpenShift version to run, eg. %s", version.GetOpenShiftVersion()))
+	startFlagSet.String(hypervVirtualSwitch, "", "The hyperv virtual switch name. Defaults to first found. (only supported with HyperV driver)")
 }
 
 // initClusterUpFlags creates the CLI flags which needs to be passed on to 'oc cluster up'

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -185,6 +185,7 @@ type MachineConfig struct {
 	HostOnlyCIDR     string // Only used by the virtualbox driver
 	OpenShiftVersion string
 	ShellProxyEnv    string // Only used for proxy purpose
+	HypervVirtualSwitch string // Hyper virtual switch name
 }
 
 func engineOptions(config MachineConfig) *engine.Options {

--- a/pkg/minikube/cluster/cluster_windows.go
+++ b/pkg/minikube/cluster/cluster_windows.go
@@ -26,6 +26,7 @@ func createHypervHost(config MachineConfig) drivers.Driver {
 	d := hyperv.NewDriver(constants.MachineName, constants.Minipath)
 	d.Boot2DockerURL = config.GetISOFileURI()
 	d.MemSize = config.Memory
+	d.VSwitch = config.HypervVirtualSwitch
 	d.CPU = config.CPUs
 	d.DiskSize = int(config.DiskSize)
 	d.SSHUser = "docker"


### PR DESCRIPTION
Fix #590 

Tested with :
- `MINISHIFT_HYPERV_VIRTUAL_SWITCH`  environment variable
- `--hyperv-virtual-switch` option in start command
- `minishift config set hyperv-virtual-switch switch_name`

Above three are working as expected.

Working on tests !