### PR TITLE
Issue #639 Install default addons as part of start/update command

### DIFF
--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -21,7 +21,7 @@ import (
 
 	"strings"
 
-	"github.com/minishift/minishift/out/bindata"
+	"github.com/minishift/minishift/cmd/minishift/cmd/util"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -36,10 +36,9 @@ const (
 )
 
 var (
-	defaultAssets = []string{"anyuid", "admin-user", "xpaas"}
-	force         bool
-	enable        bool
-	defaults      bool
+	force    bool
+	enable   bool
+	defaults bool
 )
 
 var addonsInstallCmd = &cobra.Command{
@@ -59,8 +58,8 @@ func init() {
 func runInstallAddon(cmd *cobra.Command, args []string) {
 	addOnManager := GetAddOnManager()
 	if defaults {
-		unpackAddons(addOnManager.BaseDir())
-		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(defaultAssets, ", ")))
+		util.UnpackAddons(addOnManager.BaseDir())
+		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(util.DefaultAssets, ", ")))
 		return
 	}
 
@@ -80,14 +79,5 @@ func runInstallAddon(cmd *cobra.Command, args []string) {
 		// need to get a new manager
 		addOnManager := GetAddOnManager()
 		enableAddon(addOnManager, addOnName, 0)
-	}
-}
-
-func unpackAddons(dir string) {
-	for _, asset := range defaultAssets {
-		err := bindata.RestoreAssets(dir, asset)
-		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Unable to install default add-ons: %s", err.Error()))
-		}
 	}
 }

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -120,7 +120,7 @@ func configurableFields() string {
 	return strings.Join(fields, "\n")
 }
 
-// ReadConfig reads in the JSON minishift config
+// ReadConfig reads the config from $MINISHIFT_HOME/config/config.json file
 func ReadConfig() (MinishiftConfig, error) {
 	f, err := os.Open(constants.ConfigFile)
 	if err != nil {
@@ -138,7 +138,7 @@ func ReadConfig() (MinishiftConfig, error) {
 	return m, nil
 }
 
-// Writes a minikube config to the JSON file
+// Writes a config to the $MINISHIFT_HOME/config/config.json file
 func WriteConfig(m MinishiftConfig) error {
 	f, err := os.Create(constants.ConfigFile)
 	if err != nil {

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -388,7 +388,7 @@ func ensureNotRunning(client *libmachine.Client, machineName string) {
 func validateOpenshiftVersion() {
 	requestedVersion := viper.GetString(startFlags.OpenshiftVersion.Name)
 
-	valid, err := clusterup.ValidateOpenshiftMinVersion(requestedVersion, constants.MinOpenshiftSuportedVersion)
+	valid, err := clusterup.ValidateOpenshiftMinVersion(requestedVersion, constants.MinOpenshiftSupportedVersion)
 	if err != nil {
 		atexit.ExitWithMessage(1, err.Error())
 	}
@@ -396,7 +396,7 @@ func validateOpenshiftVersion() {
 	if !valid {
 		fmt.Printf("Minishift does not support Openshift version %s. "+
 			"You need to use a version >= %s\n", viper.GetString(startFlags.OpenshiftVersion.Name),
-			constants.MinOpenshiftSuportedVersion)
+			constants.MinOpenshiftSupportedVersion)
 		atexit.Exit(1)
 	}
 

--- a/cmd/minishift/cmd/update_test.go
+++ b/cmd/minishift/cmd/update_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestCreateUpdateMarker(t *testing.T) {
+	testFile, err := ioutil.TempFile(os.TempDir(), "testFile")
+	testFileName := testFile.Name()
+	defer os.Remove(testFileName)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	expectedInstallAddon, expectedPreviousVersion := true, "1.0.0"
+	createUpdateMarker(testFileName, UpdateMarker{expectedInstallAddon, expectedPreviousVersion})
+
+	// Read json file
+	var markerData UpdateMarker
+
+	file, err := ioutil.ReadFile(testFileName)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	json.Unmarshal(file, &markerData)
+	if markerData.InstallAddon != expectedInstallAddon {
+		t.Fatalf("Expected allow installation of addon to be %t but got %t.", expectedInstallAddon, markerData.InstallAddon)
+	}
+	if markerData.PreviousVersion != expectedPreviousVersion {
+		t.Fatalf("Expected previous version to be %t but got %t.", expectedPreviousVersion, markerData.PreviousVersion)
+	}
+}

--- a/cmd/minishift/cmd/util/util.go
+++ b/cmd/minishift/cmd/util/util.go
@@ -23,6 +23,12 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
+
+	"github.com/minishift/minishift/out/bindata"
+)
+
+var (
+	DefaultAssets = []string{"anyuid", "admin-user", "xpaas"}
 )
 
 func VMExists(client *libmachine.Client, machineName string) bool {
@@ -53,4 +59,15 @@ func ExitIfNotRunning(driver drivers.Driver, machineName string) {
 	if !running {
 		atexit.ExitWithMessage(0, fmt.Sprintf("The execution of this command requires a running '%s' VM, but there is currently none.", machineName))
 	}
+}
+
+// UnpackAddons will unpack the default addons into addons default dir
+func UnpackAddons(addonsDir string) error {
+	for _, asset := range DefaultAssets {
+		if err := bindata.RestoreAssets(addonsDir, asset); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -24,31 +24,21 @@ import (
 	"github.com/minishift/minishift/pkg/version"
 )
 
-// MachineName is the name to use for the VM.
-const MachineName = "minishift"
-
-// APIServerPort is the port that the API server should listen on.
-const APIServerPort = 8443
+const (
+	MachineName                  = "minishift"      // Name to use for the VM
+	APIServerPort                = 8443             // Port that the API server should listen on
+	MiniShiftEnvPrefix           = "MINISHIFT"      // Prefix for the environmental variables
+	MiniShiftHomeEnv             = "MINISHIFT_HOME" // Environment variable used to change the Minishift home directory
+	VersionPrefix                = "v"
+	MinOpenshiftSupportedVersion = "v1.4.1"
+	DefaultMemory                = 2048
+	DefaultCPUS                  = 2
+	DefaultDiskSize              = "20g"
+	UpdateMarkerFileName         = "updated"
+)
 
 // Fix for windows
 var Minipath = getMinishiftHomeDir()
-
-// MiniShiftEnvPrefix is the prefix for the environmental variables
-const MiniShiftEnvPrefix = "MINISHIFT"
-
-// MiniShiftHomeEnv is the environment variable used to change the Minishift home directory
-const MiniShiftHomeEnv = "MINISHIFT_HOME"
-
-const VersionPrefix = "v"
-
-// Minimum Openshift supported version
-const MinOpenshiftSuportedVersion = "v1.4.1"
-
-const (
-	DefaultMemory   = 2048
-	DefaultCPUS     = 2
-	DefaultDiskSize = "20g"
-)
 
 var KubeConfigPath = filepath.Join(Minipath, "machines", MachineName+"_kubeconfig")
 

--- a/pkg/testing/cli/harness.go
+++ b/pkg/testing/cli/harness.go
@@ -51,7 +51,7 @@ func CreateTee(t *testing.T, silent bool) *Tee {
 	return tee
 }
 
-// VerifyExitCodeAndMessage creates an exit handler which verifies that the programm will try to exit execution with the specified
+// VerifyExitCodeAndMessage creates an exit handler which verifies that the program will try to exit execution with the specified
 // exit code and message.
 func VerifyExitCodeAndMessage(t *testing.T, tee *Tee, expectedExitCode int, expectedErrorMessage string) func(int) bool {
 	var exitHandler func(int) bool

--- a/pkg/util/filehelper/file.go
+++ b/pkg/util/filehelper/file.go
@@ -152,3 +152,20 @@ func CopyDir(src string, dst string) (err error) {
 
 	return
 }
+
+// IsDirEmpty returns true if and only if the specified path denotes an empty directory, false otherwise.
+func IsEmptyDir(path string) bool {
+	// https://stackoverflow.com/a/30708914/1120530
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/filehelper/file_test.go
+++ b/pkg/util/filehelper/file_test.go
@@ -92,3 +92,35 @@ func Test_file_is_not_a_directory(t *testing.T) {
 		t.Fatalf("The path '%s' should not be a directory", testDir)
 	}
 }
+
+func Test_non_existing_directory(t *testing.T) {
+	testDir := "/foo/bar"
+	if empty := IsEmptyDir(testDir); empty {
+		t.Fatalf("Expected that the directory %s doesn't exist.", testDir)
+	}
+}
+
+func Test_existing_empty_directory(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "minishift-test-filetest-")
+	defer os.RemoveAll(testDir)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	if empty := IsEmptyDir(testDir); !empty {
+		t.Fatalf("Expected %s to be empty.", testDir)
+	}
+}
+
+func Test_existing_nonempty_directory(t *testing.T) {
+	testDir, _ := ioutil.TempDir("", "minishift-test-filetest-")
+	_, err := ioutil.TempFile(testDir, "foo")
+	defer os.RemoveAll(testDir)
+	if err != nil {
+		t.Fatal("Unexpected error: " + err.Error())
+	}
+
+	if empty := IsEmptyDir(testDir); empty {
+		t.Fatalf("Expected %s to be nonempty.", testDir)
+	}
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 )
@@ -48,19 +47,6 @@ func Until(fn func() error, w io.Writer, name string, sleep time.Duration, done 
 
 func Pad(str string) string {
 	return fmt.Sprint("\n%s\n", str)
-}
-
-// If the file represented by path exists and
-// readable, return true otherwise return false.
-func CanReadFile(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-
-	defer f.Close()
-
-	return true
 }
 
 func Retry(attempts int, callback func() error) (err error) {


### PR DESCRIPTION
Fix #639 

@hferentschik , This PR is only missing tests, rest functionally working in Linux and **Windows**. You heard it correct :smile: 

Will write tests as well. Thanks for the suggestion (looks like better one) :+1: 

I have tested in the following way:
```
$ make
go install -pkgdir=/home/budhram/gowork/src/github.com/minishift/minishift/out/bindata -ldflags="-X github.com/minishift/minishift/pkg/version.version=1.0.0 -X github.com/minishift/minishift/pkg/version.isoVersion=v1.0.2 -X github.com/minishift/minishift/pkg/version.openshiftVersion=v1.5.1" ./cmd/minishift

$ minishift version
minishift v1.0.0

$ minishift delete

$ rm -rf ~/.minishift

$ minishift start
Starting local OpenShift cluster using 'kvm' hypervisor...
Downloading ISO 'https://github.com/minishift/minishift-b2d-iso/releases/download/v1.0.2/minishift-b2d.iso'
...
# You might hit by issue https://github.com/minishift/minishift/issues/989 
...
-- Removing temporary directory ... OK
-- Checking container networking ... OK
-- Server Information ... 
   OpenShift server started.
   The server is accessible via web console at:
       https://192.168.42.231:8443

   You are logged in as:
       User:     developer
       Password: developer

   To login as administrator:
       oc login -u system:admin

-- Installing default addons ... OK
 40.00 MiB / 40.00 MiB [==========================================================================================================================] 100.00% 0s


$ minishift update
A newer version of minishift is available.
Do you want to update from 1.0.0 to 1.0.1 now? [y/N]: y (doing Control + C to test --force)
Downloading https://github.com/minishift/minishift/releases/download/v1.0.1/minishift-1.0.1-linux-amd64.tgz
^C

$ minishift update --force
Downloading https://github.com/minishift/minishift/releases/download/v1.0.1/minishift-1.0.1-linux-amd64.tgz
 3.43 MiB / 3.43 MiB [============================================================================================================================] 100.00% 0s
 3.43 MiB / 3.43 MiB [============================================================================================================================] 100.00% 0s
 3.43 MiB / 3.43 MiB [============================================================================================================================] 100.00% 0s
Updated successfully to minishift v1.0.1.
Post update changes will be executed on the next call of any minishift command.

$ minishift version
Minishift version: 1.0.1

$ git diff Makefile
diff --git a/Makefile b/Makefile
index 248cce5..f4b00f9 100644
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Various versions - Minishift, default OpenShift, default B2D ISO
-MINISHIFT_VERSION = 1.0.1
+MINISHIFT_VERSION = 1.0.0
 OPENSHIFT_VERSION = v1.5.1
 B2D_ISO_VERSION = v1.0.2
 CENTOS_ISO_VERSION = v1.0.0

#### Compile again to v1.0.0
$ make
go install -pkgdir=/home/budhram/gowork/src/github.com/minishift/minishift/out/bindata -ldflags="-X github.com/minishift/minishift/pkg/version.version=1.0.0 -X github.com/minishift/minishift/pkg/version.isoVersion=v1.0.2 -X github.com/minishift/minishift/pkg/version.openshiftVersion=v1.5.1" ./cmd/minishift

#### Change the *.addon file here or delete the folder to test

#### Run any command
$ minishift version
Binary has been recently updated.
--- Updating default addons ...OK
minishift v1.0.0

```