### PR TITLE
[WIP] Issue #840 Fix encoding and force remove source/variables.adoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,7 @@ ADDON_BINDATA_DIR = $(CURDIR)/$(BUILD_DIR)/bindata
 ADDON_ASSET_FILE = $(ADDON_BINDATA_DIR)/addon_assets.go
 
 # Setup for the docs tasks
-ifeq ($(GOOS),windows)
-	UID := 1000
-else
-	UID = $(shell id -u)
-endif
+IMAGE_UID ?= 1000
 DOCS_SYNOPISIS_DIR = docs/source/_tmp
 
 # Start of the actual build targets
@@ -92,7 +88,7 @@ prerelease:
 
 .PHONY: build_docs_container
 build_docs_container:
-	cd docs && docker build --build-arg uid=$(UID) -t minishift/docs .
+	cd docs && docker build --build-arg uid=$(IMAGE_UID) -t minishift/docs .
 
 .PHONY: gen_adoc_tar
 gen_adoc_tar: synopsis_docs build_docs_container

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -174,7 +174,7 @@ function artifacts_upload_on_pr_and_master_trigger() {
   # For PR build, GIT_BRANCH is set to branch name other than origin/master
   if [[ "$GIT_BRANCH" = "origin/master" ]]; then
     install_docs_prerequisite_packages;
-    make gen_adoc_tar
+    make gen_adoc_tar IMAGE_UID=$(id -u)
     build_openshift_origin_docs $(pwd)/docs/build/minishift-adoc.tar;
 
     mkdir -p minishift/master/$BUILD_NUMBER/
@@ -199,7 +199,7 @@ function docs_tar_upload() {
   set +x
 
   version=$(cat docs/source/variables.adoc | cut -d' ' -f2 | head -n1)
-  LATEST=latest
+  LATEST=latest_test
   mkdir -p minishift/docs/$version minishift/docs/$LATEST
   cp docs/build/minishift-adoc.tar minishift/docs/$version/
   cp docs/build/minishift-adoc.tar minishift/docs/$LATEST/
@@ -219,10 +219,10 @@ else
   source ~/jenkins-env # Source environment variables for minishift_ci user
   PASS=$(echo $CICO_API_KEY | cut -d'-' -f1-2)
 
-  if [[ "$JOB_NAME" = "minishift-docs" ]]; then
+  if [[ "$JOB_NAME" != "minishift-docs" ]]; then
     prepare;
     cd gopath/src/github.com/minishift/minishift
-    make gen_adoc_tar
+    make gen_adoc_tar IMAGE_UID=$(id -u)
     docs_tar_upload $PASS
   else
     setup_kvm_docker_machine_driver;
@@ -230,5 +230,6 @@ else
     cd $GOPATH/src/github.com/minishift/minishift
     run_tests;
     artifacts_upload_on_pr_and_master_trigger $PASS;
+    make gen_adoc_tar IMAGE_UID=$(id -u)
   fi
 fi

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -14,7 +14,12 @@
 
 FROM ruby:2.4
 
-RUN apt-get update && apt-get install -y pandoc
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update -qq && apt-get install -y pandoc locales -qq && locale-gen en_US.UTF-8 en_us && dpkg-reconfigure locales && dpkg-reconfigure locales && locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
 
 ARG uid
 ENV UID=${uid:-1000}
@@ -25,6 +30,8 @@ RUN chown docs:docs /home/docs
 
 # From here we run everything as dev user
 USER docs
+
+RUN echo locale
 
 ADD Gemfile .
 ADD Gemfile.lock .

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -24,7 +24,7 @@ end
 task :clean do
   rm_f Rake::FileList.new("#{GENERATED_ADOC_DIR}/*.adoc")
   rm_rf BUILD_DIR
-  rm ADOC_VARIABLES
+  rm_f ADOC_VARIABLES
 end
 
 file TOPIC_MAP => [:init, 'source/_topic_map.yml'] do
@@ -78,7 +78,7 @@ task :adoc_tar => [:init, :adoc_variables, :markdown_to_asciidoc] do
       file_list.each { |f|
         tar.add_file(f, 0444) { |io|
           if File.extname(f) == ".adoc" then
-            adoc_content = File.read(f)
+            adoc_content = File.read(f, encoding: "ISO8859-1:utf-8")
             adoc_content = adoc_content.gsub(/include::.*variables\.adoc\[\]/, "include::minishift/variables.adoc[]")
             io.write(adoc_content)
           else

--- a/docs/source/developing/writing-docs.adoc
+++ b/docs/source/developing/writing-docs.adoc
@@ -31,21 +31,40 @@ link:../command-ref/minishift_docker-env{outfilesuffix}[`minishift docker-env`].
 
 To build the Docker image, run:
 
-[source,sh]
 ----
 $ make build_docs_container
 ----
 
 To generate the documentation into the directory `docs/build`, run:
 
-[source,sh]
 ----
 $ make gen_docs
 ----
 
+[NOTE]
+====
+Your local checkout of the sources are going to be mounted into the container in order to built the docs.
+Depending on your UID on the host, you might see file permissions problems when trying to run _gen_docs_.
+This is caused by the fact, that the _docs_ user used within the container uses per default a UID of 1000.
+This might conflict with the user id of the mounted docs sources.
+Your output might look like:
+----
+$ make gen_docs
+mkdir -p build
+rake aborted!
+Errno::EACCES: Permission denied @ dir_s_mkdir - build
+----
+
+In this case you need to build the container with a different user id.
+This will ensure that the _docs_ user in the container will be able to create files and directories.
+
+----
+$ make build_docs_container IMAGE_UID=$(id -u)
+----
+====
+
 To build and serve the documentation for editing, run:
 
-[source,sh]
 ----
 $ make serve_docs
 ----
@@ -66,7 +85,6 @@ meta data.
 
 This tarball can be built using:
 
-[source,sh]
 ----
 $ make gen_adoc_tar
 ----
@@ -90,7 +108,6 @@ Minishift documentation.
 Start with building the documentation tarball as described in <<section-deploying-minishift-docs>>,
 then follow these steps (assuming you are in the directory of your openshift-docs checkout):
 
-[source,sh]
 ----
 $ mkdir minishift
 $ cd minishift


### PR DESCRIPTION
Fix #840 

There are couple of issues: 
- `make gen_adoc_tar` couldn't find `source/variables.adoc` file so added force clean option
- Getting `invalid byte sequence in US-ASCII` error so fixed the encoding.
```
rake aborted!
ArgumentError: invalid byte sequence in US-ASCII
/home/docs/Rakefile:82:in `gsub'
/home/docs/Rakefile:82:in `block (5 levels) in <top (required)>'
/home/docs/Rakefile:79:in `block (4 levels) in <top (required)>'
/home/docs/Rakefile:78:in `block (3 levels) in <top (required)>'
/home/docs/Rakefile:77:in `block (2 levels) in <top (required)>'
/home/docs/Rakefile:76:in `open'
/home/docs/Rakefile:76:in `block in <top (required)>'
Tasks: TOP => adoc_tar
(See full trace by running task with --trace)
Makefile:99: recipe for target 'gen_adoc_tar' failed
make: *** [gen_adoc_tar] Error 1
```

Labelled the PR as WIP as changes in `centos_ci.sh` is for testing purpose.