### PR TITLE
Issue #742 Downloading message for 'oc' binary

### DIFF
--- a/pkg/util/github/github.go
+++ b/pkg/util/github/github.go
@@ -125,7 +125,7 @@ func DownloadOpenShiftReleaseBinary(binaryType OpenShiftBinaryType, osType minis
 		return errors.Wrap(err, fmt.Sprintf("Cannot download OpenShift release asset %d", assetID))
 	}
 	if len(url) > 0 {
-		glog.V(2).Infof("Downloading %s %s\n", binaryType.String(), *release.TagName)
+		fmt.Println(fmt.Sprintf("Downloading OpenShift binary '%s' in version '%s'", binaryType.String(), *release.TagName))
 		httpResp, err := http.Get(url)
 		if err != nil {
 			return errors.Wrap(err, "Cannot download OpenShift release asset.")


### PR DESCRIPTION
Fix #742 

Now, the message is 

```
Downloading ISO 'https://github.com/minishift/minishift-b2d-iso/releases/download/v1.0.2/minishift-b2d.iso'
 40.00 MB / 40.00 MB [============================================================================================================================================================] 100.00% 0s
Downloading OpenShift client binary oc with version 'v1.5.0-rc.0'
 19.96 MB / 19.96 MB [============================================================================================================================================================] 100.00% 0s
-- Checking OpenShift client ... OK
```

The URL here being used to download oc seems to be https://github-cloud.s3.amazonaws.com/releases/22442668/bb24051a . 

Not sure should I use this or message above is fine. I went with the later one for better readability. 