### PR TITLE
Issue #874 Implementation to run integration test for downstream bits

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -6,7 +6,7 @@ Feature: Basic
 
   Scenario: Starting Minishift
     Given Minishift has state "Does Not Exist"
-     When executing "minishift start --docker-env=FOO=BAR --docker-env=BAZ=BAT" succeeds
+     When executing "minishift start" succeeds
      Then Minishift should have state "Running"
 
   Scenario: OpenShift is ready after startup
@@ -100,15 +100,6 @@ Feature: Basic
      Then stdout should contain
       """
       hello
-      """
-
-  Scenario: User is able to set custom Docker specific environment variables
-    Given Minishift has state "Running"
-     When executing "minishift ssh cat /var/lib/boot2docker/profile" succeeds
-     Then stdout should contain
-      """
-      export "FOO=BAR"
-      export "BAZ=BAT"
       """
 
   Scenario: User is able to retrieve host and port of OpenShift registry

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -108,6 +108,9 @@ func FeatureContext(s *godog.Suite) {
 
 	s.BeforeSuite(func() {
 		testDir = setUp()
+		if runner.IsCDK() {
+			runner.CDKSetup()
+		}
 		fmt.Println("Running Integration test in:", testDir)
 		fmt.Println("using binary:", givenPath)
 	})

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -81,6 +81,19 @@ func (m *MinishiftRunner) Start() {
 	m.RunCommand(fmt.Sprintf("start %s", m.CommandArgs))
 }
 
+func (m *MinishiftRunner) CDKSetup() {
+	if (os.Getenv("MINISHIFT_USERNAME") == "") || (os.Getenv("MINISHIFT_PASSWORD") == "") {
+		fmt.Println("Either MINISHIFT_USERNAME or MINISHIFT_PASSWORD is not set as environment variable")
+		os.Exit(1)
+	}
+	m.RunCommand(fmt.Sprintf("setup-cdk --force --minishift-home %s", os.Getenv(constants.MiniShiftHomeEnv)))
+}
+
+func (m *MinishiftRunner) IsCDK() bool {
+	cmdOut, _, _ := m.RunCommand("-h")
+	return strings.Contains(cmdOut, "setup-cdk")
+}
+
 func (m *MinishiftRunner) EnsureRunning() {
 	if m.GetStatus() != "Running" {
 		m.Start()


### PR DESCRIPTION
I did test and it works as expected but user should have RHN username/password as environment variable. 

One test scenario fail because it's specific to b2d image.

```cucumber
  Scenario: User is able to set custom Docker specific environment variables
    Given Minishift has state "Running"
     When executing "minishift ssh cat /var/lib/boot2docker/profile" succeeds
     Then stdout should contain
      """
      export "FOO=BAR"
      export "BAZ=BAT"
      """

--- Failed steps:

    Then  stdout should contain # features/basic.feature:62
      Error: Output did not match. Expected: export "FOO=BAR"
export "BAZ=BAT", Actual: 
```
