### PR TITLE
Issue #876 Update 'openshift service list' command to handle NodePorts

### DIFF
--- a/pkg/minishift/openshift/registry.go
+++ b/pkg/minishift/openshift/registry.go
@@ -35,6 +35,6 @@ func GetDockerRegistryInfo() (string, error) {
 		return "", errors.New(fmt.Sprintf("No information found for '%s'", service))
 	}
 
-	registryInfo := byteArrayToString(cmdOut)
+	registryInfo := string(cmdOut)
 	return registryInfo, nil
 }

--- a/pkg/minishift/openshift/service_test.go
+++ b/pkg/minishift/openshift/service_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	instanceState "github.com/minishift/minishift/pkg/minishift/config"
+	test "github.com/minishift/minishift/pkg/testing"
+	testdata "github.com/minishift/minishift/pkg/testing/testdata"
+)
+
+//
+type ByName []ServiceSpec
+
+func (a ByName) Len() int           { return len(a) }
+func (a ByName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByName) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
+func Test_getServiceSpec_if_service_exist_with_route(t *testing.T) {
+	namespace := "bar"
+	service := "guestbook-v1"
+	https := false
+
+	setup(t, namespace)
+	defer teardown()
+
+	got, err := GetServiceSpec(service, namespace, https)
+
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := "http://guestbook-myproject.192.168.64.2.nip.io"
+	if https {
+		expected = "https://guestbook-myproject.192.168.64.2.nip.io"
+	}
+
+	if got != expected {
+		t.Fatalf("Expected: %+v, Got: %+v", expected, got)
+	}
+}
+
+func Test_getServiceSpec_if_service_exist_without_route(t *testing.T) {
+	namespace := "bar"
+	service := "guestbook-v1-np"
+	https := false
+
+	setup(t, namespace)
+	defer teardown()
+
+	_, err := GetServiceSpec(service, namespace, https)
+
+	if err == nil {
+		t.Fatalf("Error should be: %+v", err.Error())
+	}
+
+	expectedErrorText := fmt.Sprintf("Service '%s' in namespace '%s' does not have route associated which can be opened in the browser.", service, namespace)
+	if expectedErrorText != err.Error() {
+		t.Fatalf("Expected: %+v, Got: %+v", expectedErrorText, err.Error())
+	}
+
+}
+
+func Test_getServiceSpec_if_service_not_exist(t *testing.T) {
+	namespace := "bar"
+	service := "nonExistService"
+	https := false
+
+	setup(t, namespace)
+	defer teardown()
+
+	_, err := GetServiceSpec(service, namespace, https)
+
+	if err == nil {
+		t.Fatalf("Error should be: %+v", err.Error())
+	}
+
+	expectedErrorText := fmt.Sprintf("Service %s does not exist in namespace bar.", service)
+	if expectedErrorText != err.Error() {
+		t.Fatalf("Expected: %+v, Got: %+v", expectedErrorText, err.Error())
+	}
+
+}
+
+func Test_getServiceSpecs_with_multiple_nodeports_and_routes(t *testing.T) {
+	namespace := "bar"
+
+	setup(t, namespace)
+	defer teardown()
+
+	got, err := GetServiceSpecs(namespace)
+
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := []ServiceSpec{{Namespace: namespace, Name: "guestbook-v1-np", URL: []string(nil), NodePort: "32740", Weight: []string(nil)},
+		{Namespace: namespace, Name: "guestbook-v2-np", URL: []string(nil), NodePort: "30485", Weight: []string(nil)},
+		{Namespace: namespace, Name: "guestbook-v1", URL: []string{"http://guestbook-v1-3002-myproject.192.168.64.2.nip.io", "http://guestbook-myproject.192.168.64.2.nip.io", "http://guestbook-v1-myproject.192.168.64.2.nip.io"}, NodePort: "", Weight: []string{"", "50%", ""}},
+		{Namespace: namespace, Name: "guestbook-v2", URL: []string{"http://guestbook-v2-myproject.192.168.64.2.nip.io", "http://guestbook-v2-3002-myproject.192.168.64.2.nip.io", "http://guestbook-myproject.192.168.64.2.nip.io"}, NodePort: "", Weight: []string{"", "", "50%"}}}
+
+	sort.Sort(ByName(got))
+	sort.Sort(ByName(expected))
+
+	comapareServiceSpec(t, got, expected)
+}
+
+func comapareServiceSpec(t *testing.T, got, expected []ServiceSpec) {
+	for i, service := range got {
+		sort.Strings(service.URL)
+		sort.Strings(expected[i].URL)
+		sort.Strings(service.Weight)
+		sort.Strings(expected[i].Weight)
+		if service.Namespace != expected[i].Namespace {
+			t.Fatalf("Expected Namespace: %+v, Got Namespace: %+v", expected[i].Namespace, service.Namespace)
+		}
+
+		for j := range service.URL {
+			if service.URL[j] != expected[i].URL[j] {
+				t.Fatalf("Expected Route URL: %+v, Got Route URL: %+v", expected[i].URL[j], service.URL[j])
+			}
+		}
+
+		if service.Name != expected[i].Name {
+			t.Fatalf("Expected Service: %+v, Got Service: %+v", expected[i].Name, service.Name)
+		}
+		if service.NodePort != expected[i].NodePort {
+			t.Fatalf("Expected NodePort: %+v, Got NodePort: %+v", expected[i].NodePort, service.NodePort)
+		}
+		for j := range service.Weight {
+			if service.Weight[j] != expected[i].Weight[j] {
+				t.Fatalf("Expected Weight: %+v, Got Weight: %+v", expected[i].Weight[j], service.Weight[j])
+			}
+		}
+	}
+
+}
+
+func setup(t *testing.T, namespace string) {
+	instanceState.InstanceConfig = &instanceState.InstanceConfigType{OcPath: "oc"}
+
+	fakeRunner := test.NewFakeRunner(t)
+	runner = fakeRunner.Runner
+
+	args := fmt.Sprintf("get projects --config=%s %s", systemKubeConfigPath, ProjectsCustomCol)
+	expectString := fmt.Sprintf("NAME\n%s", namespace)
+	fakeRunner.ExpectAndReturn(args, expectString)
+
+	args = fmt.Sprintf("get svc -o json --config=%s -n %s", systemKubeConfigPath, namespace)
+	expectString = testdata.ServiceSpec
+	fakeRunner.ExpectAndReturn(args, expectString)
+
+	args = fmt.Sprintf("get route -o json --config=%s -n %s", systemKubeConfigPath, namespace)
+	expectString = testdata.RouteSpec
+	fakeRunner.ExpectAndReturn(args, expectString)
+}
+
+func teardown() {
+	instanceState.InstanceConfig = nil
+}

--- a/pkg/testing/runner_mock.go
+++ b/pkg/testing/runner_mock.go
@@ -1,0 +1,70 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+var (
+	expectCommands []ExpectedCommand
+	t              *testing.T
+)
+
+type Runner struct{}
+
+type FakeRunner struct {
+	*Runner
+}
+
+type ExpectedCommand struct {
+	commandArgs     string
+	commandToOutput string
+}
+
+func NewFakeRunner(test *testing.T) *FakeRunner {
+	fakeRunner := &FakeRunner{}
+	t = test
+	return fakeRunner
+}
+
+func (f *FakeRunner) ExpectAndReturn(input string, output string) {
+	expectCommands = append(expectCommands, ExpectedCommand{commandArgs: input, commandToOutput: output})
+}
+
+/*func (f *FakeRunner) Verify() {
+
+}*/
+
+func (f *Runner) Output(command string, args ...string) ([]byte, error) {
+	argStringOption := strings.Join(args, " ")
+
+	if expectCommands[0].commandArgs == argStringOption {
+		commandToOutput := expectCommands[0].commandToOutput
+		expectCommands = expectCommands[1:]
+		return []byte(commandToOutput), nil
+	}
+
+	t.Fatalf("Expected: %+v, Got: %+v\n", argStringOption, expectCommands[0].commandArgs)
+	return nil, nil
+}
+
+func (f *Runner) Run(stdOut io.Writer, stdErr io.Writer, commandPath string, args ...string) int {
+	return 0
+}

--- a/pkg/testing/testdata/testdata.go
+++ b/pkg/testing/testdata/testdata.go
@@ -1,0 +1,429 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testdata
+
+const (
+	ServiceSpec = `{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftWebConsole"
+                },
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "labels": {
+                    "app": "guestbook-v1"
+                },
+                "name": "guestbook-v1",
+                "namespace": "myproject",
+                "resourceVersion": "1013",
+                "selfLink": "/api/v1/namespaces/myproject/services/guestbook-v1",
+                "uid": "e928f3fc-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "clusterIP": "172.30.28.148",
+                "ports": [
+                    {
+                        "name": "3000-tcp",
+                        "port": 3000,
+                        "protocol": "TCP",
+                        "targetPort": 3000
+                    },
+                    {
+                        "name": "3001-tcp",
+                        "port": 3001,
+                        "protocol": "TCP",
+                        "targetPort": 3001
+                    },
+                    {
+                        "name": "3002-tcp",
+                        "port": 3002,
+                        "protocol": "TCP",
+                        "targetPort": 3002
+                    }
+                ],
+                "selector": {
+                    "deploymentconfig": "guestbook-v1"
+                },
+                "sessionAffinity": "None",
+                "type": "ClusterIP"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "labels": {
+                    "app": "guestbook-v1-np"
+                },
+                "name": "guestbook-v1-np",
+                "namespace": "myproject",
+                "resourceVersion": "1017",
+                "selfLink": "/api/v1/namespaces/myproject/services/guestbook-v1-np",
+                "uid": "e939a0cc-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "clusterIP": "172.30.195.59",
+                "ports": [
+                    {
+                        "name": "11001-3003",
+                        "nodePort": 32740,
+                        "port": 11001,
+                        "protocol": "TCP",
+                        "targetPort": 3003
+                    }
+                ],
+                "selector": {
+                    "deploymentconfig": "guestbook-v1"
+                },
+                "sessionAffinity": "None",
+                "type": "NodePort"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftWebConsole"
+                },
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "labels": {
+                    "app": "guestbook-v2"
+                },
+                "name": "guestbook-v2",
+                "namespace": "myproject",
+                "resourceVersion": "1020",
+                "selfLink": "/api/v1/namespaces/myproject/services/guestbook-v2",
+                "uid": "e9441b71-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "clusterIP": "172.30.211.226",
+                "ports": [
+                    {
+                        "name": "3000-tcp",
+                        "port": 3000,
+                        "protocol": "TCP",
+                        "targetPort": 3000
+                    },
+                    {
+                        "name": "3001-tcp",
+                        "port": 3001,
+                        "protocol": "TCP",
+                        "targetPort": 3000
+                    },
+                    {
+                        "name": "3002-tcp",
+                        "port": 3002,
+                        "protocol": "TCP",
+                        "targetPort": 3002
+                    }
+                ],
+                "selector": {
+                    "deploymentconfig": "guestbook-v2"
+                },
+                "sessionAffinity": "None",
+                "type": "ClusterIP"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "labels": {
+                    "app": "guestbook-v2-np"
+                },
+                "name": "guestbook-v2-np",
+                "namespace": "myproject",
+                "resourceVersion": "1024",
+                "selfLink": "/api/v1/namespaces/myproject/services/guestbook-v2-np",
+                "uid": "e9574204-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "clusterIP": "172.30.10.97",
+                "ports": [
+                    {
+                        "name": "11002-3003",
+                        "nodePort": 30485,
+                        "port": 11002,
+                        "protocol": "TCP",
+                        "targetPort": 3003
+                    }
+                ],
+                "selector": {
+                    "deploymentconfig": "guestbook-v2"
+                },
+                "sessionAffinity": "None",
+                "type": "NodePort"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {},
+    "resourceVersion": "",
+    "selfLink": ""
+}`
+
+	RouteSpec = `{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "name": "guestbook",
+                "namespace": "myproject",
+                "resourceVersion": "1027",
+                "selfLink": "/oapi/v1/namespaces/myproject/routes/guestbook",
+                "uid": "e96607a6-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "alternateBackends": [
+                    {
+                        "kind": "Service",
+                        "name": "guestbook-v2",
+                        "weight": 1
+                    }
+                ],
+                "host": "guestbook-myproject.192.168.64.2.nip.io",
+                "port": {
+                    "targetPort": "3000-tcp"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "guestbook-v1",
+                    "weight": 1
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2017-07-06T12:52:04Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "guestbook-myproject.192.168.64.2.nip.io",
+                        "routerName": "router",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "name": "guestbook-v1",
+                "namespace": "myproject",
+                "resourceVersion": "1030",
+                "selfLink": "/oapi/v1/namespaces/myproject/routes/guestbook-v1",
+                "uid": "e96b2cc7-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "host": "guestbook-v1-myproject.192.168.64.2.nip.io",
+                "port": {
+                    "targetPort": "3000-tcp"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "guestbook-v1",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2017-07-06T12:52:04Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "guestbook-v1-myproject.192.168.64.2.nip.io",
+                        "routerName": "router",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "name": "guestbook-v1-3002",
+                "namespace": "myproject",
+                "resourceVersion": "1031",
+                "selfLink": "/oapi/v1/namespaces/myproject/routes/guestbook-v1-3002",
+                "uid": "e979fa12-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "host": "guestbook-v1-3002-myproject.192.168.64.2.nip.io",
+                "port": {
+                    "targetPort": "3002-tcp"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "guestbook-v1",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2017-07-06T12:52:04Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "guestbook-v1-3002-myproject.192.168.64.2.nip.io",
+                        "routerName": "router",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "name": "guestbook-v2",
+                "namespace": "myproject",
+                "resourceVersion": "1033",
+                "selfLink": "/oapi/v1/namespaces/myproject/routes/guestbook-v2",
+                "uid": "e986b47a-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "host": "guestbook-v2-myproject.192.168.64.2.nip.io",
+                "port": {
+                    "targetPort": "3000-tcp"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "guestbook-v2",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2017-07-06T12:52:04Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "guestbook-v2-myproject.192.168.64.2.nip.io",
+                        "routerName": "router",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2017-07-06T12:52:04Z",
+                "name": "guestbook-v2-3002",
+                "namespace": "myproject",
+                "resourceVersion": "1035",
+                "selfLink": "/oapi/v1/namespaces/myproject/routes/guestbook-v2-3002",
+                "uid": "e98824fd-6249-11e7-bcae-26239b7ec447"
+            },
+            "spec": {
+                "host": "guestbook-v2-3002-myproject.192.168.64.2.nip.io",
+                "port": {
+                    "targetPort": "3002-tcp"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "guestbook-v2",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2017-07-06T12:52:04Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "guestbook-v2-3002-myproject.192.168.64.2.nip.io",
+                        "routerName": "router",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {},
+    "resourceVersion": "",
+    "selfLink": ""
+}`
+)


### PR DESCRIPTION
Fix #876 

Using current PR service list now looks like

```
$ ./minishift openshift service list
|-----------|-----------------|----------------------------------------------------|---------------------------|
| NAMSEPACE |      NAME       |                     ROUTE-URL                      |         NODEPORT          |
|-----------|-----------------|----------------------------------------------------|---------------------------|
| default   | docker-registry | No route for service                               | No node port              |
| default   | kubernetes      | No route for service                               | No node port              |
| default   | router          | No route for service                               | No node port              |
| myproject | simpleservice   | http://simpleservice-myproject.192.168.42.8.nip.io | No node port              |
| myproject | testservice     | No route for service                               | No node port              |
| myproject | mariadb         | No route for service                               | No node port              |
| myproject | mariadb-ingress | No route for service                               | http://192.168.42.8:31145 |
|-----------|-----------------|----------------------------------------------------|---------------------------|
```