### PR TITLE
Issue #1133 Fix and split jsonConfigContains, add regexp support

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -49,12 +49,12 @@ Feature: Basic
     and its subcommands, changing values stored in "config/config.json".
     Given Minishift has state "Running"
      When executing "minishift config set <property> <value>" succeeds
-     Then JSON config file "config/config.json" contains key "<property>" with value "<value>"
+     Then JSON config file "config/config.json" contains key "<property>" with value matching "<value>"
       And stdout of command "minishift config get <property>" is equal to "<value>"
       And stdout of command "minishift config view --format {{.ConfigKey}}:{{.ConfigValue}}" contains "<property>:<value>"
      When executing "minishift config unset <property>" succeeds
      Then stdout of command "minishift config get <property>" is equal to "<nil>"
-      And JSON config file "config/config.json" does not contain key "<property>"
+      And JSON config file "config/config.json" does not have key "<property>"
 
   Examples: Config values to work with
     | property  | value |


### PR DESCRIPTION
Splits configContains into 3 separate functions: jsonConfigContains compares actual and expected key values, jsonConfigHasKey - checks whether key has any value, getConfigValue - gets the actual value.

Adds support for regular expressions in field of expected key values.
