### PR TITLE
[WIP] Issue #639 Install default addons as part of start command

### DIFF
--- a/cmd/minishift/cmd/addon/addon.go
+++ b/cmd/minishift/cmd/addon/addon.go
@@ -20,6 +20,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	forceFlag  = "force"
+	enableFlag = "enable"
+)
+
+var (
+	defaultAssets = []string{"anyuid", "admin-user"}
+	force         bool
+	enable        bool
+)
+
 var AddonsCmd = &cobra.Command{
 	Use:   "addons SUBCOMMAND [flags]",
 	Short: "Manages Minishift add-ons",

--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -19,9 +19,6 @@ package addon
 import (
 	"fmt"
 
-	"strings"
-
-	"github.com/minishift/minishift/out/bindata"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -29,17 +26,6 @@ import (
 const (
 	unspecifiedSourceError   = "You need to specify the source for the add-on."
 	failedPluginInstallation = "Add-on installation failed with the error: %s"
-
-	forceFlag    = "force"
-	enableFlag   = "enable"
-	defaultsFlag = "defaults"
-)
-
-var (
-	defaultAssets = []string{"anyuid", "admin-user"}
-	force         bool
-	enable        bool
-	defaults      bool
 )
 
 var addonsInstallCmd = &cobra.Command{
@@ -52,18 +38,11 @@ var addonsInstallCmd = &cobra.Command{
 func init() {
 	addonsInstallCmd.Flags().BoolVar(&force, forceFlag, false, "Forces the installation of the add-on even if the add-on was previously installed.")
 	addonsInstallCmd.Flags().BoolVar(&enable, enableFlag, false, "If true, installs and enables the specified add-on with the default priority.")
-	addonsInstallCmd.Flags().BoolVar(&defaults, defaultsFlag, false, "If true, installs all Minishift default add-ons.")
 	AddonsCmd.AddCommand(addonsInstallCmd)
 }
 
 func runInstallAddon(cmd *cobra.Command, args []string) {
 	addOnManager := GetAddOnManager()
-	if defaults {
-		unpackAddons(addOnManager.BaseDir())
-		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(defaultAssets, ", ")))
-		return
-	}
-
 	if len(args) != 1 {
 		atexit.ExitWithMessage(1, unspecifiedSourceError)
 	}
@@ -80,14 +59,5 @@ func runInstallAddon(cmd *cobra.Command, args []string) {
 		// need to get a new manager
 		addOnManager := GetAddOnManager()
 		enableAddon(addOnManager, addOnName, 0)
-	}
-}
-
-func unpackAddons(dir string) {
-	for _, asset := range defaultAssets {
-		err := bindata.RestoreAssets(dir, asset)
-		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Unable to install default add-ons: %s", err.Error()))
-		}
 	}
 }

--- a/cmd/minishift/cmd/addon/util.go
+++ b/cmd/minishift/cmd/addon/util.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/cmd/minishift/cmd/config"
+	"github.com/minishift/minishift/out/bindata"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/addon"
 	"github.com/minishift/minishift/pkg/minishift/addon/command"
@@ -30,11 +31,11 @@ import (
 )
 
 const (
-	ip_key             = "ip"
-	routing_suffix_key = "routing-suffix"
+	ipKey            = "ip"
+	routingSuffixKey = "routing-suffix"
 )
 
-// getAddOnManager returns the addon manager
+// GetAddOnManager returns the addon manager
 func GetAddOnManager() *manager.AddOnManager {
 	addOnConfigs := getAddOnConfiguration()
 	m, err := manager.NewAddOnManager(constants.MakeMiniPath("addons"), addOnConfigs)
@@ -45,14 +46,15 @@ func GetAddOnManager() *manager.AddOnManager {
 	return m
 }
 
+// GetExecutionContext returns the currently executing context
 func GetExecutionContext(ip string, routingSuffix string, ocPath string, kubeConfigPath string, sshCommander provision.SSHCommander) *command.ExecutionContext {
 	context, err := command.NewExecutionContext(ocPath, kubeConfigPath, sshCommander)
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to initialise execution context: %s", err.Error()))
 	}
 
-	context.AddToContext(ip_key, ip)
-	context.AddToContext(routing_suffix_key, routingSuffix)
+	context.AddToContext(ipKey, ip)
+	context.AddToContext(routingSuffixKey, routingSuffix)
 
 	return context
 }
@@ -104,4 +106,16 @@ func fillStruct(data map[string]interface{}, result interface{}) {
 		val := t.FieldByName(k)
 		val.Set(reflect.ValueOf(v))
 	}
+}
+
+// UnpackAddons unpack the addons
+func UnpackAddons(dir string) error {
+	for _, asset := range defaultAssets {
+		err := bindata.RestoreAssets(dir, asset)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -119,7 +119,7 @@ func configurableFields() string {
 	return strings.Join(fields, "\n")
 }
 
-// ReadConfig reads in the JSON minishift config
+// ReadConfig reads the config from $MINISHIFT_HOME/config/config.json file
 func ReadConfig() (MinishiftConfig, error) {
 	f, err := os.Open(constants.ConfigFile)
 	if err != nil {
@@ -137,7 +137,7 @@ func ReadConfig() (MinishiftConfig, error) {
 	return m, nil
 }
 
-// Writes a minikube config to the JSON file
+// Writes a config to the $MINISHIFT_HOME/config/config.json file
 func WriteConfig(m MinishiftConfig) error {
 	f, err := os.Create(constants.ConfigFile)
 	if err != nil {

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -33,6 +33,7 @@ import (
 	cmdOpenshift "github.com/minishift/minishift/cmd/minishift/cmd/openshift"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -62,6 +63,8 @@ var viperWhiteList = []string{
 	"log_dir",
 }
 
+var homeDirExists bool
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "minishift",
@@ -69,6 +72,11 @@ var RootCmd = &cobra.Command{
 	Long:  `Minishift is a command-line tool that provisions and manages single-node OpenShift clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		var err error
+
+		if filehelper.Exists(constants.Minipath) {
+			homeDirExists = true
+		}
+
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {
 				glog.Exitf("Error creating minishift directory: %s", err)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -47,6 +47,7 @@ import (
 	"github.com/minishift/minishift/pkg/minishift/provisioner"
 	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
 	"github.com/minishift/minishift/pkg/util"
+	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/minishift/minishift/pkg/version"
 	"github.com/pkg/errors"
@@ -236,6 +237,13 @@ func postClusterUp(machineName string, ip string, port int, routingSuffix string
 	if err := ocRunner.AddCliContext(machineName, ip, user, project); err != nil {
 		fmt.Println("Error adding OpenShift context: ", err)
 		atexit.Exit(1)
+	}
+
+	// Run the default addons if MINISHIFT_HOME dir does not exist or empty
+	if !homeDirExists || filehelper.IsDirEmpty(constants.Minipath) {
+		fmt.Print("-- Installing default addons ... ")
+		addon.UnpackAddons(constants.MakeMiniPath("addons"))
+		fmt.Println("OK")
 	}
 
 	addOnManager := addon.GetAddOnManager()

--- a/pkg/util/filehelper/file.go
+++ b/pkg/util/filehelper/file.go
@@ -152,3 +152,20 @@ func CopyDir(src string, dst string) (err error) {
 
 	return
 }
+
+// IsDirEmpty checks whether directory is empty or not
+// https://stackoverflow.com/a/30708914/1120530
+func IsDirEmpty(name string) bool {
+	f, err := os.Open(name)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 )
@@ -48,19 +47,6 @@ func Until(fn func() error, w io.Writer, name string, sleep time.Duration, done 
 
 func Pad(str string) string {
 	return fmt.Sprint("\n%s\n", str)
-}
-
-// If the file represented by path exists and
-// readable, return true otherwise return false.
-func CanReadFile(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-
-	defer f.Close()
-
-	return true
 }
 
 func Retry(attempts int, callback func() error) (err error) {


### PR DESCRIPTION
### This PR is just created for initial Review

Just added the installation of default addons as part of start command.

```
$ minishift start --iso-url file:///home/budhram/cache/iso/minishift-b2d.iso --memory 4096
Starting local OpenShift cluster using 'kvm' hypervisor...
Downloading OpenShift binary 'oc' version 'v1.5.1'
 19.96 MiB / 19.96 MiB [==========================================================================================================================] 100.00% 0s
-- Checking OpenShift client ... OK
.... 
   OpenShift server started.
   The server is accessible via web console at:
       https://192.168.42.207:8443

   You are logged in as:
       User:     developer
       Password: developer

   To login as administrator:
       oc login -u system:admin

-- Installing default addons ... OK


$ minishift addons list
- admin-user     : disabled   P(0)
- anyuid         : disabled   P(0)
```

Currently, working on automatic installation of addons as part of `minishift update` command. This seems to be trivial for Linux/macOS but bit difficult and need investigation on how to do it in Windows.
