### PR TITLE
Issue #878 Fail to escape password with special charachers

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -531,7 +531,7 @@ func ocSupportFlag(cmdName string, flag string) bool {
 
 func setSubcriptionManagerParameters() {
 	cluster.RegistrationParameters.Username = viper.GetString(username)
-	cluster.RegistrationParameters.Password = util.EscapeStringForSSHUse(viper.GetString(password))
+	cluster.RegistrationParameters.Password = viper.GetString(password)
 }
 
 func getConfigClusterName(ip string, port int) string {

--- a/docs/source/using/troubleshooting.adoc
+++ b/docs/source/using/troubleshooting.adoc
@@ -21,7 +21,9 @@ special characters can trigger variable interpolation and therefore
 cause passwords to fail.
 
 Workaround: When creating and entering passwords, wrap the string with
-single quotes in the following format: `<password>`
+single quotes in the following format: `'<password>'`. If your password
+contain single quote ( `'` ) then do check the escaping string for your
+current shell. For example bash have escape string `'"'"'` for single quote.
 
 [[minishift-delete-fails-undefine-snapshots]]
 == Undefining virsh snapshots fail

--- a/pkg/minishift/registration/redhat.go
+++ b/pkg/minishift/registration/redhat.go
@@ -57,7 +57,7 @@ func (registrator *RedHatRegistrator) Register(param *RegistrationParameters) er
 		if strings.Contains(output, "not registered") {
 			subscriptionCommand := fmt.Sprintf("sudo -E subscription-manager register --auto-attach "+
 				"--username %s "+
-				"--password %s ", param.Username, param.Password)
+				"--password '%s' ", param.Username, param.Password)
 			if _, err := registrator.SSHCommand(subscriptionCommand); err != nil {
 				return err
 			}

--- a/pkg/minishift/registration/redhat_test.go
+++ b/pkg/minishift/registration/redhat_test.go
@@ -30,7 +30,7 @@ var (
 		Username: "foo",
 		Password: "foo",
 	}
-	expectedCMDRegistration = fmt.Sprintf("sudo -E subscription-manager register --auto-attach --username %s --password %s ",
+	expectedCMDRegistration = fmt.Sprintf("sudo -E subscription-manager register --auto-attach --username %s --password '%s' ",
 		param.Username, param.Password)
 	expectedCMDUnregistration = "sudo -E subscription-manager unregister"
 )

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -108,16 +108,6 @@ func (m MultiError) ToError() error {
 	return fmt.Errorf(strings.Join(errStrings, "\n"))
 }
 
-// EscapeStringForSSHUse will parse string and replace
-// shell special characters with escape
-func EscapeStringForSSHUse(s string) string {
-	r := strings.NewReplacer("$", "\\$",
-		`"`, `\"`,
-		"`", "\\`",
-		`\`, `\\`)
-	return r.Replace(s)
-}
-
 func VersionOrdinal(version string) string {
 	// ISO/IEC 14651:2011
 	// https://www.iso.org/standard/57976.html

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -60,19 +60,6 @@ func TestRetry(t *testing.T) {
 
 }
 
-func TestEscapeStringForSSHUse(t *testing.T) {
-	experimentstring := map[string]string{
-		`Pa"ssw\ord$$`: `Pa\"ssw\\ord\$\$`,
-		`Password`:     `Password`,
-		"Passwo`rd":    "Passwo\\`rd",
-	}
-	for pass, expected := range experimentstring {
-		if EscapeStringForSSHUse(pass) != expected {
-			t.Fatalf("Expected '%s' Got '%s'", expected, EscapeStringForSSHUse(pass))
-		}
-	}
-}
-
 func TestValidateProxyURI(t *testing.T) {
 	urlList := map[string]bool{
 		"http://foo.com:3128":          true,


### PR DESCRIPTION
Basically the way sshCommander works is it will take the string as it is and then start ssh session. when it start session it is always be a new shell so if we want to escape special characters then we need to make sure string we we are passing should have `'<Password>'`.