### PR TITLE
Issue #786 Automated release job via CentOS CI

### DIFF
--- a/docs/source/contributing/ci.adoc
+++ b/docs/source/contributing/ci.adoc
@@ -31,14 +31,17 @@ The following table describes the various CI systems Minishift utilizes and the 
 |Configuration files
 
 |link:https://ci.centos.org/[*CentOS CI*]
-|CentOS CIis the only CI system which can run integration tests, as it supports nested virtualization.
+|CentOS CI is the only CI system which can run integration tests, as it supports nested virtualization.
 Thus it is used to run integration tests in addition to unit tests.
 
 The artifacts of a successful master build can be found at link:http://artifacts.ci.centos.org/minishift/minishift/master/[artifacts.ci.centos.org/minishift/minishift/master/<BUILD_ID>].
 The artifacts of a successful pull request build can be found at link:http://artifacts.ci.centos.org/minishift/minishift/pr/[artifacts.ci.centos.org/minishift/minishift/pr/<PR_ID>].
 
-On top of building the master branch and pull requests, CentOS CI is also used to build the tar bundle used for xref:../contributing/writing-docs.adoc#integration-with-docs-openshift-org[integration with docs.openshift.org].
-|link:https://ci.centos.org/job/minishift/[master], link:https://ci.centos.org/job/minishift-pr/[pull requests], link:https://ci.centos.org/job/minishift-docs/[docs]
+On top of building the master branch and pull requests, CentOS CI is also used to build the tar bundle used for xref:../contributing/writing-docs.adoc#integration-with-docs-openshift-org[integration with docs.openshift.org], as well as to build xref:../contributing/releasing.adoc#automated-release[releases].
+
+
+|link:https://ci.centos.org/job/minishift/[master], link:https://ci.centos.org/job/minishift-pr/[pull requests], link:https://ci.centos.org/job/minishift-docs/[docs],
+link:https://ci.centos.org/job/minishift-release/[release]
 
 |link:https://github.com/minishift/minishift/blob/master/centos_ci.sh[centos_ci.sh]
 

--- a/docs/source/contributing/releasing.adoc
+++ b/docs/source/contributing/releasing.adoc
@@ -21,13 +21,13 @@ The following sections describe how to release Minishift either via automated jo
   For example, issues with a merged pull requests should be labeled as *resolution/done*.
 . Close milestone.
 
-[[auto-release]]
+[[automated-release]]
 == Automated Release
 
-An automated release can be performed by:
+An automated release can be performed by triggering CI job as:
 
 ----
-$ API_KEY=<api-key> RELEASE_VERSION=<version> make ci_release
+$ make ci_release API_KEY=<api-key> RELEASE_VERSION=<version>
 ----
 
 where
@@ -35,13 +35,13 @@ where
   - `api-key` : Minishift CentOS CI API key
   - `version` : Expected release version. Eg : 1.0.0 (without 'v')
 
-In case, you are not able to trigger the job via command line, try running link:https://ci.centos.org/job/minishift-release[release build] by passing required `RELEASE_VERSION` information.
+Once triggered you can follow the release process link:https://ci.centos.org/job/minishift-release/[here].
 
-The automated release perform:
+The automated release performs:
 
-- xref:cut-release[Cutting the Release]
-- xref:trigger-docs-build[Trigger the documentation build]
-- xref:post-release-tasks[Perform Post-Release Tasks]
+- xref:../contributing/releasing.adoc#cut-release[Cutting the Release]
+- xref:../contributing/releasing.adoc#trigger-docs-build[Trigger the documentation build]
+- xref:../contributing/releasing.adoc#post-release-tasks[Perform Post-Release Tasks]
 
 [[manaul-release]]
 == Manual Release

--- a/docs/source/contributing/releasing.adoc
+++ b/docs/source/contributing/releasing.adoc
@@ -2,20 +2,14 @@
 :icons:
 :toc: macro
 :toc-title:
-:toclevels: 1
+:toclevels: 2
 
 toc::[]
 
 [[releasing-overview]]
 == Overview
 
-The following sections describe how to release Minishift.
-
-[[release-prereqs]]
-== Prerequisites
-
-- You must have a https://help.github.com/articles/creating-an-access-token-for-command-line-use[GitHub personal access token]
-defined in your environment as _GITHUB_ACCESS_TOKEN_.
+The following sections describe how to release Minishift either via automated job or manually.
 
 [[preparing-github-milestone]]
 == Preparing the GitHub Milestone
@@ -27,8 +21,45 @@ defined in your environment as _GITHUB_ACCESS_TOKEN_.
   For example, issues with a merged pull requests should be labeled as *resolution/done*.
 . Close milestone.
 
+[[auto-release]]
+== Automated Release
+
+An automated release can be performed by:
+
+----
+$ API_KEY=<api-key> RELEASE_VERSION=<version> make ci_release
+----
+
+where
+
+  - `api-key` : Minishift CentOS CI API key
+  - `version` : Expected release version. Eg : 1.0.0 (without 'v')
+
+In case, you are not able to trigger the job via command line, try running link:https://ci.centos.org/job/minishift-release[release build] by passing required `RELEASE_VERSION` information.
+
+The automated release perform:
+
+- xref:cut-release[Cutting the Release]
+- xref:trigger-docs-build[Trigger the documentation build]
+- xref:post-release-tasks[Perform Post-Release Tasks]
+
+[[manaul-release]]
+== Manual Release
+
+[[release-prereqs]]
+=== Prerequisites
+
+- You must have a https://help.github.com/articles/creating-an-access-token-for-command-line-use[GitHub personal access token]
+defined in your environment as _GITHUB_ACCESS_TOKEN_.
+
 [[cut-release]]
-== Cutting the Release
+=== Cutting the Release
+
+. Run the required checks:
++
+----
+$ make prerelease
+----
 
 . Bump the Minishift version in the link:https://github.com/minishift/minishift/blob/master/Makefile[Makefile].
 
@@ -40,18 +71,19 @@ defined in your environment as _GITHUB_ACCESS_TOKEN_.
 $ make release
 ----
 
-. Trigger the documentation build.
-+
+[[trigger-docs-build]]
+=== Trigger the documentation build
+
 ----
 $ export API_KEY=<api-key>
 $ curl -H "$(curl --user minishift:$API_KEY 'https://ci.centos.org//crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')" -X POST https://ci.centos.org/job/minishift-docs/build --user "minishift:$API_KEY"
 ----
-+
+
 This will build link:http://artifacts.ci.centos.org/minishift/minishift/docs/latest/[minishift-adoc.tar], which will be consumed by *docs.openshift.org* during the next nightly build.
 For more information, see xref:../contributing/writing-docs.adoc#[Writing and Publishing Minishift Documentation].
 
 [[post-release-tasks]]
-== Post-Release Tasks
+=== Post-Release Tasks
 
 As part of the release process we also send a release announcement and edit the GitHub release page.
 


### PR DESCRIPTION
Fix #786 

Last successful automated job was https://ci.centos.org/job/minishift-release/41/ which released https://github.com/minishift-bot/minishift/releases/tag/v1.2.13.

Apart from `TODO` comments code is ready for release job.

Will update the TODO part after final comment. 
You can try running the build using the instruction given in `contributing/release > Automated Release` section.

Use `RELEASE_VERSION` apart from version listed [here](https://github.com/minishift-bot/minishift/tags) and `MILESTONE_ID` from [closed milestones](https://github.com/minishift/minishift/milestones?state=closed). I used 15 and 17. 