### PR TITLE
Issue #922 Step '"minishift start" succeeds' does not fail when oc download fails

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -80,31 +80,31 @@ func FeatureContext(s *godog.Suite) {
 	minishift = &Minishift{runner: runner}
 
 	// steps to execute minishift commands
-	s.Step(`Minishift (?:has|should have) state "([^"]*)"`, minishift.shouldHaveState)
-	s.Step(`executing "minishift ([^"]*)"`, minishift.executingMinishiftCommand)
-	s.Step(`executing "minishift ([^"]*)" (.*)$`, executingMinishiftCommandSucceedsOrFails)
-	s.Step(`([^"]*) of command "minishift ([^"]*)" is equal to "([^"]*)"`, commandReturnEquals)
-	s.Step(`([^"]*) of command "minishift ([^"]*)" contains "([^"]*)"`, commandReturnContains)
+	s.Step(`Minishift (?:has|should have) state "([^"]*)"$`, minishift.shouldHaveState)
+	s.Step(`executing "minishift ([^"]*)"$`, minishift.executingMinishiftCommand)
+	s.Step(`executing "minishift ([^"]*)" (succeeds|fails)$`, executingMinishiftCommandSucceedsOrFails)
+	s.Step(`([^"]*) of command "minishift ([^"]*)" is equal to "([^"]*)"$`, commandReturnEquals)
+	s.Step(`([^"]*) of command "minishift ([^"]*)" contains "([^"]*)"$`, commandReturnContains)
 
 	// steps for running oc
 	s.Step(`executing "oc ([^"]*)" retrying (\d+) times with wait period of (\d+) seconds$`, minishift.executingRetryingTimesWithWaitPeriodOfSeconds)
-	s.Step(`executing "oc ([^"]*)`, minishift.executingOcCommand)
-	s.Step(`executing "oc ([^"]*)" succeeds$`, minishift.executingOcCommandSucceeds)
+	s.Step(`executing "oc ([^"]*)"$`, minishift.executingOcCommand)
+	s.Step(`executing "oc ([^"]*)" (succeeds|fails)$`, minishift.executingOcCommandSucceedsOrFails)
 
 	// steps to verify stdout and stderr of commands executed
-	s.Step(`([^"]*) should contain ([^"]*)`, commandReturnShouldContain)
-	s.Step(`([^"]*) should contain`, commandReturnShouldContainContent)
-	s.Step(`([^"]*) should equal ([^"]*)`, commandReturnShouldEqual)
-	s.Step(`([^"]*) should equal`, commandReturnShouldEqualContent)
-	s.Step(`([^"]*) should be empty`, commandReturnShouldBeEmpty)
-	s.Step(`([^"]*) should be valid ([^"]*)`, shouldBeInValidFormat)
+	s.Step(`([^"]*) should contain ([^"]*)$`, commandReturnShouldContain)
+	s.Step(`([^"]*) should contain$`, commandReturnShouldContainContent)
+	s.Step(`([^"]*) should equal ([^"]*)$`, commandReturnShouldEqual)
+	s.Step(`([^"]*) should equal$`, commandReturnShouldEqualContent)
+	s.Step(`([^"]*) should be empty$`, commandReturnShouldBeEmpty)
+	s.Step(`([^"]*) should be valid ([^"]*)$`, shouldBeInValidFormat)
 
 	// step for HTTP requests
-	s.Step(`(body|status code) of HTTP request to "([^"]*)" (?:|at "([^"]*)" )(contains|is equal to) "([^"]*)"`, verifyHTTPResponse)
+	s.Step(`(body|status code) of HTTP request to "([^"]*)" (?:|at "([^"]*)" )(contains|is equal to) "([^"]*)"$`, verifyHTTPResponse)
 
 	// steps for verifying config file content
-	s.Step(`JSON config file "([^"]*)" (contains|does not contain) key "(.*)" with value "(.*)"`, configContains)
-	s.Step(`JSON config file "([^"]*)" (contains|does not contain) key "(.*)"(.*)`, configContains)
+	s.Step(`JSON config file "([^"]*)" (contains|does not contain) key "(.*)" with value "(.*)"$`, configContains)
+	s.Step(`JSON config file "([^"]*)" (contains|does not contain) key "(.*)"(.*)$`, configContains)
 
 	s.BeforeSuite(func() {
 		testDir = setUp()
@@ -239,18 +239,12 @@ func executingMinishiftCommandSucceedsOrFails(command, expectedResult string) er
 	if err != nil {
 		return err
 	}
-	success := (lastCommandOutput.ExitCode != 0 || len(lastCommandOutput.StdErr) != 0)
-	switch expectedResult {
-	case "succeeds":
-		if success {
-			return fmt.Errorf("Command did not execute successfully. cmdExit: %d, cmdErr: %s", lastCommandOutput.ExitCode, lastCommandOutput.StdErr)
-		}
-	case "fails":
-		if success {
-			return fmt.Errorf("Command executed successfully, however was expected to fail. cmdExit: %d, cmdErr: %s", lastCommandOutput.ExitCode, lastCommandOutput.StdErr)
-		}
-	default:
-		return fmt.Errorf("Expected result: %s not recognized, please use: 'fails' or 'succeeds'", expectedResult)
+	commandFailed := (lastCommandOutput.ExitCode != 0 || len(lastCommandOutput.StdErr) != 0)
+	if expectedResult == "succeeds" && commandFailed == true {
+		return fmt.Errorf("Command did not execute successfully. cmdExit: %d, cmdErr: %s", lastCommandOutput.ExitCode, lastCommandOutput.StdErr)
+	}
+	if expectedResult == "fails" && commandFailed == false {
+		return fmt.Errorf("Command executed successfully, however was expected to fail. cmdExit: %d, cmdErr: %s", lastCommandOutput.ExitCode, lastCommandOutput.StdErr)
 	}
 	return nil
 }

--- a/test/integration/minishift.go
+++ b/test/integration/minishift.go
@@ -79,13 +79,17 @@ func (m *Minishift) executingOcCommand(command string) error {
 	return nil
 }
 
-func (m *Minishift) executingOcCommandSucceeds(command string) error {
+func (m *Minishift) executingOcCommandSucceedsOrFails(command, expectedResult string) error {
 	err := m.executingOcCommand(command)
 	if err != nil {
 		return err
 	}
-	if lastCommandOutput.ExitCode != 0 || len(lastCommandOutput.StdErr) != 0 {
+	commandFailed := (lastCommandOutput.ExitCode != 0 || len(lastCommandOutput.StdErr) != 0)
+	if expectedResult == "succeeds" && commandFailed == true {
 		return fmt.Errorf("Command did not execute successfully. cmdExit: %d, cmdErr: %s", lastCommandOutput.ExitCode, lastCommandOutput.StdErr)
+	}
+	if expectedResult == "fails" && commandFailed == false {
+		return fmt.Errorf("Command executed successfully, however was expected to fail. cmdExit: %d, cmdErr: %s", lastCommandOutput.ExitCode, lastCommandOutput.StdErr)
 	}
 
 	return nil


### PR DESCRIPTION
Addresses issue #922

Fixing logical mistake in executingMinishiftCommandSucceedsOrFails() and renaming `success` variable to `failure` which better suits the result of `lastCommandOutput.ExitCode != 0 || len(lastCommandOutput.StdErr`.

Moved `s.Step(`executing "minishift ([^"]*)" (.*)$`, executingMinishiftCommandSucceedsOrFails)` before step for executingMinishiftCommand as this was matching first and due to this fact executingMinishiftCommandSucceedsOrFails() has never been actually used.



