### PR TITLE
Issue #850 Edited doc strings for latest commands

### DIFF
--- a/cmd/minishift/cmd/addon/addon.go
+++ b/cmd/minishift/cmd/addon/addon.go
@@ -23,15 +23,15 @@ import (
 const (
 	addOnConfigKey = "addons"
 
-	emptyAddOnError = "You must specify an add-on name. Use `minishift addons list` to view installed add-ons."
+	emptyAddOnError = "You must specify an add-on name. Run `minishift addons list` to view installed add-ons."
 	noAddOnMessage  = "No add-on with the name %s is installed."
 )
 
 var AddonsCmd = &cobra.Command{
 	Use:     "addons SUBCOMMAND [flags]",
 	Aliases: []string{"addon"},
-	Short:   "Manages Minishift add-ons",
-	Long:    "Manages Minishift add-ons. You can install, list, enable or disable Minishift add-ons.",
+	Short:   "Manages Minishift add-ons.",
+	Long:    "Manages Minishift add-ons. Use the sub-commands to install, list, enable or disable Minishift add-ons.",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/minishift/cmd/addon/addon_apply.go
+++ b/cmd/minishift/cmd/addon/addon_apply.go
@@ -40,8 +40,8 @@ const (
 
 var addonsApplyCmd = &cobra.Command{
 	Use:   "apply ADDON_NAME ...",
-	Short: "Executes the specified add-ons.",
-	Long:  "Executes the specified add-ons. The command works with both enabled and disabled add-ons.",
+	Short: "Applies the specified add-ons.",
+	Long:  "Applies the specified add-ons. You can specify one or more add-ons, regardless of whether the add-on is enabled or disabled.",
 	Run:   runApplyAddon,
 }
 
@@ -77,14 +77,14 @@ func runApplyAddon(cmd *cobra.Command, args []string) {
 
 	ip, err := host.Driver.GetIP()
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting IP: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting the IP address: %s", err.Error()))
 	}
 
 	routingSuffix := determineRoutingSuffix(host.Driver)
 	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
 	ocRunner, err := oc.NewOcRunner(minishiftConfig.InstanceConfig.OcPath, constants.KubeConfigPath)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error applying addon: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error applying the add-on: %s", err.Error()))
 	}
 
 	for i := range args {
@@ -92,11 +92,11 @@ func runApplyAddon(cmd *cobra.Command, args []string) {
 		addon := addOnManager.Get(addonName)
 		addonContext, err := clusterup.GetExecutionContext(ip, routingSuffix, ocRunner, sshCommander)
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprint("Error executing addon commands: ", err))
+			atexit.ExitWithMessage(1, fmt.Sprint("Error applying the add-on: ", err))
 		}
 		err = addOnManager.ApplyAddOn(addon, addonContext)
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprint("Error executing addon commands: ", err))
+			atexit.ExitWithMessage(1, fmt.Sprint("Error applying the add-on: ", err))
 		}
 	}
 }
@@ -104,7 +104,7 @@ func runApplyAddon(cmd *cobra.Command, args []string) {
 func determineRoutingSuffix(driver drivers.Driver) string {
 	defer func() {
 		if r := recover(); r != nil {
-			atexit.ExitWithMessage(1, "Unable to determine routing suffix from OpenShift master config.")
+			atexit.ExitWithMessage(1, "Cannot determine the routing suffix from the OpenShift master configuration.")
 		}
 	}()
 
@@ -113,13 +113,13 @@ func determineRoutingSuffix(driver drivers.Driver) string {
 
 	raw, err := openshift.ViewConfig(openshift.MASTER, dockerCommander)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to retrieve OpenShift master configuration: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot get the OpenShift master configuration: %s", err.Error()))
 	}
 
 	var config map[interface{}]interface{}
 	err = yaml.Unmarshal([]byte(raw), &config)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to parse OpenShift master configuration: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot parse the OpenShift master configuration: %s", err.Error()))
 	}
 
 	// making assumptions about the master config here. In case the config structure changes, the code might panic here

--- a/cmd/minishift/cmd/addon/addon_disable.go
+++ b/cmd/minishift/cmd/addon/addon_disable.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	emptyDisableError       = "You must specify an add-on name. Use `minishift addons list` to view installed add-ons."
+	emptyDisableError       = "You must specify an add-on name. Run `minishift addons list` to view installed add-ons."
 	noAddOnToDisableMessage = "No add-on with the name %s is installed."
 )
 
@@ -53,9 +53,9 @@ func runDisableAddon(cmd *cobra.Command, args []string) {
 
 	addOnConfig, err := addOnManager.Disable(addOnName)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to disable add-on %s: %s", addOnName, err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to disable the add-on %s: %s", addOnName, err.Error()))
 	} else {
-		fmt.Println(fmt.Sprintf("Addon '%s' disabled", addOnName))
+		fmt.Println(fmt.Sprintf("Add-on '%s' disabled", addOnName))
 	}
 
 	addOnConfigMap := GetAddOnConfiguration()

--- a/cmd/minishift/cmd/addon/addon_enable.go
+++ b/cmd/minishift/cmd/addon/addon_enable.go
@@ -38,7 +38,7 @@ var addonsEnableCmd = &cobra.Command{
 }
 
 func init() {
-	addonsEnableCmd.Flags().IntVar(&priority, priorityFlag, 0, "The priority of the add-on when it is applied.")
+	addonsEnableCmd.Flags().IntVar(&priority, priorityFlag, 0, "The priority of the add-on.")
 	AddonsCmd.AddCommand(addonsEnableCmd)
 }
 
@@ -60,9 +60,9 @@ func runEnableAddon(cmd *cobra.Command, args []string) {
 func enableAddon(addOnManager *manager.AddOnManager, addOnName string, priority int) {
 	addOnConfig, err := addOnManager.Enable(addOnName, priority)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to enable add-on %s: %s", addOnName, err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot enable the add-on %s: %s", addOnName, err.Error()))
 	} else {
-		fmt.Println(fmt.Sprintf("Addon '%s' enabled", addOnName))
+		fmt.Println(fmt.Sprintf("Add-on '%s' enabled", addOnName))
 	}
 
 	addOnConfigMap := GetAddOnConfiguration()

--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	unspecifiedSourceError   = "You need to specify the source for the add-on."
+	unspecifiedSourceError   = "You must specify the source of the add-on."
 	failedPluginInstallation = "Add-on installation failed with the error: %s"
 
 	forceFlag    = "force"

--- a/cmd/minishift/cmd/addon/addons_list.go
+++ b/cmd/minishift/cmd/addon/addons_list.go
@@ -64,12 +64,12 @@ func init() {
 	var err error
 	defaultListTemplate, err = template.New("list").Parse(defaultAddonListFormat)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating list template: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating the list template: %s", err.Error()))
 	}
 
 	verboseListTemplate, err = template.New("list").Parse(verboseAddonListFormat)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating list template: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating the list template: %s", err.Error()))
 	}
 }
 
@@ -91,7 +91,7 @@ func printAddOnList(manager *manager.AddOnManager, writer io.Writer, template *t
 		addonTemplate := DisplayAddOn{addon.MetaData().Name(), addon.MetaData().Description(), stringFromStatus(addon.IsEnabled()), addon.GetPriority()}
 		err := template.Execute(writer, addonTemplate)
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Error executing template: %s", err.Error()))
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error executing the template: %s", err.Error()))
 		}
 	}
 }

--- a/cmd/minishift/cmd/addon/util.go
+++ b/cmd/minishift/cmd/addon/util.go
@@ -32,7 +32,7 @@ func GetAddOnManager() *manager.AddOnManager {
 	addOnConfigs := GetAddOnConfiguration()
 	m, err := manager.NewAddOnManager(constants.MakeMiniPath("addons"), addOnConfigs)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to initialize the add-on manager: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot initialize the add-on manager: %s", err.Error()))
 	}
 
 	return m
@@ -41,14 +41,14 @@ func GetAddOnManager() *manager.AddOnManager {
 func WriteAddOnConfig(addOnConfigMap map[string]*addon.AddOnConfig) {
 	c, err := config.ReadConfig()
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to read the Minishift configuration: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot read the Minishift configuration: %s", err.Error()))
 	}
 
 	c[addOnConfigKey] = addOnConfigMap
 
 	err = config.WriteConfig(c)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to write the Minishift configuration: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot write the Minishift configuration: %s", err.Error()))
 	}
 }
 
@@ -57,7 +57,7 @@ func WriteAddOnConfig(addOnConfigMap map[string]*addon.AddOnConfig) {
 func GetAddOnConfiguration() map[string]*addon.AddOnConfig {
 	c, err := config.ReadConfig()
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to read the Minishift configuration: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot read the Minishift configuration: %s", err.Error()))
 	}
 
 	var configSlice map[string]interface{}

--- a/cmd/minishift/cmd/hostfolder/hostfolder.go
+++ b/cmd/minishift/cmd/hostfolder/hostfolder.go
@@ -22,8 +22,8 @@ import (
 
 var HostfolderCmd = &cobra.Command{
 	Use:   "hostfolder SUBCOMMAND [flags]",
-	Short: "Manages host folders for use by the OpenShift cluster.",
-	Long:  `Manages host folders for use by the OpenShift cluster. Use the sub-commands to define, mount, unmount, and list host folders.`,
+	Short: "Manages host folders for the OpenShift cluster.",
+	Long:  `Manages host folders for the OpenShift cluster. Use the sub-commands to define, mount, unmount, and list host folders.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/minishift/cmd/hostfolder/mount.go
+++ b/cmd/minishift/cmd/hostfolder/mount.go
@@ -33,8 +33,8 @@ var (
 
 var hostfolderMountCmd = &cobra.Command{
 	Use:   "mount HOSTFOLDER_NAME",
-	Short: "Mounts a host folder to the running OpenShift cluster.",
-	Long:  `Mounts a host folder to the running OpenShift cluster.`,
+	Short: "Mounts the specified host folder to the running OpenShift cluster.",
+	Long:  `Mounts the specified host folder to the running OpenShift cluster. You can set the 'all' flag to mount all of the defined host folders.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
@@ -59,7 +59,7 @@ var hostfolderMountCmd = &cobra.Command{
 		}
 
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Error to mount host folder: %s", err.Error()))
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error mounting the host folder: %s", err.Error()))
 		}
 
 	},
@@ -67,5 +67,5 @@ var hostfolderMountCmd = &cobra.Command{
 
 func init() {
 	HostfolderCmd.AddCommand(hostfolderMountCmd)
-	hostfolderMountCmd.Flags().BoolVarP(&mountAll, "all", "a", false, "Mounts all defined host folders to the OpenShift cluster.")
+	hostfolderMountCmd.Flags().BoolVarP(&mountAll, "all", "a", false, "Mounts all defined host folders to the running OpenShift cluster.")
 }

--- a/cmd/minishift/cmd/hostfolder/umount.go
+++ b/cmd/minishift/cmd/hostfolder/umount.go
@@ -50,7 +50,7 @@ var hostfolderUmountCmd = &cobra.Command{
 
 		err = hostfolderActions.Umount(host.Driver, args[0])
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Error to unmount host folder: %s", err.Error()))
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error unmounting the host folder: %s", err.Error()))
 		}
 	},
 }

--- a/cmd/minishift/cmd/image/export.go
+++ b/cmd/minishift/cmd/image/export.go
@@ -31,8 +31,8 @@ import (
 
 var imageExportCmd = &cobra.Command{
 	Use:   "export [image ...]",
-	Short: "Exports container images (experimental).",
-	Long:  "Exports container images (experimental).",
+	Short: "Exports the specified container images (experimental).",
+	Long:  "Exports the specified container images (experimental).",
 	Run:   exportImage,
 }
 
@@ -44,21 +44,21 @@ func exportImage(cmd *cobra.Command, args []string) {
 	defer api.Close()
 
 	if len(args) < 1 {
-		atexit.ExitWithMessage(0, "No image specifications provided")
+		atexit.ExitWithMessage(0, "You must specify at least one container image.")
 	}
 
 	util.ExitIfUndefined(api, constants.MachineName)
 
 	host, err := api.Load(constants.MachineName)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating VM client: %v", err))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating the VM client: %v", err))
 	}
 
 	util.ExitIfNotRunning(host.Driver, constants.MachineName)
 
 	handler, err := image.NewDockerImageHandler(host.Driver)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to create image handler: %v", err))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot create the image handler: %v", err))
 	}
 
 	imageCacheConfig := &image.ImageCacheConfig{
@@ -69,7 +69,7 @@ func exportImage(cmd *cobra.Command, args []string) {
 	}
 	err = handler.ExportImages(imageCacheConfig)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Export of container images failed: %v", err))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Failed to export the container images: %v", err))
 	}
 }
 
@@ -79,7 +79,7 @@ func createLogFile() *os.File {
 	logFilePath := filepath.Join(constants.MakeMiniPath("logs"), fmt.Sprintf("image-export-%s.log", timeStamp))
 	logFile, err := os.Create(logFilePath)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to create log file for image export: %v", err))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot create the log file of the image export: %v", err))
 	}
 
 	return logFile

--- a/cmd/minishift/cmd/image/image.go
+++ b/cmd/minishift/cmd/image/image.go
@@ -22,8 +22,8 @@ import (
 
 var ImageCmd = &cobra.Command{
 	Use:    "image SUBCOMMAND [flags]",
-	Short:  "Command for exporting and importing container images (experimental).",
-	Long:   "Command for exporting and importing container images (experimental).",
+	Short:  "Exports and imports container images (experimental).",
+	Long:   "Exports and imports container images (experimental).",
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/minishift/cmd/oc_env.go
+++ b/cmd/minishift/cmd/oc_env.go
@@ -65,11 +65,11 @@ func executeOcTemplateStdout(shellCfg *OcShellConfig) error {
 
 var ocEnvCmd = &cobra.Command{
 	Use:   "oc-env",
-	Short: "Sets path of 'oc' binary.",
-	Long:  `Sets path of OpenShift client binary, 'oc'.`,
+	Short: "Sets the path of the 'oc' binary.",
+	Long:  `Sets the path of OpenShift client binary 'oc'.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if config.InstanceConfig.OcPath == "" {
-			atexit.ExitWithMessage(1, "Unable to find OpenShift client binary.\nPlease make sure that OpenShift has been provisioned successfully.")
+			atexit.ExitWithMessage(1, "Cannot find the OpenShift client binary.\nMake sure that OpenShift was provisioned successfully.")
 		}
 
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
@@ -85,7 +85,7 @@ var ocEnvCmd = &cobra.Command{
 
 		shellCfg, err = getOcShellConfig(config.InstanceConfig.OcPath, forceShell)
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Error running oc-env command: %s", err.Error()))
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error running the oc-env command: %s", err.Error()))
 		}
 
 		executeOcTemplateStdout(shellCfg)

--- a/cmd/minishift/cmd/openshift/config.go
+++ b/cmd/minishift/cmd/openshift/config.go
@@ -27,8 +27,8 @@ const (
 
 var configCmd = &cobra.Command{
 	Use:   "config SUBCOMMAND [flags]",
-	Short: "Displays or patches OpenShift configuration.",
-	Long:  "Displays or patches OpenShift master or node configuration. Patches are supplied in JSON format.",
+	Short: "Displays or patches the OpenShift configuration.",
+	Long:  "Displays or patches the OpenShift master or node configuration. Patches must be in a valid JSON format.",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/minishift/cmd/openshift/list_versions.go
+++ b/cmd/minishift/cmd/openshift/list_versions.go
@@ -26,8 +26,8 @@ import (
 // getVersionsCmd represents the ip command
 var getVersionsCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Gets the list of OpenShift versions available for Minishift.",
-	Long:  `Gets the list of OpenShift versions available for Minishift.`,
+	Short: "Gets the list of OpenShift versions that are available for Minishift.",
+	Long:  `Gets the list of OpenShift versions that are available for Minishift.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		openshiftVersions.PrintUpStreamVersions(os.Stdout, version.GetOpenShiftVersion())
 	},

--- a/cmd/minishift/cmd/openshift/openshift.go
+++ b/cmd/minishift/cmd/openshift/openshift.go
@@ -22,8 +22,8 @@ import (
 
 var OpenShiftCmd = &cobra.Command{
 	Use:   "openshift SUBCOMMAND [flags]",
-	Short: "Interact with an Openshift Cluster",
-	Long:  "Interact with an Openshift cluster, check available versions and modify master config resources",
+	Short: "Interacts with your local OpenShift cluster.",
+	Long:  "Interacts with your local OpenShift cluster. Use the sub-commands to check available OpenShift versions, access services, and modify configuration resources.",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/minishift/cmd/openshift/registry.go
+++ b/cmd/minishift/cmd/openshift/registry.go
@@ -29,8 +29,8 @@ import (
 
 var registryCmd = &cobra.Command{
 	Use:   "registry [flags]",
-	Short: "Prints host and port of the OpenShift registry.",
-	Long:  `Prints host and port of the OpenShift docker registry in the format 'host:port'.`,
+	Short: "Prints the host name and port number of the OpenShift registry to the standard output.",
+	Long:  `Prints the host name and port number of the OpenShift Docker registry in the format: 'host:port'`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		//Check if Minishift VM is running

--- a/cmd/minishift/cmd/openshift/restart.go
+++ b/cmd/minishift/cmd/openshift/restart.go
@@ -33,7 +33,7 @@ import (
 var restartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "Restarts the OpenShift cluster.",
-	Long:  "Restarts the OpenShift cluster, keeping the VM alive.",
+	Long:  "Restarts the OpenShift cluster and maintains the state of the Minishift VM.",
 	Run:   runRestart,
 }
 
@@ -54,6 +54,6 @@ func runRestart(cmd *cobra.Command, args []string) {
 	dockerCommander := docker.NewVmDockerCommander(sshCommander)
 	_, err = openshift.RestartOpenShift(dockerCommander)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error restarting OpenShift cluster: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error restarting the OpenShift cluster: %s", err.Error()))
 	}
 }

--- a/cmd/minishift/cmd/openshift/service.go
+++ b/cmd/minishift/cmd/openshift/service.go
@@ -36,8 +36,8 @@ var (
 // serviceCmd represents the service command
 var serviceCmd = &cobra.Command{
 	Use:   "service [flags] SERVICE",
-	Short: "Opens the URL for the specified service in the browser or prints it to the console",
-	Long:  `Opens the URL for the specified service and namespace in the browser or prints it to the console. If no namespace is provided, 'default' is assumed.`,
+	Short: "Opens the URL for the specified service in the browser or prints it to the console.",
+	Long:  `Opens the URL for the specified service and namespace in the default browser or prints it to the console. If no namespace is provided, 'default' is assumed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 || len(args) > 1 {
 			atexit.ExitWithMessage(1, "You must specify the name of the service.")
@@ -61,7 +61,7 @@ var serviceCmd = &cobra.Command{
 
 func init() {
 	serviceCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "The namespace of the service.")
-	serviceCmd.Flags().BoolVar(&urlMode, "url", false, "Access the service in the command-line console instead of the default browser.")
+	serviceCmd.Flags().BoolVar(&urlMode, "url", false, "Access the service in the command-line console instead of in the default browser.")
 	serviceCmd.Flags().BoolVar(&https, "https", false, "Access the service with HTTPS instead of HTTP.")
 	OpenShiftCmd.AddCommand(serviceCmd)
 }

--- a/cmd/minishift/cmd/openshift/service_list.go
+++ b/cmd/minishift/cmd/openshift/service_list.go
@@ -30,8 +30,8 @@ var serviceListNamespace string
 // serviceListCmd represents the service list command
 var serviceListCmd = &cobra.Command{
 	Use:   "list [flags]",
-	Short: "Gets the URLs of the services in your local cluster.",
-	Long:  `Gets the URLs of the services in your local cluster.`,
+	Short: "Gets the URLs of the services in your local OpenShift cluster.",
+	Long:  `Gets the URLs of the services in your local OpenShift cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		urls, err := openshift.GetServiceURLs(serviceListNamespace)
 		if err != nil {

--- a/cmd/minishift/cmd/openshift/set.go
+++ b/cmd/minishift/cmd/openshift/set.go
@@ -37,8 +37,8 @@ const (
 	patchFlag  = "patch"
 
 	unknownPatchTargetError = "Unkown patch target. Only 'master' and 'node' are supported."
-	emptyPatchError         = "You need to specify a patch using --patch."
-	invalidJSONError        = "The specified patch need to be valid JSON."
+	emptyPatchError         = "You must specify a patch using the --patch flag."
+	invalidJSONError        = "The patch must be a valid JSON file."
 )
 
 var (
@@ -48,14 +48,14 @@ var (
 
 var setCmd = &cobra.Command{
 	Use:   "set",
-	Short: "Updates the specified OpenShift configuration resource with the specified patch.",
-	Long:  "Updates the specified OpenShift configuration resource with the specified patch. The patch needs to be in JSON format.",
+	Short: "Patches the OpenShift configuration resource with the specified patch.",
+	Long:  "Patches the OpenShift configuration resource with the specified patch. The patch must be a valid JSON file.",
 	Run:   runPatch,
 }
 
 func init() {
-	setCmd.Flags().StringVar(&target, targetFlag, "master", "Target configuration to patch. Either 'master' or 'node'.")
-	setCmd.Flags().StringVar(&patch, patchFlag, "", "The patch to apply")
+	setCmd.Flags().StringVar(&target, targetFlag, "master", "Target configuration to patch. Options are 'master' or 'node'.")
+	setCmd.Flags().StringVar(&patch, patchFlag, "", "The patch to apply.")
 	configCmd.AddCommand(setCmd)
 }
 
@@ -86,7 +86,7 @@ func runPatch(cmd *cobra.Command, args []string) {
 
 	_, err = openshift.Patch(patchTarget, patch, dockerCommander)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error patching OpenShift configuration: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error patching the OpenShift configuration: %s", err.Error()))
 	}
 }
 

--- a/cmd/minishift/cmd/openshift/version.go
+++ b/cmd/minishift/cmd/openshift/version.go
@@ -32,8 +32,8 @@ import (
 // version command represent current running openshift version and available one.
 var versionCmd = &cobra.Command{
 	Use:   "version [command] [flags]",
-	Short: "Print the current running openshift version to stdout",
-	Long:  `Print the current running openshift version to stdout`,
+	Short: "Prints the current running OpenShift version to the standard output.",
+	Long:  `Prints the current running OpenShift version to the standard output.`,
 	Run:   runVersion,
 }
 
@@ -49,7 +49,7 @@ func runVersion(cmd *cobra.Command, args []string) {
 	dockerCommander := docker.NewVmDockerCommander(sshCommander)
 	version, err := dockerCommander.Exec(" ", "origin", "openshift", "version")
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error restarting OpenShift cluster: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error restarting the OpenShift cluster: %s", err.Error()))
 	}
 	fmt.Fprintln(os.Stdout, version)
 }

--- a/cmd/minishift/cmd/openshift/view.go
+++ b/cmd/minishift/cmd/openshift/view.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	configTargetFlag         = "target"
-	unknownConfigTargetError = "Unkown config target. Only 'master' and 'node' are supported."
+	unknownConfigTargetError = "Unknown configuration target. Only 'master' and 'node' are supported."
 )
 
 var (
@@ -48,7 +48,7 @@ var viewCmd = &cobra.Command{
 }
 
 func init() {
-	viewCmd.Flags().StringVar(&configTarget, configTargetFlag, "master", "Target configuration to display. Either 'master' or 'node'.")
+	viewCmd.Flags().StringVar(&configTarget, configTargetFlag, "master", "Target configuration to display. Options are 'master' or 'node'.")
 	configCmd.AddCommand(viewCmd)
 }
 
@@ -77,7 +77,7 @@ func runViewConfig(cmd *cobra.Command, args []string) {
 
 	out, err := openshift.ViewConfig(configFileTarget, dockerCommander)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Unable to display OpenShift configuration: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot display the OpenShift configuration: %s", err.Error()))
 	}
 
 	fmt.Println(out)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -502,7 +502,7 @@ func validateOpenshiftVersion() {
 	}
 
 	if !valid {
-		fmt.Printf("Minishift does not support Openshift version %s. "+
+		fmt.Printf("Minishift does not support OpenShift version %s. "+
 			"You need to use a version >= %s\n", viper.GetString(startFlags.OpenshiftVersion.Name),
 			constants.MinOpenshiftSupportedVersion)
 		atexit.Exit(1)

--- a/cmd/minishift/cmd/update.go
+++ b/cmd/minishift/cmd/update.go
@@ -48,8 +48,8 @@ var (
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update to latest version of Minishift.",
-	Long:  `Checks for the latest version of Minishift, prompt the user and update the binary if user answers with 'y'.`,
+	Short: "Updates Minishift to the latest version.",
+	Long:  `Checks for the latest version of Minishift, prompts the user, and updates the binary if the user answers 'y'.`,
 	Run:   runUpdate,
 }
 
@@ -89,16 +89,16 @@ func runUpdate(cmd *cobra.Command, args []string) {
 				atexit.ExitWithMessage(1, fmt.Sprintf("Update failed: %s", err))
 			}
 
-			fmt.Printf("\nUpdated successfully to minishift v%s.\n", latestVersion)
+			fmt.Printf("\nUpdated successfully to Minishift version %s.\n", latestVersion)
 
 			markerData := UpdateMarker{InstallAddon: false, PreviousVersion: version.GetMinishiftVersion()}
 
-			fmt.Print("\nDo you want to update default addons? [y/N]: ")
+			fmt.Print("\nDo you want to update the default add-ons? [y/N]: ")
 			fmt.Scanln(&confirm)
 
 			if strings.ToLower(confirm) == "y" {
 				markerData.InstallAddon = true
-				fmt.Println("Default add-ons will be updated when executing the next minishift command.")
+				fmt.Println("Default add-ons will be updated the next time you run any 'minishift' command.")
 			}
 			if err := createUpdateMarker(filepath.Join(constants.Minipath, constants.UpdateMarkerFileName), markerData); err != nil {
 				atexit.ExitWithMessage(1, "Failed to create update marker file.")
@@ -107,7 +107,7 @@ func runUpdate(cmd *cobra.Command, args []string) {
 		}
 
 	} else {
-		fmt.Printf("Nothing to update.\nAlready using latest version: %s.\n", latestVersion)
+		fmt.Printf("Nothing to update.\nAlready using the latest version: %s.\n", latestVersion)
 	}
 }
 
@@ -115,7 +115,7 @@ func init() {
 	RootCmd.AddCommand(updateCmd)
 	updateCmd.Flags().AddFlag(httpProxyFlag)
 	updateCmd.Flags().AddFlag(httpsProxyFlag)
-	updateCmd.Flags().BoolVar(&addonForce, addonForceFlag, false, "Force update the addons post binary update. Otherwise, prompt user to update addons.")
+	updateCmd.Flags().BoolVar(&addonForce, addonForceFlag, false, "Force update the add-ons after the binary update. Otherwise, prompt the user to update add-ons.")
 }
 
 func createUpdateMarker(markerPath string, data UpdateMarker) error {

--- a/cmd/minishift/cmd/util/util.go
+++ b/cmd/minishift/cmd/util/util.go
@@ -34,7 +34,7 @@ var (
 func VMExists(client *libmachine.Client, machineName string) bool {
 	exists, err := client.Exists(machineName)
 	if err != nil {
-		atexit.ExitWithMessage(1, "Unable to determine state of Minishift VM.")
+		atexit.ExitWithMessage(1, "Cannot determine the state of Minishift VM.")
 	}
 	return exists
 }
@@ -42,7 +42,7 @@ func VMExists(client *libmachine.Client, machineName string) bool {
 func ExitIfUndefined(client *libmachine.Client, machineName string) {
 	exists := VMExists(client, machineName)
 	if !exists {
-		atexit.ExitWithMessage(0, fmt.Sprintf("The execution of this command requires an existing '%s' VM. However, there is currently none defined.", machineName))
+		atexit.ExitWithMessage(0, fmt.Sprintf("Running this command requires an existing '%s' VM, but no VM is defined.", machineName))
 	}
 }
 
@@ -57,7 +57,7 @@ func IsHostStopped(driver drivers.Driver) bool {
 func ExitIfNotRunning(driver drivers.Driver, machineName string) {
 	running := IsHostRunning(driver)
 	if !running {
-		atexit.ExitWithMessage(0, fmt.Sprintf("The execution of this command requires a running '%s' VM, but there is currently none.", machineName))
+		atexit.ExitWithMessage(0, fmt.Sprintf("Running this command requires a running '%s' VM, but no VM is running.", machineName))
 	}
 }
 

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -15,7 +15,7 @@ Feature: Basic
     When executing "minishift addons enable anyuid" succeeds
     Then stdout should contain
      """
-     Addon 'anyuid' enabled
+     Add-on 'anyuid' enabled
      """
 
   @minishift-only


### PR DESCRIPTION
Fixes issue #850 

Since the last time the doc strings were added, new commands were incorporated in to Minishift. This PR reviews and cleans up the doc strings.

Out of scope by request: *_test.go files
