### PR TITLE
Issue #1153 Proxy set not working with docker env

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -236,9 +236,13 @@ func handleProxies() *util.ProxyConfig {
 	return proxyConfig
 }
 
+// getSlice return slice for provided key if value type is []interface{} otherwise nil
 func getSlice(key string) []string {
 	if viper.IsSet(key) {
-		return viper.GetStringSlice(key)
+		value := viper.Get(key)
+		if _, ok := value.([]interface{}); ok {
+			return viper.GetStringSlice(key)
+		}
 	}
 	return nil
 }
@@ -262,10 +266,10 @@ func startHost(libMachineClient *libmachine.Client) (*host.Host, string) {
 		CPUs:             viper.GetInt(startFlags.CPUs.Name),
 		DiskSize:         calculateDiskSizeInMB(viper.GetString(startFlags.DiskSize.Name)),
 		VMDriver:         viper.GetString(startFlags.VmDriver.Name),
-		DockerEnv:        getSlice(startFlags.DockerEnv.Name),
-		DockerEngineOpt:  getSlice(startFlags.DockerEngineOpt.Name),
+		DockerEnv:        append(dockerEnv, getSlice(startFlags.DockerEnv.Name)...),
+		DockerEngineOpt:  append(dockerEngineOpt, getSlice(startFlags.DockerEngineOpt.Name)...),
 		InsecureRegistry: determineInsecureRegistry(startFlags.InsecureRegistry.Name),
-		RegistryMirror:   getSlice(startFlags.RegistryMirror.Name),
+		RegistryMirror:   append(registryMirror, getSlice(startFlags.RegistryMirror.Name)...),
 		HostOnlyCIDR:     viper.GetString(startFlags.HostOnlyCIDR.Name),
 		ShellProxyEnv:    shellProxyEnv,
 	}

--- a/cmd/minishift/cmd/start_test.go
+++ b/cmd/minishift/cmd/start_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/minishift/minishift/cmd/minishift/cmd/config"
 
 	"fmt"
+	"sort"
+	"strings"
+
+	"bytes"
+
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/tests"
 	"github.com/minishift/minishift/pkg/minishift/clusterup"
@@ -36,8 +41,6 @@ import (
 	"github.com/minishift/minishift/pkg/testing/cli"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/viper"
-	"sort"
-	"strings"
 )
 
 var (
@@ -382,6 +385,37 @@ func TestDetermineIsoUrlWithInvalidName(t *testing.T) {
 	defer tearDown()
 
 	determineIsoUrl("foo")
+}
+
+func Test_getslice_withConfig(t *testing.T) {
+	viper.SetConfigType("json")
+	defer viper.Reset()
+	var confFile = []byte(`
+{
+    "bar": [
+        "hello",
+        "world"
+    ]
+}
+	`)
+
+	viper.ReadConfig(bytes.NewBuffer(confFile))
+
+	expectedSlice := []string{"hello", "world"}
+	for i, v := range getSlice("bar") {
+		if expectedSlice[i] != v {
+			t.Errorf("expected %+v. Got %+v", expectedSlice[i], v)
+		}
+	}
+}
+
+func Test_getslice_withCommandLine(t *testing.T) {
+	viper.Set("foo", []string{"hello", "world"})
+	defer viper.Reset()
+
+	if getSlice("foo") != nil {
+		t.Errorf("expected %+v. Got %+v", nil, getSlice("foo"))
+	}
 }
 
 func assertCommandLineArguments(expectedArguments []string, t *testing.T) {


### PR DESCRIPTION
This will close #1154 because what we need a solution which works for CLI arguments and config set both. if we only apply @nimatt patch part of his PR then it will only going to work with CLI arguments and then if I set anything in the config set that would fail. 

```
# PR from @nimatt
$ ./minishift start --http-proxy http://fedora:fedora123@10.70.49.109:3128 --docker-env abc=foo
DockerEnv:[]string{"abc=foo", "HTTP_PROXY=http://fedora:fedora123@10.70.49.109:3128", "NO_PROXY=localhost,127.0.0.1,172.30.1.1"},

$ ./minishift config view
- docker-env           : [abc=foo]

$ ./minishift start --http-proxy http://fedora:fedora123@10.70.49.109:3128   ==> not take from config
DockerEnv:[]string{"HTTP_PROXY=http://fedora:fedora123@10.70.49.109:3128", "NO_PROXY=localhost,127.0.0.1,172.30.1.1"},

# Current PR
$ ./minishift start --http-proxy http://fedora:fedora123@10.70.49.109:3128   ==> not take from config
DockerEnv:[]string{"abc=foo", "HTTP_PROXY=http://fedora:fedora123@10.70.49.109:3128", "NO_PROXY=localhost,127.0.0.1,172.30.1.1"},
```

Addresses issue #1153 