### PR TITLE
Issue #734 refactor Managing Minishift topic

### DIFF
--- a/docs/source/_topic_map.yml
+++ b/docs/source/_topic_map.yml
@@ -10,7 +10,7 @@ Topics:
     Topics:
       - Name: Overview
         File: index
-      - Name: Installing Docker Machine drivers
+      - Name: Installing Docker Machine Drivers
         File: docker-machine-drivers
       - Name: Installing Minishift
         File: installing
@@ -23,17 +23,19 @@ Topics:
         File: index
       - Name: Managing Minishift
         File: managing-minishift
+      - Name: HTTP/HTTPS Proxies
+        File: proxies
       - Name: Add-ons
         File: addons
       - Name: Host Folders
         File: mounting-host-folders
       - Name: Interacting with OpenShift
         File: interacting-with-openshift
-      - Name: Minishift Docker daemon
+      - Name: Minishift Docker Daemon
         File: docker-daemon
       - Name: Troubleshooting Minishift
         File: troubleshooting
-      - Name: Accessing the OpenShift docker registry
+      - Name: Accessing the OpenShift Docker Registry
         File: accessing-the-openshift-docker-registry
   - Name: Developing Minishift
     Dir: developing
@@ -44,7 +46,7 @@ Topics:
         File: developing
       - Name: Minishift CI
         File: ci
-      - Name: Writing documentation
+      - Name: Writing Documentation
         File: writing-docs
       - Name: Releasing Minishift
         File: releasing

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -24,11 +24,51 @@ see the link:../using/interacting-with-openshift{outfilesuffix}[Interacting with
 For more information about the OpenShift cluster architecture, see
 https://docs.openshift.org/latest/architecture/index.html[Architecture Overview] in the OpenShift documentation.
 
-The following steps describe how to get started with Minishift on a
-GNU/Linux operating system with the KVM hypervisor driver.
+[[basic-commands]]
+== Basic Minishift commands
+
+[[minishift-start-command]]
+=== Minishift start
+
+The link:../command-ref/minishift_start{outfilesuffix}[`minishift start`] command creates and
+configures the Minishift VM and provisions a local, single-node
+OpenShift instance within the VM.
+
+The command also copies the `oc` binary to your host so that you can interact
+with OpenShift through the `oc` command line tool or through the Web console,
+which can be accessed through the URL provided in the output
+of the `minishift start` command.
+
+[[minishift-stop-command]]
+=== Minishift stop
+
+The link:../command-ref/minishift_stop{outfilesuffix}[`minishift stop`] command stops your OpenShift cluster and
+shuts down the Minishift VM, but preserves the OpenShift cluster state.
+
+Starting Minishift again will restore the OpenShift cluster, allowing
+you to continue working from the last session. However, you must enter the same
+parameters that you used in the original start command.
+
+Efforts to further refine this experience are in progress. For details, see
+the GitHub issue https://github.com/minishift/minishift/issues/179[#179].
+
+[[minishift-delete-command]]
+=== Minishift delete
+
+The link:../command-ref/minishift_delete{outfilesuffix}[`minishift delete`] command deletes the OpenShift cluster,
+and also shuts down and deletes the Minishift VM. No data or state are preserved.
+
+[[networking]]
+== Networking
+
+The Minishift VM is exposed to the host system with a host-only IP address that
+can be obtained with the `minishift ip` command.
 
 [[starting-minishift]]
 == Starting Minishift
+
+The following steps describe how to get started with Minishift on a
+GNU/Linux operating system with the KVM hypervisor driver.
 
 .  Run the `minishift start` command.
 +

--- a/docs/source/layouts/layout.erb
+++ b/docs/source/layouts/layout.erb
@@ -96,15 +96,17 @@
 
                   <li><a class="" href="/using/managing-minishift.html">Managing Minishift</a></li>
 
-                  <li><a class="" href="/using/addons.html">Minishift Add-ons</a></li>
+                  <li><a class="" href="/using/proxies.html">HTTP/HTTPS Proxies</a></li>
+
+                  <li><a class="" href="/using/addons.html">Add-ons</a></li>
 
                   <li><a class="" href="/using/mounting-host-folders.html">Host Folders</a></li>
 
                   <li><a class="" href="/using/interacting-with-openshift.html">Interacting with OpenShift</a></li>
 
-                  <li><a class="" href="/using/docker-daemon.html">Minishift Docker daemon</a></li>
+                  <li><a class="" href="/using/docker-daemon.html">Minishift Docker Daemon</a></li>
 
-                  <li><a class="" href="/using/accessing-the-openshift-docker-registry.html">Accessing the OpenShift Registry</a></li>
+                  <li><a class="" href="/using/accessing-the-openshift-docker-registry.html">Accessing the OpenShift Docker Registry</a></li>
 
                   <li><a class="" href="/using/troubleshooting.html">Troubleshooting Minishift</a></li>
               </ul>

--- a/docs/source/using/index.adoc
+++ b/docs/source/using/index.adoc
@@ -6,6 +6,7 @@ This section describes how to manage your Minishift VM and interact with your
 OpenShift cluster. It also helps troubleshooting common issues.
 
 - link:../using/managing-minishift{outfilesuffix}[Managing Minishift]
+- link:../using/proxies{outfilesuffix}[HTTP/HTTPS Proxies]
 - link:../using/addons{outfilesuffix}[Minishift Add-ons]
 - link:../using/mounting-host-folders{outfilesuffix}[Host Folders]
 - link:../using/interacting-with-openshift{outfilesuffix}[Interacting with OpenShift]

--- a/docs/source/using/managing-minishift.adoc
+++ b/docs/source/using/managing-minishift.adoc
@@ -19,40 +19,6 @@ The following sections contain information about managing the Minishift VM.
 For details about using Minishift to manage your local OpenShift cluster,
 see the link:../using/interacting-with-openshift{outfilesuffix}[Interacting with OpenShift] section.
 
-[[minishift-life-cycle]]
-== Minishift life-cycle
-
-[[minishift-start-intro]]
-=== Minishift start
-
-The link:../command-ref/minishift_start{outfilesuffix}[`minishift start`] command creates and
-configures the Minishift VM and provisions a local, single-node
-OpenShift instance within the VM.
-
-The command also copies the `oc` binary to your host so that you can interact
-with OpenShift through the `oc` command line tool or through the Web console,
-which can be accessed through the URL provided in the output
-of the `minishift start` command.
-
-[[minishift-stop-intro]]
-=== Minishift stop
-
-The link:../command-ref/minishift_stop{outfilesuffix}[`minishift stop`] command stops your OpenShift cluster and
-shuts down the Minishift VM, but preserves the OpenShift cluster state.
-
-Starting Minishift again will restore the OpenShift cluster, allowing
-you to continue working from the last session. However, you must enter the same
-parameters that you used in the original start command.
-
-Efforts to further refine this experience are in progress. For details, see
-the GitHub issue https://github.com/minishift/minishift/issues/179[#179].
-
-[[minishift-delete-intro]]
-=== Minishift delete
-
-The link:../command-ref/minishift_delete{outfilesuffix}[`minishift delete`] command deletes the OpenShift cluster,
-and also shuts down and deletes the Minishift VM. No data or state are preserved.
-
 [[runtime-options]]
 == Runtime options
 
@@ -107,7 +73,7 @@ places all runtime state into `~/.minishift`. This environment variable is
 currently experimental and semantics might change in future releases.
 
 [[persistent-configuration]]
-=== Persistent configuration
+== Persistent configuration
 
 Using persistent configuration allows you to control the Minishift
 behavior without specifying actual command line flags, similar to the
@@ -124,7 +90,7 @@ environment variables that can be used to replace any option of any
 command.
 
 [[setting-persistent-configuration-values]]
-==== Setting persistent configuration values
+=== Setting persistent configuration values
 
 The easiest way to change a persistent configuration option is with
 the link:../command-ref/minishift_config_set{outfilesuffix}[`config set`] sub-command. For example:
@@ -157,7 +123,7 @@ $ minishift config get memory
 ----
 
 [[unsetting-persistent-configuration-values]]
-==== Unsetting persistent configuration values
+=== Unsetting persistent configuration values
 
 To remove a persistent configuration option, you can use the
 link:../command-ref/minishift_config_unset{outfilesuffix}[`unset`] sub-command. For example:
@@ -203,46 +169,3 @@ _/var/lib/minishift/openshift.local.pv_ on the Minishift VM.
 
 TIP: By specifying a directory for _host-pv-dir_ which is backed by a <<mounted-host-folders,mounted host folder>>,
 you can get the persistent data of your application onto your host file system.
-
-[[http-s-proxies]]
-== HTTP/HTTPS Proxies
-
-If you are behind a HTTP/HTTPS proxy, you need to supply proxy options
-to allow Docker and OpenShift to work properly. To do this, pass the required
-flags during `minishift start`.
-
-For example:
-
-[listing.console]
-
-----
-$ minishift start --http-proxy http://YOURPROXY:PORT --https-proxy https://YOURPROXY:PORT
-----
-
-In an authenticated proxy environment, the `proxy_user` and
-`proxy_password` must be a part of proxy URI.
-
-[listing.console]
-
-----
- $ minishift start --http-proxy http://<proxy_username>:<proxy_password>@YOURPROXY:PORT \
-                   --https-proxy https://<proxy_username>:<proxy_password>@YOURPROXY:PORT
-----
-
-You can also use the `--no-proxy` flag to specify a comma-separated list of hosts
-that should not be proxied. For a list of all available options, see the
-link:../command-ref/minishift_start{outfilesuffix}[synopsis] of the `start` command.
-
-Using the proxy options will transparently configure the Docker daemon
-and OpenShift to use the specified proxies.
-
-NOTE: Using the proxy options requires that you run OpenShift version 1.5.0-alpha.2 or later.
-Use the `openshift-version` option to request a specific version of OpenShift. You can list
-all Minishift-compatible OpenShift versions with
-the link:../command-ref/minishift_openshift_list-versions{outfilesuffix}[`minishift openshift list-versions`] command.
-
-[[networking]]
-== Networking
-
-The Minishift VM is exposed to the host system with a host-only IP address that
-can be obtained with the `minishift ip` command.

--- a/docs/source/using/proxies.adoc
+++ b/docs/source/using/proxies.adoc
@@ -1,0 +1,45 @@
+[[http-https-proxies]]
+== HTTP/HTTPS Proxies
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+
+toc::[]
+
+[[proxies-overview]]
+== Overview
+
+If you are behind a HTTP/HTTPS proxy, you need to supply proxy options
+to allow Docker and OpenShift to work properly. To do this, pass the required
+flags during `minishift start`.
+
+For example:
+
+[listing.console]
+
+----
+$ minishift start --http-proxy http://YOURPROXY:PORT --https-proxy https://YOURPROXY:PORT
+----
+
+In an authenticated proxy environment, the `proxy_user` and
+`proxy_password` must be a part of proxy URI.
+
+[listing.console]
+
+----
+ $ minishift start --http-proxy http://<proxy_username>:<proxy_password>@YOURPROXY:PORT \
+                   --https-proxy https://<proxy_username>:<proxy_password>@YOURPROXY:PORT
+----
+
+You can also use the `--no-proxy` flag to specify a comma-separated list of hosts
+that should not be proxied. For a list of all available options, see the
+link:../command-ref/minishift_start{outfilesuffix}[synopsis] of the `start` command.
+
+Using the proxy options will transparently configure the Docker daemon
+and OpenShift to use the specified proxies.
+
+NOTE: Using the proxy options requires that you run OpenShift version 1.5.0-alpha.2 or later.
+Use the `openshift-version` option to request a specific version of OpenShift. You can list
+all Minishift-compatible OpenShift versions with
+the link:../command-ref/minishift_openshift_list-versions{outfilesuffix}[`minishift openshift list-versions`] command.

--- a/docs/source/variables.adoc
+++ b/docs/source/variables.adoc
@@ -1,2 +1,2 @@
-:minishift-version: unset
-:openshift-version: unset
+:minishift-version: 1.0.0-rc.1
+:openshift-version: v1.5.0-rc.0


### PR DESCRIPTION
Fixes #734 

This PR addresses several needs for the Managing Minishift topic:

1. Move the basic commands (start/stop/delete/ip) to the Quickstart topic
2. Extract proxies info to a separate topic
3. Minor proofing

NOTE: there's some conflict in the file when I tried to rebase (last rebase was yesterday), I don't know who touched the file but I can't rebase gracefully, would appreciate help on this.