### PR TITLE
Issue #1123 update xhyve manual install instructions

### DIFF
--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -130,7 +130,7 @@ $ sudo chown root:wheel /usr/local/bin/docker-machine-driver-xhyve
 . Set owner User ID (SUID) for the binary as follows:
 +
 ----
-$ sudo chmod u+s /usr/local/bin/docker-machine-driver-xhyve
+$ sudo chmod u+s,+x /usr/local/bin/docker-machine-driver-xhyve
 ----
 
 [NOTE]


### PR DESCRIPTION
Fixes issue #1123 

This PR adds an additional flag to the command in step 3 of the manual installation of xhyve.