### PR TITLE
Issue #1170 Add option to enable experimental flags

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -77,6 +77,9 @@ var (
 	OpenshiftEnv      = createConfigSetting("openshift-env", nil, nil, nil, false)
 	Metrics           = createConfigSetting("metrics", SetBool, nil, nil, true)
 	Logging           = createConfigSetting("logging", SetBool, nil, nil, true)
+	// future enabled flags
+	ServiceCatalog      = createConfigSetting("service-catalog", SetBool, nil, nil, true)
+	ExtraClusterUpFlags = createConfigSetting("extra-clusterup-flags", SetString, nil, nil, true)
 
 	// Setting proxy
 	NoProxyList = createConfigSetting("no-proxy", SetString, nil, nil, true)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -449,6 +449,11 @@ func initClusterUpFlags() *flag.FlagSet {
 	clusterUpFlagSet.AddFlag(cmdutil.HttpProxyFlag)
 	clusterUpFlagSet.AddFlag(cmdutil.HttpsProxyFlag)
 
+	if hasEnabledExperimental {
+		clusterUpFlagSet.Bool(startFlags.ServiceCatalog.Name, false, "Install service catalog (experimental)")
+		clusterUpFlagSet.String(startFlags.ExtraClusterUpFlags.Name, "", "Specify optional flags for use with 'cluster up' (unsupported)")
+	}
+
 	return clusterUpFlagSet
 }
 

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/docker/machine/libmachine/drivers"
-	startFlags "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
 	miniutil "github.com/minishift/minishift/pkg/minishift/util"
 
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -38,27 +38,27 @@ const (
 
 // preflightChecksAfterStartingHost is executed before the startHost function.
 func preflightChecksBeforeStartingHost() {
-	switch viper.GetString(startFlags.VmDriver.Name) {
+	switch viper.GetString(configCmd.VmDriver.Name) {
 	case "xhyve":
 		preflightCheckSucceedsOrFails(
-			startFlags.SkipCheckXHyveDriver.Name,
+			configCmd.SkipCheckXHyveDriver.Name,
 			checkXhyveDriver,
 			"Checking if xhyve driver is installed",
-			false, startFlags.WarnCheckXHyveDriver.Name,
+			false, configCmd.WarnCheckXHyveDriver.Name,
 			"See the 'Setting Up the Driver Plug-in' topic for more information")
 	case "kvm":
 		preflightCheckSucceedsOrFails(
-			startFlags.SkipCheckKVMDriver.Name,
+			configCmd.SkipCheckKVMDriver.Name,
 			checkKvmDriver,
 			"Checking if KVM driver is installed",
-			false, startFlags.WarnCheckXHyveDriver.Name,
+			false, configCmd.WarnCheckXHyveDriver.Name,
 			"See the 'Setting Up the Driver Plug-in' topic for more information")
 	case "hyperv":
 		preflightCheckSucceedsOrFails(
-			startFlags.SkipCheckHyperVDriver.Name,
+			configCmd.SkipCheckHyperVDriver.Name,
 			checkHypervDriver,
 			"Checking if Hyper-V driver is configured",
-			false, startFlags.WarnCheckHyperVDriver.Name,
+			false, configCmd.WarnCheckHyperVDriver.Name,
 			"Hyper-V virtual switch is not set")
 	}
 }
@@ -66,43 +66,43 @@ func preflightChecksBeforeStartingHost() {
 // preflightChecksAfterStartingHost is executed after the startHost function.
 func preflightChecksAfterStartingHost(driver drivers.Driver) {
 	preflightCheckSucceedsOrFailsWithDriver(
-		startFlags.SkipInstanceIP.Name,
+		configCmd.SkipInstanceIP.Name,
 		checkInstanceIP, driver,
 		"Checking for IP address",
-		false, startFlags.WarnInstanceIP.Name,
+		false, configCmd.WarnInstanceIP.Name,
 		"Error determining IP address")
 	/*
 		// This happens too late in the preflight, as provisioning needs an IP already
 			preflightCheckSucceedsOrFailsWithDriver(
-				startFlags.SkipCheckNetworkHost.Name,
+				configCmd.SkipCheckNetworkHost.Name,
 				checkVMConnectivity, driver,
 				"Checking if VM is reachable from host",
-				startFlags.WarnCheckNetworkHost.Name,
+				configCmd.WarnCheckNetworkHost.Name,
 				"Please check our troubleshooting guide")
 	*/
 	preflightCheckSucceedsOrFailsWithDriver(
-		startFlags.SkipCheckNetworkPing.Name,
+		configCmd.SkipCheckNetworkPing.Name,
 		checkIPConnectivity, driver,
 		"Checking if external host is reachable from the Minishift VM",
-		true, startFlags.WarnCheckNetworkPing.Name,
+		true, configCmd.WarnCheckNetworkPing.Name,
 		"VM is unable to ping external host")
 	preflightCheckSucceedsOrFailsWithDriver(
-		startFlags.SkipCheckNetworkHTTP.Name,
+		configCmd.SkipCheckNetworkHTTP.Name,
 		checkHttpConnectivity, driver,
 		"Checking HTTP connectivity from the VM",
-		true, startFlags.WarnCheckNetworkHTTP.Name,
+		true, configCmd.WarnCheckNetworkHTTP.Name,
 		"VM cannot connect to external URL with HTTP")
 	preflightCheckSucceedsOrFailsWithDriver(
-		startFlags.SkipCheckStorageMount.Name,
+		configCmd.SkipCheckStorageMount.Name,
 		checkStorageMounted, driver,
 		"Checking if persistent storage volume is mounted",
-		false, startFlags.WarnCheckStorageMount.Name,
+		false, configCmd.WarnCheckStorageMount.Name,
 		"Persistent volume storage is not mounted")
 	preflightCheckSucceedsOrFailsWithDriver(
-		startFlags.SkipCheckStorageUsage.Name,
+		configCmd.SkipCheckStorageUsage.Name,
 		checkStorageUsage, driver,
 		"Checking available disk space",
-		false, startFlags.WarnCheckStorageUsage.Name,
+		false, configCmd.WarnCheckStorageUsage.Name,
 		"Insufficient disk space on the persistent storage volume")
 }
 
@@ -250,7 +250,7 @@ func checkVMConnectivity(driver drivers.Driver) bool {
 
 // checkIPConnectivity checks if the VM has connectivity to the outside network
 func checkIPConnectivity(driver drivers.Driver) bool {
-	ipToPing := viper.GetString(startFlags.CheckNetworkPingHost.Name)
+	ipToPing := viper.GetString(configCmd.CheckNetworkPingHost.Name)
 	if ipToPing == "" {
 		ipToPing = "8.8.8.8"
 	}
@@ -261,7 +261,7 @@ func checkIPConnectivity(driver drivers.Driver) bool {
 
 // checkHttpConnectivity allows to test outside connectivity and possible proxy support
 func checkHttpConnectivity(driver drivers.Driver) bool {
-	urlToRetrieve := viper.GetString(startFlags.CheckNetworkHttpHost.Name)
+	urlToRetrieve := viper.GetString(configCmd.CheckNetworkHttpHost.Name)
 	if urlToRetrieve == "" {
 		urlToRetrieve = "http://minishift.io/index.html"
 	}

--- a/cmd/minishift/cmd/util/env.go
+++ b/cmd/minishift/cmd/util/env.go
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"os"
+	"regexp"
+)
+
+const (
+	booleanTruthyMatch = "^(?i:true|y|yes|1|on)$"
+	booleanFalsyMatch  = "^(?i:false|n|no|0|off)$"
+)
+
+var (
+	BooleanFormatError  = errors.New("Invalid format for boolean value.")
+	BooleanNoValueError = errors.New("No value given.")
+)
+
+// GetBoolEnv returns truthy or falsy value of given environmental variable.
+// It returns an error on failure with a default of false.
+func GetBoolEnv(varName string) (bool, error) {
+	varValue := os.Getenv(varName)
+
+	// no value given
+	if varValue == "" {
+		return false, BooleanNoValueError
+	}
+
+	truthy := regexp.MustCompile(booleanTruthyMatch)
+	falsy := regexp.MustCompile(booleanFalsyMatch)
+
+	if truthy.FindString(varValue) != "" {
+		return true, nil
+	}
+	if falsy.FindString(varValue) != "" {
+		return false, nil
+	}
+
+	return false, BooleanFormatError
+}

--- a/docs/source/using/managing-minishift.adoc
+++ b/docs/source/using/managing-minishift.adoc
@@ -292,3 +292,24 @@ $ minishift ssh -- docker ps
 CONTAINER    IMAGE                   COMMAND                CREATED        STATUS        NAMES
 71fe8ff16548 openshift/origin:v1.5.1 "/usr/bin/openshift s" 4 minutes ago  Up 4 minutes  origin
 ----
+
+[[experimental-functionality]]
+== Experimental functionality
+
+To allow users and developers to get early access to some upcoming features, we offer a way to enable experimental functionality.
+
+You do this by setting the environment variable `MINISHIFT_ENABLE_EXPERIMENTAL` which will make additional flags available:
+
+----
+$ export MINISHIFT_ENABLE_EXPERIMENTAL=y
+----
+
+At the moment this is only relevant for the xref:../command-ref/minishift_start.adoc#[`minishift start`] command where you get additional options related to  xref:../openshift/openshift-client-binary.adoc#[`oc cluster up`].
+By setting the environment variable, you get access to the `service-catalog` flag which allows you to provision OpenShift's link:https://docs.openshift.org/latest/architecture/service_catalog/index.html[service catalog].
+
+You also get access to the `extra-clusterup-flags` flag, allowing you to pass any extra flags to `oc cluster up`.
+Minishift does per default not expose all `oc cluster up` flags in its CLI, either because certain features are not considered stable or simply because Minishift has not caught up yet with the latest options in `oc cluster up`.
+In these cases `extra-clusterup-flags` can be used to run experiments with these options.
+
+Be aware that these features can break or give a result you weren't expecting.
+We welcome your feedback when using them.

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	startFlags "github.com/minishift/minishift/cmd/minishift/cmd/config"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/kubeconfig"
 	"github.com/minishift/minishift/pkg/minishift/addon/command"
@@ -65,6 +66,15 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runne
 	cmdArgs := []string{"cluster", "up", "--use-existing-config"}
 
 	fmt.Println("-- Checking `oc` support for startup flags ... ")
+
+	// Deal with extra flags (remove from cluster up params)
+	var extraFlags string
+	if val, ok := clusterUpParams[startFlags.ExtraClusterUpFlags.Name]; ok {
+		extraFlags = val
+		delete(clusterUpParams, startFlags.ExtraClusterUpFlags.Name)
+	}
+
+	// Check if clusterUp flags are supported
 	for key, value := range clusterUpParams {
 		fmt.Printf("   %s ... ", key)
 		if !oc.SupportFlag(key, config.OcPath, runner) {
@@ -72,8 +82,19 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runne
 			return errors.New(fmt.Sprintf("Flag %s is not supported for oc version %s. Use 'openshift-version' flag to select a different version of OpenShift.", key, config.OpenShiftVersion))
 		}
 		fmt.Println("OK")
+
 		cmdArgs = append(cmdArgs, "--"+key)
 		cmdArgs = append(cmdArgs, value)
+	}
+
+	// Deal with extra flags (add to command arguments)
+	if len(extraFlags) > 0 {
+		fmt.Println("-- Extra `oc` cluster up flags (experimental) ... ")
+		fmt.Printf("   '%s'\n", extraFlags)
+		extraFlagFields := strings.Fields(extraFlags)
+		for _, extraFlag := range extraFlagFields {
+			cmdArgs = append(cmdArgs, extraFlag)
+		}
 	}
 
 	exitCode := runner.Run(os.Stdout, os.Stderr, config.OcPath, cmdArgs...)

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	startFlags "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/kubeconfig"
 	"github.com/minishift/minishift/pkg/minishift/addon/command"
@@ -69,9 +69,9 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runne
 
 	// Deal with extra flags (remove from cluster up params)
 	var extraFlags string
-	if val, ok := clusterUpParams[startFlags.ExtraClusterUpFlags.Name]; ok {
+	if val, ok := clusterUpParams[configCmd.ExtraClusterUpFlags.Name]; ok {
 		extraFlags = val
-		delete(clusterUpParams, startFlags.ExtraClusterUpFlags.Name)
+		delete(clusterUpParams, configCmd.ExtraClusterUpFlags.Name)
 	}
 
 	// Check if clusterUp flags are supported


### PR DESCRIPTION
Usage:
```
$ minishift start --service-catalog
Unknown flag: --service-catalog
$ MINISHIFT_ENABLE_EXPERIMENTAL=on minishift start -h | grep service-catalog 
      --service-catalog                 Install service catalog (experimental)
```

Allowed truthy values are (case insensitive):
  * `y` or `yes`
  * `on`
  * `true`
  * `1`

Allowed falsy values are (case insensitive):
  * `n` or `no`
  * `off`
  * `false`
  * `0`

Empty or no value given is interpreted as `false`

```
$ export MINISHIFT_EXTRA_CLUSTERUP_FLAGS="--service-catalog"
$ MINISHIFT_ENABLE_EXPERIMENTAL=on minishift start
!!! Experimental features are enabled !!!
Starting local OpenShift cluster using 'kvm' hypervisor...
Error during 'cluster up' execution: Flag service-catalog is not supported for oc version v1.5.1. Use 'openshift-version' flag to select a different version of OpenShift.
```
Note: purposely run against v1.5.1 (to fail the supported flags check)
See: https://github.com/minishift/minishift/issues/1170#issuecomment-318104621