### PR TITLE
Issue #929 Alias 'minishift dashboard' to 'minishift console'

### DIFF
--- a/cmd/minishift/cmd/console.go
+++ b/cmd/minishift/cmd/console.go
@@ -38,9 +38,10 @@ CONSOLE_URL=%s`
 
 // consoleCmd represents the console command
 var consoleCmd = &cobra.Command{
-	Use:   "console",
-	Short: "Opens or displays the OpenShift Web Console URL.",
-	Long:  `Opens the OpenShift Web Console URL in the default browser or displays it to the console.`,
+	Use:     "console",
+	Aliases: []string{"dashboard"},
+	Short:   "Opens or displays the OpenShift Web Console URL.",
+	Long:    `Opens the OpenShift Web Console URL in the default browser or displays it to the console.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -72,6 +72,8 @@ Feature: Basic
     Given Minishift has state "Running"
      When executing "minishift console --url" succeeds
      Then stdout should be valid URL
+     When executing "minishift dashboard --url" succeeds
+     Then stdout should be valid URL
 
   Scenario: OpenShift developer has sudo permissions
      The 'developer' user should be configured with the sudoer role after starting Minishift


### PR DESCRIPTION
Fix #929 