### PR TITLE
Issue #924 Changes version output format to "minishift vX.X.X".

### DIFF
--- a/cmd/minishift/cmd/version.go
+++ b/cmd/minishift/cmd/version.go
@@ -32,7 +32,7 @@ var versionCmd = &cobra.Command{
 		RootCmd.PersistentPreRun(cmd, args)
 	},
 	Run: func(command *cobra.Command, args []string) {
-		fmt.Println("Minishift version:", version.GetVersion())
+		fmt.Println("minishift", version.GetVersion())
 	},
 }
 

--- a/cmd/minishift/cmd/version.go
+++ b/cmd/minishift/cmd/version.go
@@ -32,7 +32,7 @@ var versionCmd = &cobra.Command{
 		RootCmd.PersistentPreRun(cmd, args)
 	},
 	Run: func(command *cobra.Command, args []string) {
-		fmt.Println("minishift", version.GetVersion())
+		fmt.Printf("minishift v%v\n", version.GetVersion())
 	},
 }
 


### PR DESCRIPTION
The version output format looks quite different to the output from `minishift openshift version` and `s2i version` which is a minor annoyance for automation.

Old format:
```bash
$ minishift version
Minishift version: 1.0.1
```

New format:
```bash
$ minishift version
minishift v1.0.1
```

Other tools with similar formats:
```
$ minishift openshift version
openshift v1.5.0+031cbe4
kubernetes v1.5.2+43a9be4
etcd 3.1.0
$ s2i version
s2i v1.1.6
```