### PR TITLE
Issue #485 Improve startup feedback

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -52,54 +52,78 @@ const (
 
 var (
 	// minishift
-	ISOUrl           = createFlag("iso-url", SetString, []setFn{IsValidUrl}, []setFn{RequiresRestartMsg}, true)
-	CPUs             = createFlag("cpus", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
-	Memory           = createFlag("memory", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
-	DiskSize         = createFlag("disk-size", SetString, []setFn{IsValidDiskSize}, []setFn{RequiresRestartMsg}, true)
-	VmDriver         = createFlag("vm-driver", SetString, []setFn{IsValidDriver}, []setFn{RequiresRestartMsg}, true)
-	OpenshiftVersion = createFlag("openshift-version", SetString, nil, nil, true)
-	HostOnlyCIDR     = createFlag("host-only-cidr", SetString, []setFn{IsValidCIDR}, nil, true)
-	DockerEnv        = createFlag("docker-env", SetSlice, nil, nil, true)
-	DockerEngineOpt  = createFlag("docker-opt", SetSlice, nil, nil, true)
-	InsecureRegistry = createFlag("insecure-registry", SetSlice, nil, nil, true)
-	RegistryMirror   = createFlag("registry-mirror", SetSlice, nil, nil, true)
-	AddonEnv         = createFlag("addon-env", SetSlice, nil, nil, true)
+	ISOUrl           = createConfigSetting("iso-url", SetString, []setFn{IsValidUrl}, []setFn{RequiresRestartMsg}, true)
+	CPUs             = createConfigSetting("cpus", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
+	Memory           = createConfigSetting("memory", SetInt, []setFn{IsPositive}, []setFn{RequiresRestartMsg}, true)
+	DiskSize         = createConfigSetting("disk-size", SetString, []setFn{IsValidDiskSize}, []setFn{RequiresRestartMsg}, true)
+	VmDriver         = createConfigSetting("vm-driver", SetString, []setFn{IsValidDriver}, []setFn{RequiresRestartMsg}, true)
+	OpenshiftVersion = createConfigSetting("openshift-version", SetString, nil, nil, true)
+	HostOnlyCIDR     = createConfigSetting("host-only-cidr", SetString, []setFn{IsValidCIDR}, nil, true)
+	DockerEnv        = createConfigSetting("docker-env", SetSlice, nil, nil, true)
+	DockerEngineOpt  = createConfigSetting("docker-opt", SetSlice, nil, nil, true)
+	InsecureRegistry = createConfigSetting("insecure-registry", SetSlice, nil, nil, true)
+	RegistryMirror   = createConfigSetting("registry-mirror", SetSlice, nil, nil, true)
+	AddonEnv         = createConfigSetting("addon-env", SetSlice, nil, nil, true)
 
 	// cluster up
-	SkipRegistryCheck = createFlag("skip-registry-check", SetBool, nil, nil, true)
-	PublicHostname    = createFlag("public-hostname", SetString, nil, nil, true)
-	RoutingSuffix     = createFlag("routing-suffix", SetString, nil, nil, true)
-	HostConfigDir     = createFlag("host-config-dir", SetString, []setFn{IsValidPath}, nil, true)
-	HostVolumeDir     = createFlag("host-volumes-dir", SetString, []setFn{IsValidPath}, nil, true)
-	HostDataDir       = createFlag("host-data-dir", SetString, []setFn{IsValidPath}, nil, true)
-	HostPvDir         = createFlag("host-pv-dir", SetString, []setFn{IsValidPath}, nil, true)
-	ServerLogLevel    = createFlag("server-loglevel", SetInt, []setFn{IsPositive}, nil, true)
-	OpenshiftEnv      = createFlag("openshift-env", nil, nil, nil, false)
-	Metrics           = createFlag("metrics", SetBool, nil, nil, true)
-	Logging           = createFlag("logging", SetBool, nil, nil, true)
+	SkipRegistryCheck = createConfigSetting("skip-registry-check", SetBool, nil, nil, true)
+	PublicHostname    = createConfigSetting("public-hostname", SetString, nil, nil, true)
+	RoutingSuffix     = createConfigSetting("routing-suffix", SetString, nil, nil, true)
+	HostConfigDir     = createConfigSetting("host-config-dir", SetString, []setFn{IsValidPath}, nil, true)
+	HostVolumeDir     = createConfigSetting("host-volumes-dir", SetString, []setFn{IsValidPath}, nil, true)
+	HostDataDir       = createConfigSetting("host-data-dir", SetString, []setFn{IsValidPath}, nil, true)
+	HostPvDir         = createConfigSetting("host-pv-dir", SetString, []setFn{IsValidPath}, nil, true)
+	ServerLogLevel    = createConfigSetting("server-loglevel", SetInt, []setFn{IsPositive}, nil, true)
+	OpenshiftEnv      = createConfigSetting("openshift-env", nil, nil, nil, false)
+	Metrics           = createConfigSetting("metrics", SetBool, nil, nil, true)
+	Logging           = createConfigSetting("logging", SetBool, nil, nil, true)
 
 	// Setting proxy
-	NoProxyList = createFlag("no-proxy", SetString, nil, nil, true)
-	HttpProxy   = createFlag("http-proxy", SetString, []setFn{IsValidProxy}, nil, true)
-	HttpsProxy  = createFlag("https-proxy", SetString, []setFn{IsValidProxy}, nil, true)
+	NoProxyList = createConfigSetting("no-proxy", SetString, nil, nil, true)
+	HttpProxy   = createConfigSetting("http-proxy", SetString, []setFn{IsValidProxy}, nil, true)
+	HttpsProxy  = createConfigSetting("https-proxy", SetString, []setFn{IsValidProxy}, nil, true)
 
 	// Subscription Manager
-	Username         = createFlag("username", SetString, nil, nil, true)
-	Password         = createFlag("password", SetString, nil, nil, true)
-	SkipRegistration = createFlag("skip-registration", SetBool, nil, nil, true)
+	Username         = createConfigSetting("username", SetString, nil, nil, true)
+	Password         = createConfigSetting("password", SetString, nil, nil, true)
+	SkipRegistration = createConfigSetting("skip-registration", SetBool, nil, nil, true)
 
 	// Global flags
-	LogDir             = createFlag("log_dir", SetString, []setFn{IsValidPath}, nil, true)
-	ShowLibmachineLogs = createFlag("show-libmachine-logs", SetBool, nil, nil, true)
+	LogDir             = createConfigSetting("log_dir", SetString, []setFn{IsValidPath}, nil, true)
+	ShowLibmachineLogs = createConfigSetting("show-libmachine-logs", SetBool, nil, nil, true)
 
 	// Host Folders
-	HostFoldersMountPath = createFlag("hostfolders-mountpath", SetString, nil, nil, true)
-	HostFoldersAutoMount = createFlag("hostfolders-automount", SetBool, nil, nil, true)
+	HostFoldersMountPath = createConfigSetting("hostfolders-mountpath", SetString, nil, nil, true)
+	HostFoldersAutoMount = createConfigSetting("hostfolders-automount", SetBool, nil, nil, true)
 
-	ImageCaching = createFlag("image-caching", SetBool, nil, nil, true)
+	ImageCaching = createConfigSetting("image-caching", SetBool, nil, nil, true)
+
+	// Preflight checks (before start)
+	SkipCheckKVMDriver    = createConfigSetting("skip-check-kvm-driver", SetBool, nil, nil, true)
+	WarnCheckKVMDriver    = createConfigSetting("warn-check-kvm-driver", SetBool, nil, nil, true)
+	SkipCheckXHyveDriver  = createConfigSetting("skip-check-xhyve-driver", SetBool, nil, nil, true)
+	WarnCheckXHyveDriver  = createConfigSetting("warn-check-xhyve-driver", SetBool, nil, nil, true)
+	SkipCheckHyperVDriver = createConfigSetting("skip-check-hyperv-driver", SetBool, nil, nil, true)
+	WarnCheckHyperVDriver = createConfigSetting("warn-check-hyperv-driver", SetBool, nil, nil, true)
+	// Preflight checks (after start)
+	SkipInstanceIP        = createConfigSetting("skip-check-instance-ip", SetBool, nil, nil, true)
+	WarnInstanceIP        = createConfigSetting("warn-check-instance-ip", SetBool, nil, nil, true)
+	SkipCheckNetworkHost  = createConfigSetting("skip-check-network-host", SetBool, nil, nil, true)
+	WarnCheckNetworkHost  = createConfigSetting("warn-check-network-host", SetBool, nil, nil, true)
+	SkipCheckNetworkPing  = createConfigSetting("skip-check-network-ping", SetBool, nil, nil, true)
+	WarnCheckNetworkPing  = createConfigSetting("warn-check-network-ping", SetBool, nil, nil, true)
+	SkipCheckNetworkHTTP  = createConfigSetting("skip-check-network-http", SetBool, nil, nil, true)
+	WarnCheckNetworkHTTP  = createConfigSetting("warn-check-network-http", SetBool, nil, nil, true)
+	SkipCheckStorageMount = createConfigSetting("skip-check-storage-mount", SetBool, nil, nil, true)
+	WarnCheckStorageMount = createConfigSetting("warn-check-storage-mount", SetBool, nil, nil, true)
+	SkipCheckStorageUsage = createConfigSetting("skip-check-storage-usage", SetBool, nil, nil, true)
+	WarnCheckStorageUsage = createConfigSetting("warn-check-storage-usage", SetBool, nil, nil, true)
+	// Preflight values
+	CheckNetworkHttpHost = createConfigSetting("check-network-http-host", SetString, nil, nil, true)
+	CheckNetworkPingHost = createConfigSetting("check-network-ping-host", SetString, nil, nil, true)
 )
 
-func createFlag(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool) *Setting {
+func createConfigSetting(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool) *Setting {
 	flag := Setting{
 		Name:        name,
 		set:         set,

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -225,7 +225,7 @@ func performPostUpdateExecution(markerPath string) error {
 	json.Unmarshal(file, &markerData)
 	if markerData.InstallAddon {
 		fmt.Println(fmt.Sprintf("Minishift was upgraded from v%s to v%s. Running post update actions.", markerData.PreviousVersion, version.GetMinishiftVersion()))
-		fmt.Print("--- Updating default add-ons ... ")
+		fmt.Print("-- Updating default add-ons ... ")
 		util.UnpackAddons(constants.MakeMiniPath("add-ons"))
 		fmt.Println("OK")
 		fmt.Println(fmt.Sprintf("Default add-ons %s installed", strings.Join(util.DefaultAssets, ", ")))

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -1,0 +1,331 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/docker/machine/libmachine/drivers"
+	startFlags "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	miniutil "github.com/minishift/minishift/pkg/minishift/util"
+
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/viper"
+)
+
+const (
+	StorageDisk = "/mnt/sda1"
+)
+
+// preflightChecksAfterStartingHost is executed before the startHost function.
+func preflightChecksBeforeStartingHost() {
+	switch viper.GetString(startFlags.VmDriver.Name) {
+	case "xhyve":
+		preflightCheckSucceedsOrFails(
+			startFlags.SkipCheckXHyveDriver.Name,
+			checkXhyveDriver,
+			"Checking if xhyve driver is installed",
+			false, startFlags.WarnCheckXHyveDriver.Name,
+			"See the 'Setting Up the Driver Plug-in' topic for more information")
+	case "kvm":
+		preflightCheckSucceedsOrFails(
+			startFlags.SkipCheckKVMDriver.Name,
+			checkKvmDriver,
+			"Checking if KVM driver is installed",
+			false, startFlags.WarnCheckXHyveDriver.Name,
+			"See the 'Setting Up the Driver Plug-in' topic for more information")
+	case "hyperv":
+		preflightCheckSucceedsOrFails(
+			startFlags.SkipCheckHyperVDriver.Name,
+			checkHypervDriver,
+			"Checking if Hyper-V driver is configured",
+			false, startFlags.WarnCheckHyperVDriver.Name,
+			"Hyper-V virtual switch is not set")
+	}
+}
+
+// preflightChecksAfterStartingHost is executed after the startHost function.
+func preflightChecksAfterStartingHost(driver drivers.Driver) {
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipInstanceIP.Name,
+		checkInstanceIP, driver,
+		"Checking for IP address",
+		false, startFlags.WarnInstanceIP.Name,
+		"Error determining IP address")
+	/*
+		// This happens too late in the preflight, as provisioning needs an IP already
+			preflightCheckSucceedsOrFailsWithDriver(
+				startFlags.SkipCheckNetworkHost.Name,
+				checkVMConnectivity, driver,
+				"Checking if VM is reachable from host",
+				startFlags.WarnCheckNetworkHost.Name,
+				"Please check our troubleshooting guide")
+	*/
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckNetworkPing.Name,
+		checkIPConnectivity, driver,
+		"Checking if external host is reachable from the Minishift VM",
+		true, startFlags.WarnCheckNetworkPing.Name,
+		"VM is unable to ping external host")
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckNetworkHTTP.Name,
+		checkHttpConnectivity, driver,
+		"Checking HTTP connectivity from the VM",
+		true, startFlags.WarnCheckNetworkHTTP.Name,
+		"VM cannot connect to external URL with HTTP")
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckStorageMount.Name,
+		checkStorageMounted, driver,
+		"Checking if persistent storage volume is mounted",
+		false, startFlags.WarnCheckStorageMount.Name,
+		"Persistent volume storage is not mounted")
+	preflightCheckSucceedsOrFailsWithDriver(
+		startFlags.SkipCheckStorageUsage.Name,
+		checkStorageUsage, driver,
+		"Checking available disk space",
+		false, startFlags.WarnCheckStorageUsage.Name,
+		"Insufficient disk space on the persistent storage volume")
+}
+
+// preflightCheckFunc returns true when check passed
+type preflightCheckFunc func() bool
+
+// preflightCheckFunc used driver to interact with the VM instance and returns
+// true when check passed
+type preflightCheckWithDriverFunc func(driver drivers.Driver) bool
+
+// preflightCheckSucceedsOrFails executes a pre-flight test function and prints
+// the returned status in a standardized way. If the test fails and returns a
+// false, the application will exit with errorMessage to describe what the
+// cause is. It takes configNameOverrideIfSkipped to allow skipping the test.
+// While treatAsWarning and configNameOverrideIfWarning can be used to make the
+// test to be treated as a warning instead.
+func preflightCheckSucceedsOrFails(configNameOverrideIfSkipped string, execute preflightCheckFunc, message string, treatAsWarning bool, configNameOverrideIfWarning string, errorMessage string) {
+	fmt.Printf("-- %s ... ", message)
+
+	isConfiguredToSkip := viper.GetBool(configNameOverrideIfSkipped)
+	isConfiguredToWarn := viper.GetBool(configNameOverrideIfWarning)
+
+	if isConfiguredToSkip {
+		fmt.Println("SKIP")
+		return
+	}
+
+	if execute() {
+		fmt.Println("OK")
+		return
+	}
+
+	fmt.Println("FAIL")
+	errorMessage = fmt.Sprintf("   %s", errorMessage)
+	if isConfiguredToWarn || treatAsWarning {
+		fmt.Println(errorMessage)
+	} else {
+		atexit.ExitWithMessage(1, errorMessage)
+	}
+}
+
+// preflightCheckSucceedsOrFails executes a pre-flight test function which uses
+// the driver to interact with the VM instance. It prints the returned status in
+// a standardized way. If the test fails and returns a false, the application
+// will exit with errorMessage to describe what the cause is. It takes
+// configNameOverrideIfSkipped to allow skipping the test. While treatAsWarning
+// and configNameOverrideIfWarning can be used to make the test to be treated as
+// a warning instead.
+func preflightCheckSucceedsOrFailsWithDriver(configNameOverrideIfSkipped string, execute preflightCheckWithDriverFunc, driver drivers.Driver, message string, treatAsWarning bool, configNameOverrideIfWarning string, errorMessage string) {
+	fmt.Printf("-- %s ... ", message)
+
+	isConfiguredToSkip := viper.GetBool(configNameOverrideIfSkipped)
+	isConfiguredToWarn := viper.GetBool(configNameOverrideIfWarning)
+
+	if isConfiguredToSkip {
+		fmt.Println("SKIP")
+		return
+	}
+
+	if execute(driver) {
+		fmt.Println("OK")
+		return
+	}
+
+	fmt.Println("FAIL")
+	errorMessage = fmt.Sprintf("   %s", errorMessage)
+	if isConfiguredToWarn || treatAsWarning {
+		fmt.Println(errorMessage)
+	} else {
+		atexit.ExitWithMessage(1, errorMessage)
+	}
+}
+
+// checkXhyveDriver returns true if xhyve driver is available on path and has
+// the setuid-bit set
+func checkXhyveDriver() bool {
+	path, err := exec.LookPath("docker-machine-driver-xhyve")
+
+	if err != nil {
+		return false
+	}
+
+	fi, _ := os.Stat(path)
+	// follow symlinks
+	if fi.Mode()&os.ModeSymlink != 0 {
+		path, err = os.Readlink(path)
+		if err != nil {
+			return false
+		}
+	}
+	fmt.Println("\n   Driver is available at", path)
+
+	fmt.Printf("   Checking for setuid bit ... ")
+	if fi.Mode()&os.ModeSetuid == 0 {
+		return false
+	}
+
+	return true
+}
+
+// checkKvmDriver returns true if KVM driver is available on path
+func checkKvmDriver() bool {
+	path, err := exec.LookPath("docker-machine-driver-kvm")
+	if err != nil {
+		return false
+	}
+	fmt.Printf(fmt.Sprintf("\n   Driver is available at %s ... ", path))
+
+	return true
+}
+
+// checkHypervDriver returns true if Virtual Switch has been selected
+func checkHypervDriver() bool {
+	switchEnv := os.Getenv("HYPERV_VIRTUAL_SWITCH")
+	if switchEnv == "" {
+		return false
+	}
+	return true
+}
+
+// checkInstanceIP makes sure the instance has an IPv4 address.
+// HyperV will issue IPv6 addresses on Internal virtual switch
+// https://github.com/minishift/minishift/issues/418
+func checkInstanceIP(driver drivers.Driver) bool {
+	ip, err := driver.GetIP()
+	if err == nil && net.ParseIP(ip).To4() != nil {
+		return true
+	}
+	return false
+}
+
+// checkVMConnectivity checks if VM instance IP is reachable from the host
+func checkVMConnectivity(driver drivers.Driver) bool {
+	// used to check if the host can reach the VM
+	ip, _ := driver.GetIP()
+
+	cmd := exec.Command("ping", "-n 1", ip)
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	fmt.Printf("%s\n", stdoutStderr)
+	return false
+}
+
+// checkIPConnectivity checks if the VM has connectivity to the outside network
+func checkIPConnectivity(driver drivers.Driver) bool {
+	ipToPing := viper.GetString(startFlags.CheckNetworkPingHost.Name)
+	if ipToPing == "" {
+		ipToPing = "8.8.8.8"
+	}
+
+	fmt.Printf("\n   Pinging %s ... ", ipToPing)
+	return miniutil.IsIPReachable(driver, ipToPing, false)
+}
+
+// checkHttpConnectivity allows to test outside connectivity and possible proxy support
+func checkHttpConnectivity(driver drivers.Driver) bool {
+	urlToRetrieve := viper.GetString(startFlags.CheckNetworkHttpHost.Name)
+	if urlToRetrieve == "" {
+		urlToRetrieve = "http://minishift.io/index.html"
+	}
+
+	fmt.Printf("\n   Retrieving %s ... ", urlToRetrieve)
+	return miniutil.IsRetrievable(driver, urlToRetrieve, false)
+}
+
+// checkStorageMounted checks if the peristent storage volume, storageDisk, is
+// mounted to the VM instance
+func checkStorageMounted(driver drivers.Driver) bool {
+	mounted, _ := isMounted(driver, StorageDisk)
+	return mounted
+}
+
+// checkStorageUsage checks if the peristent storage volume has enough storage
+// space available.
+func checkStorageUsage(driver drivers.Driver) bool {
+	usedPercentage := getDiskUsage(driver, StorageDisk)
+	fmt.Printf("%s ", usedPercentage)
+	usedPercentage = strings.TrimRight(usedPercentage, "%")
+	usage, err := strconv.ParseInt(usedPercentage, 10, 8)
+	if err != nil {
+		return false
+	}
+
+	if usage > 80 && usage < 95 {
+		fmt.Printf("!!! ")
+	}
+	if usage < 95 {
+		return true
+	}
+	return false
+}
+
+// isMounted checks returns usage of mountpoint known to the VM instance
+func getDiskUsage(driver drivers.Driver, mountpoint string) string {
+	cmd := fmt.Sprintf(
+		"df -h %s | awk 'FNR > 1 {print $5}'",
+		mountpoint)
+
+	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
+
+	if err != nil {
+		return "ERR"
+	}
+
+	return strings.Trim(out, "\n")
+}
+
+// isMounted checks if mountpoint is mounted to the VM instance
+func isMounted(driver drivers.Driver, mountpoint string) (bool, error) {
+	cmd := fmt.Sprintf(
+		"if grep -qs %s /proc/mounts; then echo '1'; else echo '0'; fi",
+		mountpoint)
+
+	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
+
+	if err != nil {
+		return false, err
+	}
+	if strings.Trim(out, "\n") == "0" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -29,7 +29,7 @@ The following steps describe how to get started with Minishift on a GNU/Linux op
 +
 ----
 $ minishift start
-Starting local OpenShift cluster using 'kvm' hypervisor...
+-- Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
    OpenShift server started.
    The server is accessible via web console at:
@@ -50,6 +50,9 @@ To check the IP, run the `minishift ip` command.
 - By default, Minishift uses the driver most relevant to the host OS.
 To use a different driver, set the `--vm-driver` flag in `minishift start`.
 For example, to use VirtualBox instead of KVM on GNU/Linux operating systems, run `minishift start --vm-driver=virtualbox`.
+- While Minishift starts it runs several checks to make sure that the Minishift VM and the OpenShift cluster are able to start correctly.
+If any startup checks fail, see the xref:../using/troubleshooting.adoc#[troubleshooting] topic for information about possible causes and solutions.
+
 For more information about `minishift start` options, see the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
 ====
 

--- a/docs/source/using/troubleshooting.adoc
+++ b/docs/source/using/troubleshooting.adoc
@@ -243,3 +243,71 @@ Workaround: Avoid installing packages or storing large files in the root filesys
 Instead, you can create a sub-directory in the *_mnt/sda1/_* persistent storage volume or define and mount xref:../using/host-folders.adoc#[host folders] that can share storage space between the host and the Minishift VM.
 
 If you want to perform development tasks inside the Minishift VM, it is recommended that you use containers, which are stored in persistent storage volumes, and reuse the xref:../using/docker-daemon.adoc#[Minishift Docker daemon].
+
+
+[[minshift-startup-check-failed]]
+== Minishift startup check failed
+
+While Minishift starts, it runs several startup checks to make sure that the Minishift VM and the OpenShift Cluster are able to start without any issues.
+If any configuration is incorrect or missing, the startup checks fail and Minishift does not start.
+
+The following sections describe the different startup checks.
+
+Driver plug-in configuration::
+One of the startup checks verifies that the relevant driver plug-in is configured correctly.
+If this startup check fails, review the xref:../getting-started/setting-up-driver-plugin.adoc#[setting up the driver plug-in] topic and configure the driver.
+
+If you want to force Minishift to start despite any failed checks, you can instruct Minishift to treat these errors as warnings as follows:
+
+- For KVM/Libvirt on Linux, run the following command:
++
+----
+$ minishift config set warn-check-kvm-driver true
+----
+
+- For xhyve on macOS, run the following command:
++
+----
+$ minishift config set warn-check-xhyve-driver true
+----
+
+- For Hyper-V on Windows, run the following command:
++
+----
+$ minishift config set warn-check-hyperv-driver true
+----
+
+
+Persistent storage volume configuration and usage::
+Minishift checks whether the persistent storage volume is mounted and that enough disk space is available.
++
+For example, if the persistent storage volume uses more than 95% of the available disk space, then Minishift will not start.
++
+If you want to recover the data, you can skip this test and start Minishift to access the persistent volume.
+To skip this test, run run the following command:
++
+----
+$ minishift config set skip-check-storage-usage true
+----
+
+External network connectivity::
+After the Minishift VM starts, it runs several network checks to verify whether external connectivity is possible from within the Minishift VM.
++
+By default, network checks are configured to treat the errors as warnings, because of the diversity of the development environments.
+You can configure the network checks to optimize them for your environment.
++
+For example, one of the network checks pings an external host. You can change the host by running the following command:
++
+----
+$ minishift config set check-network-ping-host <host-IP-address>
+----
++
+You can replace the `host IP address` with the address of your internal DNS server, proxy host, or an external host that you can reach from your machine.
++
+Because proxy connectivity might be problematic, you can run a check that tries to retrieve an external resource.
+You can change the URL by running the following command:
++
+----
+$ minishift config set check-network-http-host <URL>
+----
+

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -229,7 +229,7 @@ func createDriverOptions(driver drivers.Driver, explicitOptions map[string]inter
 // CacheMinikubeISOFromURL download minishift ISO from a given URI.
 // It also checks sha256sum if present and then put ISO to cached directory.
 func (m *MachineConfig) CacheMinikubeISOFromURL() error {
-	fmt.Println(fmt.Sprintf("Downloading ISO '%s'", m.MinikubeISO))
+	fmt.Println(fmt.Sprintf("\n   Downloading ISO '%s'", m.MinikubeISO))
 	tmpISOFile, err := os.Create(m.GetISOCacheFilepath() + ".part")
 	if err != nil {
 		return err
@@ -399,9 +399,12 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	}
 
 	if config.ShellProxyEnv != "" {
+		fmt.Printf("-- Setting proxy information ... ")
 		if err := minishiftUtil.SetProxyToShellEnv(h, config.ShellProxyEnv); err != nil {
+			fmt.Println("FAIL")
 			return nil, fmt.Errorf("Error setting proxy to VM: %s", err)
 		}
+		fmt.Println("OK")
 	}
 
 	return h, nil

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -64,10 +64,14 @@ type ClusterUpConfig struct {
 func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runner util.Runner) error {
 	cmdArgs := []string{"cluster", "up", "--use-existing-config"}
 
+	fmt.Println("-- Checking `oc` support for startup flags ... ")
 	for key, value := range clusterUpParams {
+		fmt.Printf("   %s ... ", key)
 		if !oc.SupportFlag(key, config.OcPath, runner) {
+			fmt.Println("FAIL")
 			return errors.New(fmt.Sprintf("Flag %s is not supported for oc version %s. Use 'openshift-version' flag to select a different version of OpenShift.", key, config.OpenShiftVersion))
 		}
+		fmt.Println("OK")
 		cmdArgs = append(cmdArgs, "--"+key)
 		cmdArgs = append(cmdArgs, value)
 	}

--- a/pkg/minishift/hostfolder/hostfolder.go
+++ b/pkg/minishift/hostfolder/hostfolder.go
@@ -285,9 +285,8 @@ func determineHostIp(driver drivers.Driver) (string, error) {
 			hostip, _, _ := net.ParseCIDR(hostaddr)
 			if miniutil.IsIPReachable(driver, hostip.String(), false) {
 				return hostip.String(), nil
-			} else {
-				return "", errors.New("Unreachable")
 			}
+			return "", errors.New("Unreachable")
 		}
 	}
 

--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -111,8 +111,12 @@ func (provisioner *MinishiftProvisioner) Provision(swarmOptions swarm.Options, a
 	}
 	provisioner.EngineOptions.StorageDriver = storageDriver
 
+	fmt.Printf("\n   Setting hostname ... ")
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
+		fmt.Println("FAIL")
 		return err
+	} else {
+		fmt.Println("OK")
 	}
 
 	if err := mcnutils.WaitFor(provisioner.dockerDaemonResponding); err != nil {

--- a/pkg/minishift/util/hostip.go
+++ b/pkg/minishift/util/hostip.go
@@ -23,6 +23,28 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 )
 
+func IsRetrievable(driver drivers.Driver, url string, printOutput bool) bool {
+	cmd := fmt.Sprintf(
+		"curl -s -m 5 %s > /dev/null 2>&1",
+		url)
+
+	if printOutput {
+		print(fmt.Sprintf("   Checking if '%s' is retrievable ... ", url))
+	}
+
+	if _, err := drivers.RunSSHCommandFromDriver(driver, cmd); err != nil {
+		if printOutput {
+			print("FAIL\n")
+		}
+		return false
+	}
+
+	if printOutput {
+		print("OK\n")
+	}
+	return true
+}
+
 // IsIPReachable returns true is IP address is reachable from the virtual instance
 func IsIPReachable(driver drivers.Driver, ip string, printOutput bool) bool {
 	cmd := fmt.Sprintf(

--- a/pkg/util/github/github.go
+++ b/pkg/util/github/github.go
@@ -125,7 +125,7 @@ func DownloadOpenShiftReleaseBinary(binaryType OpenShiftBinaryType, osType minis
 		return errors.Wrap(err, fmt.Sprintf("Cannot download OpenShift release asset %d", assetID))
 	}
 	if len(url) > 0 {
-		fmt.Println(fmt.Sprintf("Downloading OpenShift binary '%s' version '%s'", binaryType.String(), *release.TagName))
+		fmt.Println(fmt.Sprintf("-- Downloading OpenShift binary '%s' version '%s'", binaryType.String(), *release.TagName))
 		httpResp, err := http.Get(url)
 		if err != nil {
 			return errors.Wrap(err, "Cannot download OpenShift release asset.")


### PR DESCRIPTION
This fixes #485 

Several checks are performed to improve the feedback to the user. Such as basic test if the driver exists, if storage disk is mounted, warn when issues occur with connectivity, etc...

However, one of the major issues remains; checking if the host is reachable before provisioning. This happens lower down the stack (docker-machine) and therefore we are at the moment unable to detect issues which are caused by VPN usage.
