### PR TITLE
Issue #1153 Proxy not set for Docker engine

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -262,7 +262,7 @@ func startHost(libMachineClient *libmachine.Client) (*host.Host, string) {
 		CPUs:             viper.GetInt(startFlags.CPUs.Name),
 		DiskSize:         calculateDiskSizeInMB(viper.GetString(startFlags.DiskSize.Name)),
 		VMDriver:         viper.GetString(startFlags.VmDriver.Name),
-		DockerEnv:        getSlice(startFlags.DockerEnv.Name),
+		DockerEnv:        dockerEnv,
 		DockerEngineOpt:  getSlice(startFlags.DockerEngineOpt.Name),
 		InsecureRegistry: determineInsecureRegistry(startFlags.InsecureRegistry.Name),
 		RegistryMirror:   getSlice(startFlags.RegistryMirror.Name),


### PR DESCRIPTION
Using dockerEnv variable when collection machine information upon creation. This is done to fix issue with proxy not being used by the docker engine when no --docker-env parameter is given as well as correctly handling the case where both --docker-env and --http-proxy are used.