### PR TITLE
Issue #718 Downloading initial ISO and oc binary should support HTTP proxy

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -95,6 +95,7 @@ var (
 	registryMirror   []string
 	openShiftEnv     []string
 	shellProxyEnv    string
+	proxyUrl         string
 )
 
 // startCmd represents the start command
@@ -163,6 +164,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		HostOnlyCIDR:     viper.GetString(hostOnlyCIDR),
 		OpenShiftVersion: viper.GetString(openshiftVersion),
 		ShellProxyEnv:    shellProxyEnv,
+		ProxyUrl:         proxyUrl,
 	}
 
 	fmt.Printf("Starting local OpenShift cluster using '%s' hypervisor...\n", config.VMDriver)
@@ -347,9 +349,11 @@ func setOcProxy() {
 func setShellProxy() {
 	if viper.IsSet(httpProxy) {
 		shellProxyEnv += fmt.Sprintf("http_proxy=%s ", viper.GetString(httpProxy))
+		proxyUrl = viper.GetString(httpProxy)
 	}
 	if viper.IsSet(httpsProxy) {
 		shellProxyEnv += fmt.Sprintf("https_proxy=%s ", viper.GetString(httpsProxy))
+		proxyUrl = viper.GetString(httpsProxy)
 	}
 	if viper.IsSet(noProxyList) {
 		shellProxyEnv += fmt.Sprintf("no_proxy=%s", viper.GetString(noProxyList))
@@ -441,6 +445,7 @@ func clusterUp(config *cluster.MachineConfig, ip string) {
 	oc := cache.Oc{
 		OpenShiftVersion:  config.OpenShiftVersion,
 		MinishiftCacheDir: filepath.Join(constants.Minipath, "cache"),
+		ProxyUrl:          proxyUrl,
 	}
 	if err := oc.EnsureIsCached(); err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintln("Error starting the cluster: ", err))

--- a/cmd/minishift/cmd/start_test.go
+++ b/cmd/minishift/cmd/start_test.go
@@ -294,6 +294,8 @@ func TestClusterUpWithProxyFlag(t *testing.T) {
 	viper.Set("no-proxy", "10.0.0.1")
 
 	setOcProxy()
+	// To make sure oc download doesn't take localhost:3128 proxy in account
+	proxyUrl = ""
 
 	clusterUp(&testMachineConfig, testIp)
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -188,6 +188,7 @@ type MachineConfig struct {
 	HostOnlyCIDR     string // Only used by the virtualbox driver
 	OpenShiftVersion string
 	ShellProxyEnv    string // Only used for proxy purpose
+	ProxyUrl         string // Only used for proxy purpose
 }
 
 func engineOptions(config MachineConfig) *engine.Options {
@@ -214,7 +215,9 @@ func (m *MachineConfig) CacheMinikubeISOFromURL() error {
 	fmt.Println(fmt.Sprintf("Downloading ISO '%s'", m.MinikubeISO))
 
 	// store the iso inside the MINISHIFT_HOME dir
-	response, err := http.Get(m.MinikubeISO)
+	myClient := util.GetHttpClient(m.ProxyUrl)
+
+	response, err := myClient.Get(m.MinikubeISO)
 	if err != nil {
 		return err
 	}

--- a/pkg/minishift/cache/oc_caching.go
+++ b/pkg/minishift/cache/oc_caching.go
@@ -31,6 +31,7 @@ const OC_CACHE_DIR = "oc"
 type Oc struct {
 	OpenShiftVersion  string
 	MinishiftCacheDir string
+	ProxyUrl          string
 }
 
 func (oc *Oc) EnsureIsCached() error {
@@ -58,7 +59,7 @@ func (oc *Oc) isCached() bool {
 // cacheOc downloads and caches the oc binary into the minishift directory
 func (oc *Oc) cacheOc() error {
 	if !oc.isCached() {
-		if err := github.DownloadOpenShiftReleaseBinary(github.OC, minishiftos.CurrentOS(), oc.OpenShiftVersion, oc.GetCacheFilepath()); err != nil {
+		if err := github.DownloadOpenShiftReleaseBinary(github.OC, minishiftos.CurrentOS(), oc.OpenShiftVersion, oc.GetCacheFilepath(), oc.ProxyUrl); err != nil {
 			return errors.Wrapf(err, "Error attempting to download and cache %s", github.OC.String())
 		}
 	}

--- a/pkg/minishift/cache/oc_caching_test.go
+++ b/pkg/minishift/cache/oc_caching_test.go
@@ -76,7 +76,7 @@ func setUp(t *testing.T) {
 	if err != nil {
 		t.Error()
 	}
-	testOc = Oc{"v1.3.1", filepath.Join(testDir, "cache")}
+	testOc = Oc{"v1.3.1", filepath.Join(testDir, "cache"), ""}
 }
 
 func EnsureGitHubApiAccessTokenSet(t *testing.T) {

--- a/pkg/minishift/cache/openshift_caching.go
+++ b/pkg/minishift/cache/openshift_caching.go
@@ -45,7 +45,8 @@ const (
 
 // openshiftCacher is a struct with methods designed for caching openshift
 type openshiftCacher struct {
-	config cluster.MachineConfig
+	config   cluster.MachineConfig
+	ProxyUrl string
 }
 
 func (l *openshiftCacher) getOpenShiftCacheFilepath() string {
@@ -107,7 +108,7 @@ func (l *openshiftCacher) updateOpenShiftFromURI(client *ssh.Client) error {
 
 func (l *openshiftCacher) updateOpenShiftFromRelease(client *ssh.Client) error {
 	if !l.isOpenShiftCached() {
-		if err := github.DownloadOpenShiftReleaseBinary(github.OC, minishiftos.LINUX, l.config.OpenShiftVersion, l.getOpenShiftCacheFilepath()); err != nil {
+		if err := github.DownloadOpenShiftReleaseBinary(github.OC, minishiftos.LINUX, l.config.OpenShiftVersion, l.getOpenShiftCacheFilepath(), l.ProxyUrl); err != nil {
 			return errors.Wrap(err, "Error attempting to download and cache openshift")
 		}
 	}

--- a/pkg/util/github/github.go
+++ b/pkg/util/github/github.go
@@ -33,6 +33,7 @@ import (
 
 	"crypto/sha256"
 	"fmt"
+	"github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/archive"
 	minishiftos "github.com/minishift/minishift/pkg/util/os"
 	"io/ioutil"
@@ -88,7 +89,7 @@ func GetGitHubApiToken() string {
 	return ""
 }
 
-func DownloadOpenShiftReleaseBinary(binaryType OpenShiftBinaryType, osType minishiftos.OS, version, outputPath string) error {
+func DownloadOpenShiftReleaseBinary(binaryType OpenShiftBinaryType, osType minishiftos.OS, version, outputPath string, proxyUrl string) error {
 	client := Client()
 	var (
 		err     error
@@ -120,13 +121,14 @@ func DownloadOpenShiftReleaseBinary(binaryType OpenShiftBinaryType, osType minis
 
 	// Download the asset
 	var asset io.Reader
-	asset, url, err := client.Repositories.DownloadReleaseAsset("openshift", "origin", assetID)
+	asset, uri, err := client.Repositories.DownloadReleaseAsset("openshift", "origin", assetID)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Cannot download OpenShift release asset %d", assetID))
 	}
-	if len(url) > 0 {
+	if len(uri) > 0 {
 		fmt.Println(fmt.Sprintf("Downloading OpenShift binary '%s' version '%s'", binaryType.String(), *release.TagName))
-		httpResp, err := http.Get(url)
+		myClient := util.GetHttpClient(proxyUrl)
+		httpResp, err := myClient.Get(uri)
 		if err != nil {
 			return errors.Wrap(err, "Cannot download OpenShift release asset.")
 		}

--- a/pkg/util/github/github_test.go
+++ b/pkg/util/github/github_test.go
@@ -95,7 +95,7 @@ func TestDownloadOc(t *testing.T) {
 			continue
 		}
 
-		err = DownloadOpenShiftReleaseBinary(testAsset.binary, testAsset.os, testAsset.version, testDir)
+		err = DownloadOpenShiftReleaseBinary(testAsset.binary, testAsset.os, testAsset.version, testDir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -133,7 +133,7 @@ func TestInvalidVersion(t *testing.T) {
 	defer os.RemoveAll(testDir)
 
 	dummyVersion := "foo"
-	err = DownloadOpenShiftReleaseBinary(OPENSHIFT, minishiftos.WINDOWS, dummyVersion, testDir)
+	err = DownloadOpenShiftReleaseBinary(OPENSHIFT, minishiftos.WINDOWS, dummyVersion, testDir, "")
 	if err == nil {
 		t.Fatal("There should have been an error")
 	}
@@ -153,7 +153,7 @@ func TestInvalidBinaryFormat(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	err = DownloadOpenShiftReleaseBinary(OPENSHIFT, minishiftos.WINDOWS, testVersion, testDir)
+	err = DownloadOpenShiftReleaseBinary(OPENSHIFT, minishiftos.WINDOWS, testVersion, testDir, "")
 	if err == nil {
 		t.Fatal("There should have been an error")
 	}
@@ -178,7 +178,7 @@ func Test_Download_Oc_1_4_1(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	err = DownloadOpenShiftReleaseBinary(OC, minishiftos.LINUX, "v1.4.1", testDir)
+	err = DownloadOpenShiftReleaseBinary(OC, minishiftos.LINUX, "v1.4.1", testDir, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/asaskevich/govalidator"
+	"net/http"
+	"net/url"
 )
 
 // Until endlessly loops the provided function until a message is received on the done channel.
@@ -139,4 +141,13 @@ func VersionOrdinal(version string) string {
 		vo[j]++
 	}
 	return string(vo)
+}
+
+func GetHttpClient(proxyUrl string) *http.Client {
+	myClient := http.DefaultClient
+	if proxyUrl != "" {
+		proxyUrl, _ := url.Parse(proxyUrl)
+		myClient = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}}
+	}
+	return myClient
 }


### PR DESCRIPTION
This patch will modify `http` client in case of proxy and use it to download iso and oc binary. Please test it, for me working as expected I can see traffic is going from proxy server.