### PR TITLE
[Do not merge] Fixes #1137 Add option to run experimental Service Catalog

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -77,6 +77,7 @@ var (
 	OpenshiftEnv      = createFlag("openshift-env", nil, nil, nil, false)
 	Metrics           = createFlag("metrics", SetBool, nil, nil, true)
 	Logging           = createFlag("logging", SetBool, nil, nil, true)
+	ServiceCatalog    = createFlag("service-catalog", SetBool, nil, nil, true)
 
 	// Setting proxy
 	NoProxyList = createFlag("no-proxy", SetString, nil, nil, true)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -410,6 +410,7 @@ func initClusterUpFlags() *flag.FlagSet {
 	clusterUpFlagSet.StringSliceVarP(&openShiftEnv, startFlags.OpenshiftEnv.Name, "e", []string{}, "Specify key-value pairs of environment variables to set on the OpenShift container.")
 	clusterUpFlagSet.Bool(startFlags.Metrics.Name, false, "Install metrics (experimental)")
 	clusterUpFlagSet.Bool(startFlags.Logging.Name, false, "Install logging (experimental)")
+	clusterUpFlagSet.Bool(startFlags.ServiceCatalog.Name, false, "Install service catalog (experimental)")
 	clusterUpFlagSet.String(startFlags.OpenshiftVersion.Name, version.GetOpenShiftVersion(), fmt.Sprintf("The OpenShift version to run, eg. %s", version.GetOpenShiftVersion()))
 	clusterUpFlagSet.String(startFlags.NoProxyList.Name, "", "List of hosts or subnets for which no proxy should be used.")
 	clusterUpFlagSet.AddFlag(cmdutil.HttpProxyFlag)

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -66,7 +66,7 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runne
 
 	for key, value := range clusterUpParams {
 		if !oc.SupportFlag(key, config.OcPath, runner) {
-			errors.New(fmt.Sprintf("Flag %s is not supported for oc version %s. Use 'openshift-version' flag to select a different version of OpenShift.", key, config.OpenShiftVersion))
+			return errors.New(fmt.Sprintf("Flag %s is not supported for oc version %s. Use 'openshift-version' flag to select a different version of OpenShift.", key, config.OpenShiftVersion))
 		}
 		cmdArgs = append(cmdArgs, "--"+key)
 		cmdArgs = append(cmdArgs, value)
@@ -74,7 +74,7 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runne
 
 	exitCode := runner.Run(os.Stdout, os.Stderr, config.OcPath, cmdArgs...)
 	if exitCode != 0 {
-		errors.New("Error starting the cluster.")
+		return errors.New("Error starting the cluster.")
 	}
 	return nil
 }

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -68,6 +68,7 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runne
 		if !oc.SupportFlag(key, config.OcPath, runner) {
 			return errors.New(fmt.Sprintf("Flag %s is not supported for oc version %s. Use 'openshift-version' flag to select a different version of OpenShift.", key, config.OpenShiftVersion))
 		}
+
 		cmdArgs = append(cmdArgs, "--"+key)
 		cmdArgs = append(cmdArgs, value)
 	}


### PR DESCRIPTION
Addresses issue #1137

TODO:
  * ~~Does not check if `oc cluster up` supports installing with --service-catalog=true` (See: #1169)~~
  * ~~option to specify extra flags (see #1170)~~