### PR TITLE
[WIP] Issue #639 Install default addons as part of start/update command

### DIFF
--- a/cmd/minishift/cmd/addon/addon.go
+++ b/cmd/minishift/cmd/addon/addon.go
@@ -17,6 +17,7 @@ limitations under the License.
 package addon
 
 import (
+	"github.com/minishift/minishift/out/bindata"
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +28,10 @@ const (
 	noAddOnMessage  = "No add-on with the name %s is installed."
 )
 
+var (
+	defaultAssets = []string{"anyuid", "admin-user", "xpaas"}
+)
+
 var AddonsCmd = &cobra.Command{
 	Use:   "addons SUBCOMMAND [flags]",
 	Short: "Manages Minishift add-ons",
@@ -34,4 +39,12 @@ var AddonsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
+}
+
+func UnpackAddons(addonsDir string) error {
+	for _, asset := range defaultAssets {
+		return bindata.RestoreAssets(addonsDir, asset)
+	}
+
+	return nil
 }

--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -21,7 +21,6 @@ import (
 
 	"strings"
 
-	"github.com/minishift/minishift/out/bindata"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -36,10 +35,9 @@ const (
 )
 
 var (
-	defaultAssets = []string{"anyuid", "admin-user", "xpaas"}
-	force         bool
-	enable        bool
-	defaults      bool
+	force    bool
+	enable   bool
+	defaults bool
 )
 
 var addonsInstallCmd = &cobra.Command{
@@ -59,7 +57,7 @@ func init() {
 func runInstallAddon(cmd *cobra.Command, args []string) {
 	addOnManager := GetAddOnManager()
 	if defaults {
-		unpackAddons(addOnManager.BaseDir())
+		UnpackAddons(addOnManager.BaseDir())
 		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(defaultAssets, ", ")))
 		return
 	}
@@ -80,14 +78,5 @@ func runInstallAddon(cmd *cobra.Command, args []string) {
 		// need to get a new manager
 		addOnManager := GetAddOnManager()
 		enableAddon(addOnManager, addOnName, 0)
-	}
-}
-
-func unpackAddons(dir string) {
-	for _, asset := range defaultAssets {
-		err := bindata.RestoreAssets(dir, asset)
-		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Unable to install default add-ons: %s", err.Error()))
-		}
 	}
 }

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -119,7 +119,7 @@ func configurableFields() string {
 	return strings.Join(fields, "\n")
 }
 
-// ReadConfig reads in the JSON minishift config
+// ReadConfig reads the config from $MINISHIFT_HOME/config/config.json file
 func ReadConfig() (MinishiftConfig, error) {
 	f, err := os.Open(constants.ConfigFile)
 	if err != nil {
@@ -137,7 +137,7 @@ func ReadConfig() (MinishiftConfig, error) {
 	return m, nil
 }
 
-// Writes a minikube config to the JSON file
+// Writes a config to the $MINISHIFT_HOME/config/config.json file
 func WriteConfig(m MinishiftConfig) error {
 	f, err := os.Create(constants.ConfigFile)
 	if err != nil {

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -33,6 +33,7 @@ import (
 	cmdOpenshift "github.com/minishift/minishift/cmd/minishift/cmd/openshift"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -62,6 +63,11 @@ var viperWhiteList = []string{
 	"log_dir",
 }
 
+var (
+	homeDirExists bool
+	homeDirEmpty  bool
+)
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "minishift",
@@ -69,6 +75,14 @@ var RootCmd = &cobra.Command{
 	Long:  `Minishift is a command-line tool that provisions and manages single-node OpenShift clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		var err error
+
+		if filehelper.Exists(constants.Minipath) {
+			homeDirExists = true
+		}
+		if filehelper.IsDirEmpty(constants.Minipath) {
+			homeDirExists = true
+		}
+
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {
 				glog.Exitf("Error creating minishift directory: %s", err)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -156,6 +156,15 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	if !isRestart {
+		// Run the default addons if MINISHIFT_HOME dir does not exist or empty
+		if !homeDirExists || !homeDirEmpty {
+			fmt.Print("-- Installing default addons ... ")
+			if err := addon.UnpackAddons(constants.MakeMiniPath("addons")); err != nil {
+				atexit.ExitWithMessage(1, fmt.Sprintf("Error installing default addons : %s", err))
+			}
+			fmt.Println("OK")
+		}
+
 		postClusterUp(hostVm, clusterUpConfig)
 	}
 }

--- a/pkg/util/filehelper/file.go
+++ b/pkg/util/filehelper/file.go
@@ -152,3 +152,20 @@ func CopyDir(src string, dst string) (err error) {
 
 	return
 }
+
+// IsDirEmpty checks whether directory is empty or not
+// https://stackoverflow.com/a/30708914/1120530
+func IsDirEmpty(name string) bool {
+	f, err := os.Open(name)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 )
@@ -48,19 +47,6 @@ func Until(fn func() error, w io.Writer, name string, sleep time.Duration, done 
 
 func Pad(str string) string {
 	return fmt.Sprint("\n%s\n", str)
-}
-
-// If the file represented by path exists and
-// readable, return true otherwise return false.
-func CanReadFile(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-
-	defer f.Close()
-
-	return true
 }
 
 func Retry(attempts int, callback func() error) (err error) {


### PR DESCRIPTION
Fix #639 
@hferentschik , this PR works fine for Linux (tested locally). Might also work with macOS (untested).

This PR fails with Windows with usual error as we had seen `not supported by windows`.

Opened for review. Tests are yet to add, just want to make sure I am going in the right direction.