### PR TITLE
Issue 856 Introduce method to port configure persistent volumes

### DIFF
--- a/addons/anyuid/anyuid.addon
+++ b/addons/anyuid/anyuid.addon
@@ -1,5 +1,10 @@
 # Name: anyuid
-# Description: Allows authenticated users to run images under a non pre-allocated UID
-# Url: https://access.redhat.com/documentation/en-us/openshift_enterprise/3.2/html/cluster_administration/admin-guide-manage-scc
+# Description: Changes the default security context constraints to allow pods to run as any user.
+# Url: https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines
 
 oc adm policy add-scc-to-group anyuid system:authenticated
+
+echo  Add-on '#{addon-name}' changed the default security context constraints to allow pods to run as any user.
+echo  Per default OpenShift runs containers using an arbitrarily assigned user ID.
+echo  Refer to https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#security-context-constraints and
+echo  https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines for more information.

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -23,6 +23,7 @@ import (
 
 	"strings"
 
+	"bytes"
 	units "github.com/docker/go-units"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/drivers"
@@ -34,6 +35,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/kubeconfig"
+	"github.com/minishift/minishift/pkg/minishift/addon/manager"
 	"github.com/minishift/minishift/pkg/minishift/cache"
 	"github.com/minishift/minishift/pkg/minishift/clusterup"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
@@ -44,9 +46,11 @@ import (
 	"github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/minishift/minishift/pkg/version"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"time"
 )
 
 const (
@@ -185,7 +189,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	//Create the host directories if not present
-	hostDirs := []string{viper.GetString(hostConfigDir), viper.GetString(hostDataDir), viper.GetString(hostVolumesDir)}
+	hostDirs := []string{viper.GetString(hostConfigDir), viper.GetString(hostDataDir), viper.GetString(hostVolumesDir), viper.GetString(hostPvDir)}
 	err = clusterup.EnsureHostDirectoriesExist(libMachineClient, hostDirs)
 	if err != nil {
 		fmt.Println("Error creating required host directories: ", err)
@@ -231,16 +235,76 @@ func postClusterUp(machineName string, ip string, port int, routingSuffix string
 		atexit.Exit(1)
 	}
 
-	applyAddOns(ip, routingSuffix, ocPath, kubeConfigPath, sshCommander)
+	addOnManager := addon.GetAddOnManager()
+	configurePersistentVolumes(addOnManager, sshCommander, ocRunner)
+	applyAddOns(addOnManager, ip, routingSuffix, ocPath, kubeConfigPath, sshCommander)
 }
 
-func applyAddOns(ip string, routingSuffix string, ocPath string, kubeConfigPath string, sshCommander provision.SSHCommander) {
-	addOnManager := addon.GetAddOnManager()
+func applyAddOns(addOnManager *manager.AddOnManager, ip string, routingSuffix string, ocPath string, kubeConfigPath string, sshCommander provision.SSHCommander) {
 	err := addOnManager.Apply(addon.GetExecutionContext(ip, routingSuffix, ocPath, kubeConfigPath, sshCommander))
 	if err != nil {
 		fmt.Println("Error executing addon commands: ", err)
 		atexit.Exit(1)
 	}
+}
+
+// TODO - persistent volume creation should really be fixed upstream, aka 'cluster up'. See https://github.com/openshift/origin/issues/14076 (HF)
+// configurePersistentVolumes makes sure that the default persistent volumes created by 'cluster up' have the right permissions - see https://github.com/minishift/minishift/issues/856
+func configurePersistentVolumes(addOnManager *manager.AddOnManager, sshCommander provision.SSHCommander, ocRunner *oc.OcRunner) error {
+	// don't apply this if anyuid is not enabled
+	anyuid := addOnManager.Get("anyuid")
+	if anyuid == nil || !anyuid.IsEnabled() {
+		return nil
+	}
+
+	fmt.Print("-- Waiting for persistent volumes to be created ... ")
+
+	hostPvDir := viper.GetString(hostPvDir)
+
+	var out, err *bytes.Buffer
+
+	// poll the status of the persistent-volume-setup job to determine when the persitent volume creates is completed
+	for {
+		out = new(bytes.Buffer)
+		err = new(bytes.Buffer)
+		exitStatus := ocRunner.Run("get job persistent-volume-setup -n default -o 'jsonpath={ .status.active }'", out, err)
+
+		if exitStatus != 0 || len(err.String()) > 0 {
+			return errors.New("Unable to monitor persistent volume creation")
+		}
+
+		if out.String() != "1" {
+			break
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	// verify the job succeeded
+	out = new(bytes.Buffer)
+	err = new(bytes.Buffer)
+	exitStatus := ocRunner.Run("get job persistent-volume-setup -n default -o 'jsonpath={ .status.succeeded }'", out, err)
+
+	if exitStatus != 0 || len(err.String()) > 0 || out.String() != "1" {
+		return errors.New("Persistent volume creation failed")
+	}
+
+	cmd := fmt.Sprintf("sudo chmod -R 777 %s/pv*", hostPvDir)
+	sshCommander.SSHCommand(cmd)
+
+	// if we have SELinux enabled we need to sort things out there as well
+	// 'cluster up' does this as well, but we do it here as well to have all required actions collected in one
+	// place, instead of relying on some implicit knowledge on what 'cluster up does (HF)
+	cmd = fmt.Sprintf("sudo which chcon; if [ $? -eq 0 ]; then chcon -R -t svirt_sandbox_file_t %s/*; fi", hostPvDir)
+	sshCommander.SSHCommand(cmd)
+
+	cmd = fmt.Sprintf("sudo which restorecon; if [ $? -eq 0 ]; then restorecon -R %s; fi", hostPvDir)
+	sshCommander.SSHCommand(cmd)
+
+	fmt.Println("OK")
+	fmt.Println()
+
+	return nil
 }
 
 func automountHostfolders(driver drivers.Driver) {

--- a/pkg/minishift/addon/command/oc_command.go
+++ b/pkg/minishift/addon/command/oc_command.go
@@ -19,6 +19,7 @@ package command
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -41,7 +42,7 @@ func (c *OcCommand) doExecute(ec *ExecutionContext) error {
 	fmt.Print(".")
 
 	commander := ec.GetOcCommander()
-	exitStatus := commander.Run(ec.Interpolate(cmd), os.Stdout, os.Stdin)
+	exitStatus := commander.Run(ec.Interpolate(cmd), ioutil.Discard, os.Stdin)
 	if exitStatus != 0 {
 		return errors.New(fmt.Sprintf("Error executing command %s.", c.String()))
 	}

--- a/pkg/minishift/addon/manager/addon_manager.go
+++ b/pkg/minishift/addon/manager/addon_manager.go
@@ -168,7 +168,7 @@ func (m *AddOnManager) String() string {
 }
 
 func (m *AddOnManager) applyAddOn(addOn addon.AddOn, context *command.ExecutionContext) error {
-	fmt.Print(fmt.Sprintf("Applying addon %s:", addOn.MetaData().Name()))
+	fmt.Print(fmt.Sprintf("-- Applying addon '%s':", addOn.MetaData().Name()))
 	context.AddToContext("addon-name", addOn.MetaData().Name())
 	defer context.RemoveFromContext("addon-name")
 

--- a/pkg/minishift/addon/parser/addon_parser_test.go
+++ b/pkg/minishift/addon/parser/addon_parser_test.go
@@ -94,7 +94,7 @@ func Test_successful_parsing_of_addon_dir(t *testing.T) {
 		t.Fatalf("Unexpected addon name: '%s'. Expected '%s'", addOn.MetaData().Name(), expectedName)
 	}
 
-	expectedNumberOfCommands := 1
+	expectedNumberOfCommands := 5
 	if len(addOn.Commands()) != expectedNumberOfCommands {
 		t.Errorf("Unexpected number of commands. Found %d, but expected %d", len(addOn.Commands()), expectedNumberOfCommands)
 	}


### PR DESCRIPTION
Addresses issue #856

- Once persistent volumes are created global permissions will be set to allow pods to write to persistent volume
- Silenced oc stdout for more consistent output diring bootstrap
- Adding echo statements to anyuid add-on to make it more explicit what the add-on does