### PR TITLE
Issue #1084 Create integration test for proxy

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -260,6 +260,7 @@ function setup_build_environment() {
   install_core_deps;
   install_kvm_virt;
   install_docker;
+  prepare_for_proxy;
   runuser -l minishift_ci -c "/bin/bash centos_ci.sh"
 }
 
@@ -308,6 +309,11 @@ function build_and_test() {
   echo "CICO: Tests ran successfully"
 
   artifacts_upload_on_pr_and_master_trigger $1;
+}
+
+function prepare_for_proxy() {
+  export INTEGRATION_PROXY_CUSTOM_PORT=8181 #needs to be an unused port
+  firewall-cmd --zone=public --add-port=$INTEGRATION_PROXY_CUSTOM_PORT/tcp;
 }
 
 if [[ "$UID" = 0 ]]; then

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -192,12 +192,26 @@ $go test -v <relative path of package> -run "Test<Regex pattern to match tests>"
 For more information about test options, run the `go test --help` command and review the documentation.
 
 [[integration-tests]]
-=== Running Integration Tests
+=== Integration Tests
 
-Integration tests utilize link:https://github.com/DATA-DOG/godog[Godog], which uses Gherkin (Cucumber) to define test cases.
-The test cases are defined in *_test/integration/features_*.
-By default, the tests are executed against the binary created by `make build`, that is *_$GOPATH/bin/minishift_*.
-To run the tests, run:
+Integration tests utilize link:https://github.com/DATA-DOG/godog[Godog], which uses Gherkin (Cucumber) to define sets of test cases, in Gherkin terminology known as _features_.
+The features are located in *_test/integration/features_* folder.
+Features for Minishift follow these basic concepts:
+
+User stories::
+Features which follow a happy path of user.
+For example, _basic.feature_ or _coolstore.feature_.
+
+Feature and command coverage::
+Features which focuses on specific fields of Minishift functionality or individual commands.
+For example, _proxy.feature_ or _cmd-version.feature_.
+
+
+[[running-integration-tests]]
+==== Running Integration Tests
+
+By default, the tests are being run against the binary created by `make build`, which is *_$GOPATH/bin/minishift_*. 
+To run the tests, use the following command:
 
 ----
 $ make integration
@@ -209,17 +223,31 @@ To run integration tests against a Minishift binary in a different location you 
 $ make integration MINISHIFT_BINARY=<path-to-custom-binary>
 ----
 
-Additional properties for Godog runner can be specified with `GODOG_OPTS` argument.
+[[godog-options]]
+==== Using Tags and Other Godog Options
+
+Additional properties for Godog runner can be specified with the `GODOG_OPTS` argument. 
 The following options are available:
 
-- `tags`: Use `tags` to ensure that scenarios and features containing at least one of the selected tags are executed.
-- `paths`: Use `paths` to define paths to different feature files or folders containing feature files.
+Tags::
+Use `tags` to ensure that scenarios and features containing at least one of the selected tags are executed.
+
+Paths::
+Use `paths` to define paths to different feature files or folders containing feature files.
 This can be used to run feature files outside of the *_test/integration/features_* folder.
-- `format`:  Use `format` to change the format of Godog's output.
+
+Format::
+Use `format` to change the format of Godog's output.
 For example, you can use `pretty` format instead of the native `progress`.
-- `stop-on-failure`: Set `stop-on-failure` to true to stop integration tests on failure.
-- `no-colors`: Set `no-colors` to true to disable ansi colors of Godog's output.
-- `definitions`: Set `definitions` to true to print all available step definitions.
+
+Stop-on-failure::
+Set `stop-on-failure` to true to stop integration tests on failure.
+
+No-colors::
+Set `no-colors` to true to disable ansi colors of Godog's output.
+
+Definitions::
+Set `definitions` to true to print all available step definitions.
 
 For example, to run integration tests on two specific feature files using only `@basic` and `@openshift` tags and without ansi colors, the following command can be used:
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9331dcdebd3c68898e6841b0bc140c756c478f2325064216b89d035060cdc066
-updated: 2017-06-23T15:31:41.602757701+05:30
+hash: 8a468283a9a4675c087c7d25a00ce4a72c4fc0f5f05abe60eec93bfce22be14b
+updated: 2017-07-10T11:56:37.047777606+02:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
@@ -60,6 +60,8 @@ imports:
   - libmachine/version
   - libmachine/versioncmp
   - version
+- name: github.com/elazarl/goproxy
+  version: aacba83f36a55ac31cbb71c06547a328c0cd1604
 - name: github.com/fatih/color
   version: 62e9147c64a1ed519147b62a56a14e83e2be02c1
 - name: github.com/fsnotify/fsnotify

--- a/glide.yaml
+++ b/glide.yaml
@@ -60,6 +60,7 @@ import:
   version: 5
 - package: github.com/DATA-DOG/godog
   version: v0.6.2
+- package: github.com/elazarl/goproxy
 # The following repositories need to be specified explicitly, since the versions referenced by the openshift/origin dependency
 # refer to forks of these projects within the openshift organizaton
 # This needs to be manually updated after upgrading the openshift/origin dependnecy

--- a/test/integration/features/cmd-version.feature
+++ b/test/integration/features/cmd-version.feature
@@ -4,4 +4,4 @@ Command "minishift version" shows version of minishift binary.
 
   Scenario: User can get information about version of Minishift
       When executing "minishift version" succeeds
-      Then stdout should match "^minishift v[0-9]\.[0-9]\.[0-9]\+[a-z0-9]{7}\n$"
+      Then stdout should match "^minishift v[0-9]\.[0-9]\.[0-9]\+[a-z0-9]{7,8}\n$"

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -1,0 +1,61 @@
+@proxy @minishift-only
+Feature: Minishift can run behind proxy
+  As a user I can use Minishift behind a proxy.
+  INFO: Code behind this feature will start a proxy server in background
+        on port 8181 and will try to get IP of host machine automatically
+        to set MINISHIFT_HTTP_PROXY for this feature only.
+        However one can override port number or set IP manually if needed.
+        To use custom port number run this test with environmental variable
+        INTEGRATION_PROXY_CUSTOM_PORT.       
+        To use custom IP address please set INTEGRATION_PROXY_CUSTOM_IP
+        environmental variable.
+
+  Scenario: Start behind the proxy
+   Given user starts proxy server and sets MINISHIFT_HTTP_PROXY variable
+    When executing "minishift start" succeeds
+    Then proxy log should contain "Accepting CONNECT to registry-1.docker.io:443"
+     And proxy log should contain "Accepting CONNECT to auth.docker.io:443"
+
+  Scenario: Proxy environmental variable is set in created VM
+    When executing "minishift ssh -- cat /var/lib/boot2docker/profile" succeeds
+    Then stdout should match "HTTP_PROXY=http\:\/\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\:\d{1,5}"
+     And stdout should match "NO_PROXY=localhost,127.0.0.1,172.30.1.1"
+
+  Scenario: User can login to the server
+   Given Minishift has state "Running"
+    When executing "oc login --username=developer --password=developer" succeeds
+    Then stdout should contain
+     """
+     Login successful
+     """
+
+  Scenario: User can create new namespace ruby for application ruby-ex
+   Given Minishift has state "Running"
+    When executing "oc new-project ruby" succeeds
+    Then stdout should contain
+     """
+     Now using project "ruby"
+     """
+
+  Scenario: User can deploy application ruby-ex to namespace ruby
+    Given Minishift has state "Running"
+     When executing "oc new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-ex.git" succeeds
+     Then stdout should contain
+      """
+      Success
+      """
+    When executing "oc rollout status deploymentconfig ruby-ex --watch" succeeds
+    Then stdout should contain
+     """
+     "ruby-ex-1" successfully rolled out
+     """
+     And proxy log should contain "Accepting CONNECT to registry-1.docker.io:443"
+     And proxy log should contain "Accepting CONNECT to bundler.rubygems.org:443"
+     And proxy log should contain "Accepting CONNECT to rubygems.org:443"
+
+  Scenario: Delete behind the proxy
+    When executing "minishift delete" succeeds
+    Then Minishift has state "Does Not Exist"
+
+  Scenario: User stops proxy
+   Given user stops proxy server and unsets MINISHIFT_HTTP_PROXY variable

--- a/test/integration/proxy/proxy.go
+++ b/test/integration/proxy/proxy.go
@@ -1,0 +1,126 @@
+// +build integration
+
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/elazarl/goproxy"
+	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
+)
+
+var (
+	proxyListener net.Listener
+	proxyLog      *bytes.Buffer
+)
+
+const DEFAULT_PROXY_PORT string = "8181"
+
+func GetLog() string {
+	var log string
+	if proxyLog != nil {
+		log = proxyLog.String()
+	}
+
+	return log
+}
+
+func ResetLog(verbose bool) {
+	if GetLog() != "" {
+		if verbose == true {
+			fmt.Printf("beginning of proxy log >>>\n%s<<< end of proxy log\n", GetLog())
+		}
+		proxyLog.Reset()
+	}
+
+	return
+}
+
+func startProxy(proxyPort string) error {
+	var err error
+	proxyListener, err = net.Listen("tcp", ":"+proxyPort)
+	if err != nil {
+		return err
+	}
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Verbose = true
+	proxyLog = bytes.NewBufferString("")
+	proxy.Logger = log.New(proxyLog, "", log.Ldate)
+
+	http.Serve(proxyListener, proxy)
+	fmt.Println("Proxy has stopped.")
+
+	return nil
+}
+
+func getPort() string {
+	if value, present := os.LookupEnv("INTEGRATION_PROXY_CUSTOM_PORT"); present == true {
+		return value
+	}
+
+	return DEFAULT_PROXY_PORT
+}
+
+func getIP() (string, error) {
+	if value, present := os.LookupEnv("INTEGRATION_PROXY_CUSTOM_IP"); present == true {
+		return value, nil
+	}
+
+	ips := minishiftUtil.HostIPs()
+	if ips == nil {
+		return "", errors.New(`No IP found. This might be an error in automated detection of available network devices.
+							   You can use INTEGRATION_PROXY_CUSTOM_IP to set IP manually.`)
+	}
+
+	ip := strings.Split(ips[0], "/")[0]
+	return ip, nil
+}
+
+func SetProxy() error {
+	port := getPort()
+	ip, err := getIP()
+	if err != nil {
+		return err
+	}
+
+	go startProxy(port)
+
+	address := fmt.Sprintf("http://%v:%v", ip, port)
+	os.Setenv("MINISHIFT_HTTP_PROXY", address)
+	fmt.Printf("  INFO: this feature is now using MINISHIFT_HTTP_PROXY=%s\n", os.Getenv("MINISHIFT_HTTP_PROXY"))
+
+	return nil
+}
+
+func UnsetProxy() error {
+	os.Unsetenv("MINISHIFT_HTTP_PROXY")
+	if proxyListener != nil {
+		proxyListener.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds:
- detection of host IP (need verification)
- creation of proxy server
- env var set/unset steps
- destruction of proxy listener
- logging + checking proxy log

Work in progress - I mostly interested how detection of host IP works. For minishift one can't use localhost, but needs IP of host, tested on Fedora when connected via WiFi, not sure how this will work on ethernet, or ethernet + wifi combinations etc.

Thankful for help and feedback.