### PR TITLE
Issue #667 Allow usage of OpenShift versions lower than Minishfit's baseline version

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -17,10 +17,11 @@ limitations under the License.
 package constants
 
 import (
-	"github.com/minishift/minishift/pkg/util"
-	"github.com/minishift/minishift/pkg/version"
 	"os"
 	"path/filepath"
+
+	"github.com/minishift/minishift/pkg/util"
+	"github.com/minishift/minishift/pkg/version"
 )
 
 // MachineName is the name to use for the VM.
@@ -39,6 +40,9 @@ const MiniShiftEnvPrefix = "MINISHIFT"
 const MiniShiftHomeEnv = "MINISHIFT_HOME"
 
 const VersionPrefix = "v"
+
+// Minimum Openshift supported version
+const MinOpenshiftSuportedVersion = "v1.4.1"
 
 const (
 	DefaultMemory   = 2048


### PR DESCRIPTION
Addresses issue #667

With this patch Now user can use a minimum supported version of openshift.

```
$ ./minishift start --openshift-version v3.6.0-alpha.0 --show-libmachine-logs --v=5
[...]
Downloading OpenShift binary 'oc' version 'v3.6.0-alpha.0'
 20.07 MB / 20.07 MB [===========================================================================================================================================] 100.00% 0s
Starting OpenShift using openshift/origin:v3.6.0-alpha.0 ...
Pulling image openshift/origin:v3.6.0-alpha.0
Pulled 0/3 layers, 3% complete
Pulled 1/3 layers, 52% complete
Pulled 2/3 layers, 94% complete
Pulled 3/3 layers, 100% complete
Extracting
[...]

$ ./minishift start --openshift-version v1.4.1 
Starting local OpenShift cluster using 'kvm' hypervisor...
Downloading OpenShift binary 'oc' version 'v1.5.0-rc.0'
 19.96 MB / 19.96 MB [===========================================================================================================================================] 100.00% 0s
-- Checking OpenShift client ... OK
-- Checking Docker client ... OK
-- Checking Docker version ... OK
-- Checking for existing OpenShift container ... OK
-- Checking for openshift/origin:v1.4.1 image ... 
```
