### PR TITLE
[WIP] Issue #590 Allow selection of virtual switch for use with Hyper-V

### DIFF
--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -22,7 +22,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 )
 
-func createVMwareFusionHost(config MachineConfig) drivers.Driver {
+func createVMwareFusionHost(config MachineConfig) (drivers.Driver, error) {
 	d := vmwarefusion.NewDriver(constants.MachineName, constants.Minipath).(*vmwarefusion.Driver)
 	d.Boot2DockerURL = config.GetISOFileURI()
 	d.Memory = config.Memory
@@ -31,7 +31,12 @@ func createVMwareFusionHost(config MachineConfig) drivers.Driver {
 	// TODO(philips): push these defaults upstream to fixup this driver
 	d.SSHPort = 22
 	d.ISO = d.ResolveStorePath("boot2docker.iso")
-	return d
+
+	if err := setDriverOptionsFromEnvironment(d); err != nil {
+		return nil, err
+	}
+
+	return d, nil
 }
 
 type xhyveDriver struct {
@@ -51,8 +56,8 @@ type xhyveDriver struct {
 	Virtio9pFolder string
 }
 
-func createXhyveHost(config MachineConfig) *xhyveDriver {
-	return &xhyveDriver{
+func createXhyveHost(config MachineConfig) (*xhyveDriver, error) {
+	d := &xhyveDriver{
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: constants.MachineName,
 			StorePath:   constants.Minipath,
@@ -65,4 +70,6 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		Virtio9pFolder: "/Users",
 		UUID:           "F4BB3F79-AB4E-4708-95CA-E32FBFCDEFD3",
 	}
+
+	return d, nil
 }

--- a/pkg/minikube/cluster/cluster_linux.go
+++ b/pkg/minikube/cluster/cluster_linux.go
@@ -39,8 +39,8 @@ type kvmDriver struct {
 	IOMode         string
 }
 
-func createKVMHost(config MachineConfig) *kvmDriver {
-	return &kvmDriver{
+func createKVMHost(config MachineConfig) (*kvmDriver, error) {
+	d := &kvmDriver{
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: constants.MachineName,
 			StorePath:   constants.Minipath,
@@ -56,4 +56,6 @@ func createKVMHost(config MachineConfig) *kvmDriver {
 		CacheMode:      "default",
 		IOMode:         "threads",
 	}
+
+	return d, nil
 }

--- a/pkg/minikube/cluster/cluster_non_darwin_panic.go
+++ b/pkg/minikube/cluster/cluster_non_darwin_panic.go
@@ -20,10 +20,10 @@ package cluster
 
 import "github.com/docker/machine/libmachine/drivers"
 
-func createVMwareFusionHost(config MachineConfig) drivers.Driver {
+func createVMwareFusionHost(config MachineConfig) (drivers.Driver, error) {
 	panic("vmwarefusion is not supported")
 }
 
-func createXhyveHost(config MachineConfig) drivers.Driver {
+func createXhyveHost(config MachineConfig) (drivers.Driver, error) {
 	panic("xhyve is not supported")
 }

--- a/pkg/minikube/cluster/cluster_non_linux_panic.go
+++ b/pkg/minikube/cluster/cluster_non_linux_panic.go
@@ -20,6 +20,6 @@ package cluster
 
 import "github.com/docker/machine/libmachine/drivers"
 
-func createKVMHost(config MachineConfig) drivers.Driver {
+func createKVMHost(config MachineConfig) (drivers.Driver, error) {
 	panic("kvm is not supported")
 }

--- a/pkg/minikube/cluster/cluster_non_windows_panic.go
+++ b/pkg/minikube/cluster/cluster_non_windows_panic.go
@@ -20,6 +20,6 @@ package cluster
 
 import "github.com/docker/machine/libmachine/drivers"
 
-func createHypervHost(config MachineConfig) drivers.Driver {
+func createHypervHost(config MachineConfig) (drivers.Driver, error) {
 	panic("hyperv is not supported")
 }

--- a/pkg/minikube/cluster/cluster_windows.go
+++ b/pkg/minikube/cluster/cluster_windows.go
@@ -22,12 +22,17 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 )
 
-func createHypervHost(config MachineConfig) drivers.Driver {
+func createHypervHost(config MachineConfig) (drivers.Driver, error) {
 	d := hyperv.NewDriver(constants.MachineName, constants.Minipath)
 	d.Boot2DockerURL = config.GetISOFileURI()
 	d.MemSize = config.Memory
 	d.CPU = config.CPUs
 	d.DiskSize = int(config.DiskSize)
 	d.SSHUser = "docker"
-	return d
+
+	if err := setDriverOptionsFromEnvironment(d); err != nil {
+		return nil, err
+	}
+
+	return d, nil
 }

--- a/pkg/minikube/cluster/cluster_windows_test.go
+++ b/pkg/minikube/cluster/cluster_windows_test.go
@@ -36,7 +36,7 @@ func TestCreateHypervHostGeneratesCorrectIsoUrl(t *testing.T) {
 	isoPath := filepath.Join(constants.Minipath, "cache", "iso", "boot2docker.iso")
 	expectedURL := "file://" + filepath.ToSlash(isoPath)
 
-	d := createHypervHost(machineConfig)
+	d, _ := createHypervHost(machineConfig)
 	expectedDriver := "*hyperv.Driver"
 
 	if reflect.TypeOf(d).String() != expectedDriver {

--- a/pkg/minikube/cluster/set_driver_options_from_env.go
+++ b/pkg/minikube/cluster/set_driver_options_from_env.go
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/docker/machine/libmachine/drivers"
+	"os"
+	"reflect"
+)
+
+func setDriverOptionsFromEnvironment(d drivers.Driver) error {
+	supportedFlags := d.GetCreateFlags()
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{},
+		CreateFlags: supportedFlags,
+	}
+
+	for _, flag := range supportedFlags {
+		r := reflect.ValueOf(flag)
+		flagName := reflect.Indirect(r).FieldByName("Name").String()
+		flagEnvName := reflect.Indirect(r).FieldByName("EnvVar").String()
+
+		if os.Getenv(flagEnvName) != "" {
+			checkFlags.FlagsValues[flagName] = os.Getenv(flagEnvName)
+		}
+	}
+
+	if err := d.SetConfigFromFlags(checkFlags); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/minikube/cluster/set_driver_options_from_env_test.go
+++ b/pkg/minikube/cluster/set_driver_options_from_env_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/minishift/minishift/pkg/minikube/tests"
+	"github.com/minishift/minishift/pkg/testing/cli"
+	"os"
+	"testing"
+)
+
+func TestSetDriverOptionsFromEnvironment(t *testing.T) {
+	testDir := cli.SetupTmpMinishiftHome(t)
+	tee := cli.CreateTee(t, true)
+	defer cli.TearDown(testDir, tee)
+
+	d := &tests.MockDriver{
+		BaseDriver: drivers.BaseDriver{},
+	}
+	expectedURL := "/foo/bar/boot2docker.iso"
+	os.Setenv("TEST_BOOT2DOCKER_URL", expectedURL)
+	defer os.Unsetenv("TEST_BOOT2DOCKER_URL")
+
+	setDriverOptionsFromEnvironment(d)
+	if d.Boot2DockerURL != expectedURL {
+		t.Errorf("Expected %s but got %s", expectedURL, d.Boot2DockerURL)
+	}
+}
+
+func TestSetWrongDriverOptionFromEnvironment(t *testing.T) {
+	testDir := cli.SetupTmpMinishiftHome(t)
+	tee := cli.CreateTee(t, true)
+	defer cli.TearDown(testDir, tee)
+
+	d := &tests.MockDriver{
+		BaseDriver: drivers.BaseDriver{},
+	}
+	expectedURL := "/foo/bar/boot2docker.iso"
+	os.Setenv("WRONG_BOOT2DOCKER_URL", expectedURL)
+	defer os.Unsetenv("WRONG_BOOT2DOCKER_URL")
+
+	setDriverOptionsFromEnvironment(d)
+	if d.Boot2DockerURL == expectedURL {
+		t.Errorf("Expected %s to not equal to %s", expectedURL, d.Boot2DockerURL)
+	}
+}

--- a/pkg/minikube/tests/driver_mock.go
+++ b/pkg/minikube/tests/driver_mock.go
@@ -27,10 +27,15 @@ import (
 // MockDriver is a struct used to mock out libmachine.Driver
 type MockDriver struct {
 	drivers.BaseDriver
-	CurrentState state.State
-	RemoveError  bool
-	HostError    bool
-	Port         int
+	CurrentState   state.State
+	RemoveError    bool
+	HostError      bool
+	Port           int
+	Boot2DockerURL string
+}
+
+func (driver *MockDriver) DriverName() string {
+	return "test"
 }
 
 // Create creates a MockDriver instance
@@ -45,7 +50,14 @@ func (driver *MockDriver) GetIP() (string, error) {
 
 // GetCreateFlags returns the flags used to create a MockDriver
 func (driver *MockDriver) GetCreateFlags() []mcnflag.Flag {
-	return []mcnflag.Flag{}
+	return []mcnflag.Flag{
+		mcnflag.StringFlag{
+			EnvVar: "TEST_BOOT2DOCKER_URL",
+			Name:   "test-boot2docker-url",
+			Usage:  "The URL of the boot2docker image. Defaults to the latest available version",
+			Value:  "",
+		},
+	}
 }
 
 func (driver *MockDriver) GetSSHPort() (int, error) {
@@ -97,6 +109,7 @@ func (driver *MockDriver) Restart() error {
 
 // SetConfigFromFlags sets the machine config
 func (driver *MockDriver) SetConfigFromFlags(opts drivers.DriverOptions) error {
+	driver.Boot2DockerURL = opts.String(fmt.Sprintf("%s-boot2docker-url", driver.DriverName()))
 	return nil
 }
 


### PR DESCRIPTION
Fix #590 

@hferentschik Sending PR for initial review.

Found that the environment options are not there for KVM and Xhyve.

```
PS C:\gowork\src\github.com\minishift\minishift> $env:HYPERV_VIRTUAL_SWITCH="minishift_switch"
PS C:\gowork\src\github.com\minishift\minishift>
PS C:\gowork\src\github.com\minishift\minishift>
PS C:\gowork\src\github.com\minishift\minishift> $env:HYPERV_VIRTUAL_SWITCH
minishift_switch
PS C:\gowork\src\github.com\minishift\minishift>
PS C:\gowork\src\github.com\minishift\minishift>
PS C:\gowork\src\github.com\minishift\minishift> minishift.exe start -v 5 --show-libmachine-logs
Starting local OpenShift cluster using 'hyperv' hypervisor...
Found binary path at C:\gowork\bin\minishift.exe
Launching plugin server for driver hyperv
Plugin server listening at address 127.0.0.1:50000
() Calling .GetVersion
Using API Version  1
() Calling .SetConfigRaw
() Calling .GetMachineName
(minishift) Calling .GetMachineName
(minishift) Calling .DriverName
Creating CA: C:\Users\budhram\.minishift\certs\ca.pem
Creating client certificate: C:\Users\budhram\.minishift\certs\cert.pem
Running pre-create checks...
(minishift) Calling .PreCreateCheck
(minishift) DBG | [executing ==>] : C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -NonInteractive @(Get-Command Get-VM).ModuleName
(minishift) DBG | [stdout =====>] : Hyper-V
(minishift) DBG |
(minishift) DBG | [stderr =====>] :
(minishift) DBG | [executing ==>] : C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -NonInteractive @([Security.Principal.WindowsPrincipal][Security.Principal.
WindowsIdentity]::GetCurrent()).IsInRole("Hyper-V Administrators")
(minishift) DBG | [stdout =====>] : True
(minishift) DBG |
(minishift) DBG | [stderr =====>] :
(minishift) DBG | [executing ==>] : C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -NonInteractive (Get-VMSwitch).Name
(minishift) DBG | [stdout =====>] : DockerNAT
(minishift) DBG | minishift_switch
(minishift) DBG |
(minishift) DBG | [stderr =====>] :
(minishift) Calling .GetConfigRaw
Creating machine...
(minishift) Calling .Create
(minishift) Downloading C:\Users\budhram\.minishift\cache\boot2docker.iso from file://C:/Users/budhram/.minishift/cache/iso/minishift-b2d.iso...
(minishift) Creating SSH key...
(minishift) Creating VM...
(minishift) DBG | [executing ==>] : C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -NonInteractive (Get-VMSwitch).Name
(minishift) DBG | [stdout =====>] : DockerNAT
(minishift) DBG | minishift_switch
*****************************************************
(minishift) Using switch "minishift_switch"
*****************************************************
(minishift) DBG |
.....
``` 

Check now, driver is picking the right switch above.

Also working on tests.