### PR TITLE
Issue #729 Adding a helper function to split command string

### DIFF
--- a/pkg/minishift/oc/oc.go
+++ b/pkg/minishift/oc/oc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/util"
 
+	"github.com/minishift/minishift/pkg/util/cmd"
 	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/pkg/errors"
 	"io"
@@ -53,7 +54,7 @@ func NewOcRunner(ocPath string, kubeConfigPath string) (*OcRunner, error) {
 }
 
 func (oc *OcRunner) Run(command string, stdOut io.Writer, stdErr io.Writer) int {
-	args := strings.Split(command, " ")
+	args := cmd.SplitCmdString(command)
 
 	// make sure we run with our copy of kube config to not influence the user
 	args = append([]string{fmt.Sprintf("--config=%s", oc.kubeConfigPath)}, args...)

--- a/pkg/minishift/oc/oc_test.go
+++ b/pkg/minishift/oc/oc_test.go
@@ -18,6 +18,7 @@ package oc
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -56,4 +57,47 @@ func Test_invalid_kube_path_returns_error(t *testing.T) {
 	if err.Error() != expectedError {
 		t.Fatal(fmt.Sprintf("Wrong error returns. Expected '%s'. Got '%s'", expectedError, err.Error()))
 	}
+}
+
+func Test_quotes_in_commands_get_properly_parsed(t *testing.T) {
+	fakeRunner := FakeRunner{}
+	expectedCommand := "/foo/bar"
+	ocRunner := OcRunner{
+		ocPath:         expectedCommand,
+		kubeConfigPath: "/kube/config",
+		runner:         &fakeRunner,
+	}
+
+	ocRunner.Run("adm new-project foo --description='Bar Baz'", nil, nil)
+
+	if fakeRunner.cmd != expectedCommand {
+		t.Fatal(fmt.Sprintf("Wrong command. Expected '%s'. Got '%s'", expectedCommand, fakeRunner.cmd))
+	}
+
+	expectedLength := 5
+	if len(fakeRunner.args) != expectedLength {
+		t.Fatal(fmt.Sprintf("Wrong args count. Expected '%d'. Got '%d'", expectedLength, len(fakeRunner.args)))
+	}
+
+	expectedArgs := []string{"--config=/kube/config", "adm", "new-project", "foo", "--description='Bar Baz'"}
+	for i, expectedArg := range expectedArgs {
+		if expectedArg != fakeRunner.args[i] {
+			t.Error(fmt.Sprintf("Wrong argument. Expected '%s'. Got '%s'", expectedArg, fakeRunner.args[i]))
+		}
+	}
+}
+
+type FakeRunner struct {
+	cmd  string
+	args []string
+}
+
+func (r *FakeRunner) Output(command string, args ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (r *FakeRunner) Run(stdOut io.Writer, stdErr io.Writer, commandPath string, args ...string) int {
+	r.cmd = commandPath
+	r.args = args
+	return 0
 }

--- a/pkg/util/cmd/split_args.go
+++ b/pkg/util/cmd/split_args.go
@@ -1,0 +1,77 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"strings"
+	"unicode"
+)
+
+// This is a '\'
+const escapeRune = rune(92)
+
+// SplitCmdString takes a single line command string and splits it into individual arguments to be used with
+// exec.Command. It does so by honouring quotes within the original command
+func SplitCmdString(cmd string) []string {
+	lastQuote := rune(0)
+	consecutiveEscapeCount := 0
+	splitWithQuotes := func(c rune) bool {
+		switch {
+		// don't split if the character matches the "last matched quote"
+		case c == lastQuote:
+			if consecutiveEscapeCount%2 == 0 {
+				lastQuote = rune(0)
+			}
+			consecutiveEscapeCount = 0
+			return false
+		// found an escape character, don't split
+		case c == escapeRune:
+			consecutiveEscapeCount += 1
+			return false
+		// don't split if we are still in a quoted string
+		case lastQuote != rune(0):
+			consecutiveEscapeCount = 0
+			return false
+		// don't split if the character is a quote type rune, and set the lastQuote value to that
+		case unicode.In(c, unicode.Quotation_Mark):
+			lastQuote = c
+			consecutiveEscapeCount = 0
+			return false
+		// split the string if it is a space and none of the other conditionals are satisfied
+		default:
+			consecutiveEscapeCount = 0
+			return unicode.IsSpace(c)
+		}
+	}
+	result := strings.FieldsFunc(cmd, splitWithQuotes)
+	return trimOuterQuotesFromArgs(result)
+}
+
+// Remove outer quotation marks from string
+func trimOuterQuotesFromArgs(args []string) []string {
+	var result []string
+	for i := range args {
+		arg := args[i]
+		chars := []rune(arg)
+		if unicode.In(chars[0], unicode.Quotation_Mark) && chars[0] == chars[len(chars)-1] {
+			arg = arg[1 : len(arg)-1]
+		}
+		result = append(result, arg)
+	}
+
+	return result
+}

--- a/pkg/util/cmd/split_args_test.go
+++ b/pkg/util/cmd/split_args_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import "testing"
+
+func TestReturnsAnArrayOfStrings(t *testing.T) {
+	args := SplitCmdString(`date 1423`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "1423" {
+		t.Errorf("Expected the second arg to be '1423', but was '%s'", args[1])
+	}
+}
+
+func TestRemovesOuterSingleQuotes(t *testing.T) {
+	args := SplitCmdString(`date '1423'`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "1423" {
+		t.Errorf("Expected the second arg to be '1423', but was '%s'", args[1])
+	}
+}
+
+func TestRemovesOuterDoubleQuotes(t *testing.T) {
+	args := SplitCmdString(`date "1423"`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "1423" {
+		t.Errorf("Expected the second arg to be '1423', but was '%s'", args[1])
+	}
+}
+
+func TestProperlyHandlesWhitespaceWithinSingleQuotes(t *testing.T) {
+	args := SplitCmdString(`date -f '%a %b %d %T %Z %Y' "01/01/1900" '+%s'`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "-f" {
+		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
+	}
+
+	if args[2] != "%a %b %d %T %Z %Y" {
+		t.Errorf("Expected the second arg to be '%%a %%b %%d %%T %%Z %%Y', but was '%s'", args[2])
+	}
+
+	if args[3] != "01/01/1900" {
+		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
+	}
+
+	if args[4] != "+%s" {
+		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
+	}
+}
+
+func TestProperlyHandlesWhitespaceWithinDoubleQuotes(t *testing.T) {
+	args := SplitCmdString(`date -f "%a %b %d %T %Z %Y" "01/01/1900" "+%s"`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "-f" {
+		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
+	}
+
+	if args[2] != "%a %b %d %T %Z %Y" {
+		t.Errorf("Expected the second arg to be '%%a %%b %%d %%T %%Z %%Y', but was '%s'", args[2])
+	}
+
+	if args[3] != "01/01/1900" {
+		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
+	}
+
+	if args[4] != "+%s" {
+		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
+	}
+}
+
+func TestProperlyHandlesEscapedDoubleQuotesWithinDoubleQuotes(t *testing.T) {
+	args := SplitCmdString(`date -f "%a %b %d \"%T %Z %Y\"" "01/01/1900" "+%s"`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "-f" {
+		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
+	}
+
+	if args[2] != `%a %b %d \"%T %Z %Y\"` {
+		t.Errorf("Expected the second arg to be '%%a %%b %%d \\\"%%T %%Z %%Y\\\"', but was '%s'", args[2])
+	}
+
+	if args[3] != "01/01/1900" {
+		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
+	}
+
+	if args[4] != "+%s" {
+		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
+	}
+}
+
+func TestProperlyHandlesNestedSingleQuotesWithinDoubleQuotes(t *testing.T) {
+	args := SplitCmdString(`date -f "%a %b %d '%T %Z %Y' -- \"foobar\"" "01/01/1900" "+%s"`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "-f" {
+		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
+	}
+
+	if args[2] != `%a %b %d '%T %Z %Y' -- \"foobar\"` {
+		t.Errorf("Expected the second arg to be '%a %%b %%d '%%T %%Z %%Y' -- \"foobar\"', but was '%s'", args[2])
+	}
+
+	if args[3] != "01/01/1900" {
+		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
+	}
+
+	if args[4] != "+%s" {
+		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
+	}
+}
+
+func TestProperlyHandlesNestedSingleQuotesInNestedDoubleQuotes(t *testing.T) {
+	args := SplitCmdString(`date -f "\"The title of the book was 'foobar'\" - %a %b %d %T %Z %Y" "01/01/1900" "+%s"`)
+
+	if args[0] != "date" {
+		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
+	}
+
+	if args[1] != "-f" {
+		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
+	}
+
+	if args[2] != `\"The title of the book was 'foobar'\" - %a %b %d %T %Z %Y` {
+		t.Errorf("Expected the second arg to be '\\\"The title of the book was 'foobar'\\\" - %%a %%b %%d %%T %%Z %%Y', but was '%s'", args[2])
+	}
+
+	if args[3] != "01/01/1900" {
+		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
+	}
+
+	if args[4] != "+%s" {
+		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
+	}
+}


### PR DESCRIPTION
Addresses issue #729 

Pretty much as suggested in issue. Added some more comments and additional unit test.