### PR TITLE
[do-not-merge] Issue #618 Update "writing and publishing docs" topic

### DIFF
--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -21,7 +21,7 @@ import (
 
 	"strings"
 
-	"github.com/minishift/minishift/out/bindata"
+	"github.com/minishift/minishift/cmd/minishift/cmd/util"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -36,10 +36,9 @@ const (
 )
 
 var (
-	defaultAssets = []string{"anyuid", "admin-user", "xpaas"}
-	force         bool
-	enable        bool
-	defaults      bool
+	force    bool
+	enable   bool
+	defaults bool
 )
 
 var addonsInstallCmd = &cobra.Command{
@@ -59,8 +58,8 @@ func init() {
 func runInstallAddon(cmd *cobra.Command, args []string) {
 	addOnManager := GetAddOnManager()
 	if defaults {
-		unpackAddons(addOnManager.BaseDir())
-		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(defaultAssets, ", ")))
+		util.UnpackAddons(addOnManager.BaseDir())
+		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(util.DefaultAssets, ", ")))
 		return
 	}
 
@@ -80,14 +79,5 @@ func runInstallAddon(cmd *cobra.Command, args []string) {
 		// need to get a new manager
 		addOnManager := GetAddOnManager()
 		enableAddon(addOnManager, addOnName, 0)
-	}
-}
-
-func unpackAddons(dir string) {
-	for _, asset := range defaultAssets {
-		err := bindata.RestoreAssets(dir, asset)
-		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Unable to install default add-ons: %s", err.Error()))
-		}
 	}
 }

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -120,7 +120,7 @@ func configurableFields() string {
 	return strings.Join(fields, "\n")
 }
 
-// ReadConfig reads in the JSON minishift config
+// ReadConfig reads the config from $MINISHIFT_HOME/config/config.json file
 func ReadConfig() (MinishiftConfig, error) {
 	f, err := os.Open(constants.ConfigFile)
 	if err != nil {
@@ -138,7 +138,7 @@ func ReadConfig() (MinishiftConfig, error) {
 	return m, nil
 }
 
-// Writes a minikube config to the JSON file
+// Writes a config to the $MINISHIFT_HOME/config/config.json file
 func WriteConfig(m MinishiftConfig) error {
 	f, err := os.Create(constants.ConfigFile)
 	if err != nil {

--- a/cmd/minishift/cmd/console.go
+++ b/cmd/minishift/cmd/console.go
@@ -38,9 +38,10 @@ CONSOLE_URL=%s`
 
 // consoleCmd represents the console command
 var consoleCmd = &cobra.Command{
-	Use:   "console",
-	Short: "Opens or displays the OpenShift Web Console URL.",
-	Long:  `Opens the OpenShift Web Console URL in the default browser or displays it to the console.`,
+	Use:     "console",
+	Aliases: []string{"dashboard"},
+	Short:   "Opens or displays the OpenShift Web Console URL.",
+	Long:    `Opens the OpenShift Web Console URL in the default browser or displays it to the console.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -25,15 +25,19 @@ import (
 
 	"path/filepath"
 
+	"encoding/json"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/golang/glog"
 	"github.com/minishift/minishift/cmd/minishift/cmd/addon"
 	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
 	hostfolderCmd "github.com/minishift/minishift/cmd/minishift/cmd/hostfolder"
 	cmdOpenshift "github.com/minishift/minishift/cmd/minishift/cmd/openshift"
+	"github.com/minishift/minishift/cmd/minishift/cmd/util"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/minishift/minishift/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -68,7 +72,15 @@ var RootCmd = &cobra.Command{
 	Short: "Minishift is a tool for application development in local OpenShift clusters.",
 	Long:  `Minishift is a command-line tool that provisions and manages single-node OpenShift clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		var err error
+		var (
+			err          error
+			isFreshStart bool
+		)
+
+		if !filehelper.Exists(constants.Minipath) || filehelper.IsEmptyDir(constants.Minipath) {
+			isFreshStart = true
+		}
+
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {
 				glog.Exitf("Error creating minishift directory: %s", err)
@@ -80,7 +92,6 @@ var RootCmd = &cobra.Command{
 		// Create all instances config
 		allInstanceConfigPath := filepath.Join(constants.Minipath, "config", "allinstances.json")
 		minishiftConfig.AllInstancesConfig, err = minishiftConfig.NewAllInstancesConfig(allInstanceConfigPath)
-
 		if err != nil {
 			atexit.ExitWithMessage(1, fmt.Sprintf("Error creating config for all instances: %s", err.Error()))
 		}
@@ -88,9 +99,25 @@ var RootCmd = &cobra.Command{
 		// Create MACHINE_NAME.json
 		instanceConfigPath := filepath.Join(constants.Minipath, "machines", constants.MachineName+".json")
 		minishiftConfig.InstanceConfig, err = minishiftConfig.NewInstanceConfig(instanceConfigPath)
-
 		if err != nil {
 			atexit.ExitWithMessage(1, fmt.Sprintf("Error creating config for VM: %s", err.Error()))
+		}
+
+		// Run the default addons on fresh minishift start
+		if isFreshStart {
+			fmt.Print("-- Installing default add-ons ... ")
+			if err := util.UnpackAddons(constants.MakeMiniPath("addons")); err != nil {
+				atexit.ExitWithMessage(1, fmt.Sprintf("Error installing default add-ons : %s", err))
+			}
+
+			fmt.Println("OK")
+		}
+
+		// Check marker file created by update command and perform post update execution steps
+		if filehelper.Exists(filepath.Join(constants.Minipath, constants.UpdateMarkerFileName)) {
+			if err := performPostUpdateExecution(filepath.Join(constants.Minipath, constants.UpdateMarkerFileName)); err != nil {
+				atexit.ExitWithMessage(1, fmt.Sprintf("Error in performing post update exeuction: %s", err))
+			}
 		}
 
 		shouldShowLibmachineLogs := viper.GetBool(showLibmachineLogs)
@@ -178,4 +205,32 @@ func ensureConfigFileExists(configPath string) {
 			glog.Exitf("Cannot encode config %s: %s", configPath, err)
 		}
 	}
+}
+
+// performPostUpdateExecution executes the post update actions like unpacking the default addons
+// if user chose to update addons during `minishift update` command.
+// It also remove the marker file created by update command to avoid repeating the post update execution process
+func performPostUpdateExecution(markerPath string) error {
+	var markerData UpdateMarker
+
+	file, err := ioutil.ReadFile(markerPath)
+	if err != nil {
+		return err
+	}
+
+	json.Unmarshal(file, &markerData)
+	if markerData.InstallAddon {
+		fmt.Println(fmt.Sprintf("Minishift was upgraded from v%s to v%s. Running post update actions.", markerData.PreviousVersion, version.GetVersion()))
+		fmt.Print("--- Updating default add-ons ... ")
+		util.UnpackAddons(constants.MakeMiniPath("add-ons"))
+		fmt.Println("OK")
+		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(util.DefaultAssets, ", ")))
+	}
+
+	// Delete the marker file once post update execution is done
+	if err := os.Remove(markerPath); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -388,7 +388,7 @@ func ensureNotRunning(client *libmachine.Client, machineName string) {
 func validateOpenshiftVersion() {
 	requestedVersion := viper.GetString(startFlags.OpenshiftVersion.Name)
 
-	valid, err := clusterup.ValidateOpenshiftMinVersion(requestedVersion, constants.MinOpenshiftSuportedVersion)
+	valid, err := clusterup.ValidateOpenshiftMinVersion(requestedVersion, constants.MinOpenshiftSupportedVersion)
 	if err != nil {
 		atexit.ExitWithMessage(1, err.Error())
 	}
@@ -396,7 +396,7 @@ func validateOpenshiftVersion() {
 	if !valid {
 		fmt.Printf("Minishift does not support Openshift version %s. "+
 			"You need to use a version >= %s\n", viper.GetString(startFlags.OpenshiftVersion.Name),
-			constants.MinOpenshiftSuportedVersion)
+			constants.MinOpenshiftSupportedVersion)
 		atexit.Exit(1)
 	}
 

--- a/cmd/minishift/cmd/update_test.go
+++ b/cmd/minishift/cmd/update_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestCreateUpdateMarker(t *testing.T) {
+	testFile, err := ioutil.TempFile(os.TempDir(), "testFile")
+	testFileName := testFile.Name()
+	defer os.Remove(testFileName)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	expectedInstallAddon, expectedPreviousVersion := true, "1.0.0"
+	createUpdateMarker(testFileName, UpdateMarker{expectedInstallAddon, expectedPreviousVersion})
+
+	// Read json file
+	var markerData UpdateMarker
+
+	file, err := ioutil.ReadFile(testFileName)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	json.Unmarshal(file, &markerData)
+	if markerData.InstallAddon != expectedInstallAddon {
+		t.Fatalf("Expected allow installation of addon to be %t but got %t.", expectedInstallAddon, markerData.InstallAddon)
+	}
+	if markerData.PreviousVersion != expectedPreviousVersion {
+		t.Fatalf("Expected previous version to be %t but got %t.", expectedPreviousVersion, markerData.PreviousVersion)
+	}
+}

--- a/cmd/minishift/cmd/util/util.go
+++ b/cmd/minishift/cmd/util/util.go
@@ -23,6 +23,12 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
+
+	"github.com/minishift/minishift/out/bindata"
+)
+
+var (
+	DefaultAssets = []string{"anyuid", "admin-user", "xpaas"}
 )
 
 func VMExists(client *libmachine.Client, machineName string) bool {
@@ -53,4 +59,15 @@ func ExitIfNotRunning(driver drivers.Driver, machineName string) {
 	if !running {
 		atexit.ExitWithMessage(0, fmt.Sprintf("The execution of this command requires a running '%s' VM, but there is currently none.", machineName))
 	}
+}
+
+// UnpackAddons will unpack the default addons into addons default dir
+func UnpackAddons(addonsDir string) error {
+	for _, asset := range DefaultAssets {
+		if err := bindata.RestoreAssets(addonsDir, asset); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/docs/source/developing/writing-docs.adoc
+++ b/docs/source/developing/writing-docs.adoc
@@ -10,21 +10,77 @@ toc::[]
 [[writing-docs-overview]]
 == Overview
 
-This section contains information about contributing to the Minishift documentation.
-
-[[section-building-minishift-docs]]
-== Building Minishift documentation
-
 Minishift documentation is located in the `docs` sub-folder.
 The documentation is a mix of generated https://en.wikipedia.org/wiki/Markdown[Markdown] files and manually maintained https://en.wikipedia.org/wiki/AsciiDoc[Asciidoc] files.
 
-If you are adding a new file to the doumentation please update the `_topic_map.yml`  in the root of `docs/source` sub-folder.
+[[contribute-to-docs]]
+== Contributing to the documentation
 
-Per default the documentation is built in a Docker container. This way
+Minishift is an open-source project and we welcome contributions. Similar to code
+contributions, if you want to add or edit Minishift documentation, you can create an
+issue in our link:https://github.com/minishift/minishift/issues[Github issue tracker] and
+submit a pull request with the changes.
+
+[[docs-conventions-guidelines]]
+== Conventions and guidelines
+
+Minishift documentation is authored in the AsciiDoc markup format. Since Minishift is closely related to the OpenShift Origin
+project, we follow the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc[OpenShift Documentation Guidelines]
+for tagging, formatting, and structure wherever possible.
+
+The documentation source structure follows a modular format, where each file is called
+a _topic_ and each topic is stored under a sub-folder based on the relevant category, such as
+getting started, using Minishift, or command reference.
+
+TIP: You can check out the link:https://github.com/minishift/minishift/blob/master/docs/source/developing/writing-docs.adoc[raw file]
+of this topic or other existing Minishift topics to see examples of how the information is structured and which tags to use.
+
+[[common-conventions]]
+=== Commonly-used conventions
+
+- Each file must contain a topic metadata header with a top-level heading followed by required AsciiDoc variable declarations.
+The only exception to this is the command reference topics, which are automatically generated and do not require this header.
+You can view the raw file of this topic to see an example. Also, see
+the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#topic-metadata[topic metadata]
+section in the OpenShift documentation guidelines for more information.
+
+- Whenever you link to internal documentation topics, you should use relative links that can
+be resolved during the publication workflow instead of hard-coding URLs. See the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#internal-cross-references[internal cross-references]
+section of the OpenShift documentation guidelines for more information and examples.
+
+- Each section heading must be preceded by a unique anchor ID, to help make sure that
+cross-references resolve to the correct section. The anchor ID text should match the title
+as much as possible and it does not need to include the prefix _section_ or _topic_. See the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#unique-ids[unique IDs]
+section of the OpenShift documentation guidelines for more information and examples.
+
+[[adding-new-topic]]
+=== Adding a new topic
+
+If you are adding a new topic, or file, to the documentation library, you must also
+update the navigation in the following ways:
+
+- Add an entry to the relevant *_index.adoc_* file for that topic. For example, if you
+add a new topic in the *_docs/source/using/_* directory, you must update the *_docs/source/using/index.adoc_*
+file in the same directory.
+
+- Add an entry to the *__topic_map.yml_* in the *_docs/source_* sub-folder. The entry must
+contain the topic title and the file name.
+
+Make sure to add the new topic in the same order in all of the locations.
+
+[[building-docs]]
+== Building the documentation
+
+Minishift documentation is located in the *_docs_* sub-folder. The
+documentation is a mix of generated
+https://en.wikipedia.org/wiki/Markdown[Markdown] files and manually
+maintained https://en.wikipedia.org/wiki/AsciiDoc[Asciidoc] files.
+
+By default, the documentation is built in a Docker container. This way
 you avoid having to install all the required dependencies on your
 development machine. All you need is a running Docker daemon. In case
-you don't have one, use Minishift itself. For further information refer to
-link:../command-ref/minishift_docker-env{outfilesuffix}[`minishift docker-env`].
+you don't have one, use Minishift itself. For more information, see the
+link:../command-ref/minishift_docker-env{outfilesuffix}[`minishift docker-env`] command.
 
 To build the Docker image, run:
 
@@ -32,7 +88,7 @@ To build the Docker image, run:
 $ make build_docs_container
 ----
 
-To generate the documentation into the directory `docs/build`, run:
+To generate the documentation into the directory *_docs/build_*, run:
 
 ----
 $ make gen_docs
@@ -66,14 +122,25 @@ To build and serve the documentation for editing, run:
 $ make serve_docs
 ----
 
-The latter will start the https://middlemanapp.com[Middleman] server on port 4567.
-You can access the rendered documentation by browsing to http://<IP of Docker daemon>:4567.
+The `make serve_docs` command starts the link:https://middlemanapp.com[Middleman] server on
+port 4567. You can access the rendered documentation by browsing to _http://<IP-of-Docker-daemon>:4567_.
 
-[[section-deploying-minishift-docs]]
-== Deploying Minishift documentation
+If you encounter issues with the local staging of the documentation, you can run the following
+command to delete the *_build_* sub-folder and the variables file:
 
-The Minishift documentation is deployed on _docs.openshift.org_.
-To integrate with this site we deliver a tarball containing the Minishift asciidoc files as well as some link:http://www.asciibinder.org/[AsciiBinder] meta data.
+----
+$ make clean_docs
+----
+
+[[deploying-docs]]
+== Deploying the documentation
+
+The Minishift documentation is deployed on _docs.openshift.org_ under
+link:https://docs.openshift.org/latest/minishift[https://docs.openshift.org/latest/minishift].
+
+To integrate with the _docs.openshift.org_ we deliver a tarball containing
+the Minishift AsciiDoc files as well as some link:http://www.asciibinder.org/[AsciiBinder]
+meta data.
 
 This tarball can be built using:
 
@@ -81,24 +148,22 @@ This tarball can be built using:
 $ make gen_adoc_tar
 ----
 
-Once the build completes there will be a _minishift-adoc.tar_ in the _docs/build_ directory
-of your checkout.
+After the build completes there will be a *_minishift-adoc.tar_* file in the *_docs/build_* directory
+of your local repository.
 
-How this tarball is integrated into the docs.openshift.org site build is described in
-<<section-building-openshift-docs>>.
-
-[[section-building-openshift-docs]]
+[[building-openshift-docs]]
 === Building OpenShift documentation
 
-To start with you need a checkout of the link:https://github.com/openshift/openshift-docs.git[openshift-docs]
-GitHub repository. You need all the tooling to build openshift-docs. Refer to
-link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/tools_and_setup.adoc[Install and set up the tools and software] which is part of the openshift-docs repository.
+Before you start, you need to check out the link:https://github.com/openshift/openshift-docs.git[openshift-docs]
+GitHub repository. You need all the tooling to build openshift-docs. See the
+link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/tools_and_setup.adoc[Install and set up the tools and software] section,
+which is part of the _openshift-docs_ repository.
 
-Once you can successfully run `rake build` in your openshift-docs checkout, you can integrate the
+After you successfully run `rake build` in your local repository, you can integrate the
 Minishift documentation.
 
-Start with building the documentation tarball as described in <<section-deploying-minishift-docs>>,
-then follow these steps (assuming you are in the directory of your openshift-docs checkout):
+After you build the Minishift documentation tarball, follow these steps from the directory of
+your local openshift-docs repository:
 
 ----
 $ mkdir minishift
@@ -110,4 +175,7 @@ $ cd ..
 $ rake build
 ----
 
-If the build completes successfully, the site is available under _preview/openshift-origin/latest/welcome/index.html_.
+If the build completes successfully, the site is available under *_preview/openshift-origin/latest/welcome/index.html_*.
+
+OpenShift runs a nightly build in which they update the documentation. After you update the documentation,
+you must wait for the nightly build that runs at midnight EST daily to view the documentation on _docs.openshift.org_.

--- a/docs/source/using/managing-minishift.adoc
+++ b/docs/source/using/managing-minishift.adoc
@@ -275,3 +275,20 @@ Use the `openshift-version` option to request a specific version of OpenShift. Y
 
 The Minishift VM is exposed to the host system with a host-only IP address that
 can be obtained with the `minishift ip` command.
+
+[[connecting-with-ssh]]
+== Connecting to the Minishift VM with SSH
+
+You can use the xref:../command-ref/minishift_ssh.adoc#minishift-ssh[`minishift ssh`] command to interact with the Minishift VM.
+
+You can run `minishift ssh` without a sub-command to open an interactive shell and run commands on the
+Minishift VM in the same way that you run commands interactively on any remote machine using SSH.
+
+You can also run `minishift ssh` with a sub-command to send the sub-command directly to the Minishift VM and return
+the result to your local shell. For example:
+
+----
+$ minishift ssh -- docker ps
+CONTAINER    IMAGE                   COMMAND                CREATED        STATUS        NAMES
+71fe8ff16548 openshift/origin:v1.5.1 "/usr/bin/openshift s" 4 minutes ago  Up 4 minutes  origin
+----

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -24,31 +24,21 @@ import (
 	"github.com/minishift/minishift/pkg/version"
 )
 
-// MachineName is the name to use for the VM.
-const MachineName = "minishift"
-
-// APIServerPort is the port that the API server should listen on.
-const APIServerPort = 8443
+const (
+	MachineName                  = "minishift"      // Name to use for the VM
+	APIServerPort                = 8443             // Port that the API server should listen on
+	MiniShiftEnvPrefix           = "MINISHIFT"      // Prefix for the environmental variables
+	MiniShiftHomeEnv             = "MINISHIFT_HOME" // Environment variable used to change the Minishift home directory
+	VersionPrefix                = "v"
+	MinOpenshiftSupportedVersion = "v1.4.1"
+	DefaultMemory                = 2048
+	DefaultCPUS                  = 2
+	DefaultDiskSize              = "20g"
+	UpdateMarkerFileName         = "updated"
+)
 
 // Fix for windows
 var Minipath = getMinishiftHomeDir()
-
-// MiniShiftEnvPrefix is the prefix for the environmental variables
-const MiniShiftEnvPrefix = "MINISHIFT"
-
-// MiniShiftHomeEnv is the environment variable used to change the Minishift home directory
-const MiniShiftHomeEnv = "MINISHIFT_HOME"
-
-const VersionPrefix = "v"
-
-// Minimum Openshift supported version
-const MinOpenshiftSuportedVersion = "v1.4.1"
-
-const (
-	DefaultMemory   = 2048
-	DefaultCPUS     = 2
-	DefaultDiskSize = "20g"
-)
 
 var KubeConfigPath = filepath.Join(Minipath, "machines", MachineName+"_kubeconfig")
 

--- a/pkg/testing/cli/harness.go
+++ b/pkg/testing/cli/harness.go
@@ -51,7 +51,7 @@ func CreateTee(t *testing.T, silent bool) *Tee {
 	return tee
 }
 
-// VerifyExitCodeAndMessage creates an exit handler which verifies that the programm will try to exit execution with the specified
+// VerifyExitCodeAndMessage creates an exit handler which verifies that the program will try to exit execution with the specified
 // exit code and message.
 func VerifyExitCodeAndMessage(t *testing.T, tee *Tee, expectedExitCode int, expectedErrorMessage string) func(int) bool {
 	var exitHandler func(int) bool

--- a/pkg/util/filehelper/file.go
+++ b/pkg/util/filehelper/file.go
@@ -152,3 +152,20 @@ func CopyDir(src string, dst string) (err error) {
 
 	return
 }
+
+// IsDirEmpty returns true if and only if the specified path denotes an empty directory, false otherwise.
+func IsEmptyDir(path string) bool {
+	// https://stackoverflow.com/a/30708914/1120530
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/filehelper/file_test.go
+++ b/pkg/util/filehelper/file_test.go
@@ -92,3 +92,35 @@ func Test_file_is_not_a_directory(t *testing.T) {
 		t.Fatalf("The path '%s' should not be a directory", testDir)
 	}
 }
+
+func Test_non_existing_directory(t *testing.T) {
+	testDir := "/foo/bar"
+	if empty := IsEmptyDir(testDir); empty {
+		t.Fatalf("Expected that the directory %s doesn't exist.", testDir)
+	}
+}
+
+func Test_existing_empty_directory(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "minishift-test-filetest-")
+	defer os.RemoveAll(testDir)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	if empty := IsEmptyDir(testDir); !empty {
+		t.Fatalf("Expected %s to be empty.", testDir)
+	}
+}
+
+func Test_existing_nonempty_directory(t *testing.T) {
+	testDir, _ := ioutil.TempDir("", "minishift-test-filetest-")
+	_, err := ioutil.TempFile(testDir, "foo")
+	defer os.RemoveAll(testDir)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	if empty := IsEmptyDir(testDir); empty {
+		t.Fatalf("Expected %s to be nonempty.", testDir)
+	}
+}

--- a/pkg/util/shell/shell.go
+++ b/pkg/util/shell/shell.go
@@ -77,7 +77,7 @@ func GetPrefixSuffixDelimiterForSet(userShell string, pathVar bool) (prefix, suf
 		suffix = "\";\n"
 		delimiter = " \""
 		if pathVar {
-			delimiter = " $PATH "
+			suffix = "\" $PATH;\n"
 		}
 	case "powershell":
 		prefix = "$Env:"

--- a/pkg/util/shell/shell_test.go
+++ b/pkg/util/shell/shell_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shell
+
+import (
+	"os"
+	"testing"
+)
+
+type shellTestCase struct {
+	name         string
+	cmdLine      string
+	expectedHint string
+}
+
+type prefixSuffixDelimiterTestCase struct {
+	shellName string
+	prefix    string
+	suffix    string
+	pathVar   bool
+	delimiter string
+}
+
+func TestUnknownShell(t *testing.T) {
+	expectedShellName := "foo"
+	defer func(shell string) { os.Setenv("SHELL", shell) }(os.Getenv("SHELL"))
+	os.Setenv("SHELL", "/bin/"+expectedShellName)
+
+	shell, err := GetShell("")
+	if err != nil {
+		t.Fatal("Unexpected err : ", err.Error())
+	}
+
+	if shell != expectedShellName {
+		t.Fatalf("Expected shell to be %s but %s", expectedShellName, shell)
+	}
+}
+
+func TestKnownShell(t *testing.T) {
+	expectedShellName := "bash"
+	shell, err := GetShell("bash")
+	if err != nil {
+		t.Fatal("Unexpected err : ", err.Error())
+	}
+
+	if shell != expectedShellName {
+		t.Fatalf("Expected shell to be %s but %s", expectedShellName, shell)
+	}
+}
+
+func TestNoProxyFromEnvWhenUsedLowerCase(t *testing.T) {
+	expectedNoProxyVarName := "no_proxy"
+	expectedNoProxyVarValue := "FOO_BAR"
+	defer func(val string) { os.Setenv(expectedNoProxyVarName, val) }(os.Getenv(expectedNoProxyVarName))
+	os.Setenv(expectedNoProxyVarName, expectedNoProxyVarValue)
+
+	_, noProxyValue := FindNoProxyFromEnv()
+	if noProxyValue != expectedNoProxyVarValue {
+		t.Fatalf("Expected no proxy var value as %s but got %s", expectedNoProxyVarValue, noProxyValue)
+	}
+}
+
+func TestNoProxyFromEnvWhenUsedUpperCase(t *testing.T) {
+	expectedNoProxyVarName := "NO_PROXY"
+	expectedNoProxyVarValue := "FOO_BAR"
+	defer func(val string) { os.Setenv(expectedNoProxyVarName, val) }(os.Getenv(expectedNoProxyVarName))
+	os.Setenv(expectedNoProxyVarName, expectedNoProxyVarValue)
+
+	_, noProxyValue := FindNoProxyFromEnv()
+	if noProxyValue != expectedNoProxyVarValue {
+		t.Fatalf("Expected no proxy var value as %s but got %s", expectedNoProxyVarValue, noProxyValue)
+	}
+}
+
+func TestGenerateUsageHint(t *testing.T) {
+	testData := []shellTestCase{
+		{
+			name: "bash", cmdLine: "foo", expectedHint: `# Run this command to configure your shell:
+# eval $(foo)
+`,
+		},
+		{
+			name: "fish", cmdLine: "foo", expectedHint: `# Run this command to configure your shell:
+# eval (foo)
+`,
+		},
+		{
+			name: "powershell", cmdLine: "foo", expectedHint: `# Run this command to configure your shell:
+# & foo | Invoke-Expression
+`,
+		},
+		{
+			name: "cmd", cmdLine: "foo", expectedHint: `REM Run this command to configure your shell:
+REM 	@FOR /f "tokens=*" %i IN ('foo') DO @call %i
+`,
+		},
+		{
+			name: "emacs", cmdLine: "foo", expectedHint: `;; Run this command to configure your shell:
+;; (with-temp-buffer (shell-command "foo" (current-buffer)) (eval-buffer))
+`,
+		},
+	}
+
+	for _, tt := range testData {
+		hint := GenerateUsageHint(tt.name, tt.cmdLine)
+		if tt.expectedHint != hint {
+			t.Fatalf("Expected hint to be \n%s but got \n%s", tt.expectedHint, hint)
+		}
+
+	}
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 )
@@ -48,19 +47,6 @@ func Until(fn func() error, w io.Writer, name string, sleep time.Duration, done 
 
 func Pad(str string) string {
 	return fmt.Sprint("\n%s\n", str)
-}
-
-// If the file represented by path exists and
-// readable, return true otherwise return false.
-func CanReadFile(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-
-	defer f.Close()
-
-	return true
 }
 
 func Retry(attempts int, callback func() error) (err error) {

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -72,6 +72,8 @@ Feature: Basic
     Given Minishift has state "Running"
      When executing "minishift console --url" succeeds
      Then stdout should be valid URL
+     When executing "minishift dashboard --url" succeeds
+     Then stdout should be valid URL
 
   Scenario: OpenShift developer has sudo permissions
      The 'developer' user should be configured with the sudoer role after starting Minishift

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -3,7 +3,7 @@ Feature: Basic
   As a user I can perform basic operations of Minishift and OpenShift
 
   Scenario: User can install default add-ons
-    Given Minishift has state "Does Not Exist"
+   Given Minishift has state "Does Not Exist"
     When executing "minishift addons install --defaults" succeeds
     Then stdout should contain
      """
@@ -11,15 +11,16 @@ Feature: Basic
      """
 
   Scenario: User can enable the anyuid add-on
-    Given Minishift has state "Does Not Exist"
+   Given Minishift has state "Does Not Exist"
     When executing "minishift addons enable anyuid" succeeds
     Then stdout should contain
      """
      Addon 'anyuid' enabled
      """
 
+  @minishift-only
   Scenario: User can list enabled plugins
-    Given Minishift has state "Does Not Exist"
+   Given Minishift has state "Does Not Exist"
     When executing "minishift addons list" succeeds
     Then stdout should contain
      """

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -55,6 +55,16 @@ func TestMain(m *testing.M) {
 	var godogPaths = flag.String("paths", "./features", "")
 	flag.Parse()
 
+	if *godogTags != "" {
+		*godogTags += "&&"
+	}
+	runner := util.MinishiftRunner{CommandPath: givenPath}
+	if runner.IsCDK() {
+		*godogTags += "~minishift-only"
+	} else {
+		*godogTags += "~cdk-only"
+	}
+
 	status := godog.RunWithOptions("minishift", func(s *godog.Suite) {
 		FeatureContext(s)
 	}, godog.Options{


### PR DESCRIPTION
Fixes issue #618 

This PR aims to formalize the documentation guidelines and conventions. I also proofread the topic itself to reflect the proposed conventions so you can see what a "clean" topic looks like.

TL;DR: Follow OpenShift doc guidelines whenever possible, exceptions noted.

I wrote some specific examples of common conventions that people might have questions about, but the basic guideline is to keep it simple and not overkill with tags, because we need the docs to be parsed through multiple toolchains upstream and downstream.

NOTE: We are currently working in RH CCS (content services) to unify the AsciiDoc conventions from several products into a single source-of-truth. This will impact Minishift but it will take some time and it will be partially based on OpenShift conventions so future changes will probably be minor.

Please review and hopefully we can reach an agreement, and after we finalize this I will go ahead and handle #691 so that the doc set follows the conventions.