### PR TITLE
Issue #1004 Make basic.feature work for upstream and downstream

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -3,7 +3,7 @@ Feature: Basic
   As a user I can perform basic operations of Minishift and OpenShift
 
   Scenario: User can install default add-ons
-    Given Minishift has state "Does Not Exist"
+   Given Minishift has state "Does Not Exist"
     When executing "minishift addons install --defaults" succeeds
     Then stdout should contain
      """
@@ -11,15 +11,16 @@ Feature: Basic
      """
 
   Scenario: User can enable the anyuid add-on
-    Given Minishift has state "Does Not Exist"
+   Given Minishift has state "Does Not Exist"
     When executing "minishift addons enable anyuid" succeeds
     Then stdout should contain
      """
      Addon 'anyuid' enabled
      """
 
+  @minishift-only
   Scenario: User can list enabled plugins
-    Given Minishift has state "Does Not Exist"
+   Given Minishift has state "Does Not Exist"
     When executing "minishift addons list" succeeds
     Then stdout should contain
      """

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -55,6 +55,16 @@ func TestMain(m *testing.M) {
 	var godogPaths = flag.String("paths", "./features", "")
 	flag.Parse()
 
+	if *godogTags != "" {
+		*godogTags += "&&"
+	}
+	runner := util.MinishiftRunner{CommandPath: givenPath}
+	if runner.IsCDK() {
+		*godogTags += "~minishift-only"
+	} else {
+		*godogTags += "~cdk-only"
+	}
+
 	status := godog.RunWithOptions("minishift", func(s *godog.Suite) {
 		FeatureContext(s)
 	}, godog.Options{


### PR DESCRIPTION
Adding support for `@minishift` and `@cdk` tags - these are used on Minishift or CDK specific scenarios or their variants for Minishift/CDK. So if we have a scenario which is different for both, then we will have it twice - one with `@cdk` tag and values for CDK, other for Minishift... When integration tests starts, code checks if binary is Minishift or CDK and based on that it adds `&&~cdk` to tags, or respectively just `~cdk` if no tags are specified by user, these removes all cdk related cases so only those which are not specific or are specifically tagged `@minishift` remains and are run.

Addresses issue #1004