### PR TITLE
Issue #660 Do not return error when closing interactive SSH session

### DIFF
--- a/cmd/minishift/cmd/ssh.go
+++ b/cmd/minishift/cmd/ssh.go
@@ -26,6 +26,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	SshCommunicationError = "exit status 255"
+)
+
 // sshCmd represents the docker-machine ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh [-- COMMAND]",
@@ -34,9 +38,13 @@ var sshCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 		defer api.Close()
+
 		err := cluster.CreateSSHShell(api, args)
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Cannot establish SSH connection to the VM: %s", err.Error()))
+			if err.Error() == SshCommunicationError {
+				atexit.ExitWithMessage(1, fmt.Sprintf("Cannot establish SSH connection to the VM: %s", err.Error()))
+			}
+			atexit.ExitWithMessage(1, fmt.Sprintf("Command failed: %s", err.Error()))
 		}
 	},
 }

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -57,7 +57,8 @@ var (
 )
 
 const (
-	fileScheme = "file"
+	fileScheme            = "file"
+	SshCommunicationError = "exit status 255"
 )
 
 //This init function is used to set the logtostderr variable to false so that INFO level log info does not clutter the CLI
@@ -595,7 +596,12 @@ func CreateSSHShell(api libmachine.API, args []string) error {
 		return err
 	}
 
-	return client.Shell(args...)
+	err = client.Shell(args...)
+	// do not fail if interactive and able to connect
+	if err != nil && len(args) == 0 && err.Error() != SshCommunicationError {
+		return nil
+	}
+	return err
 }
 
 func GetConsoleURL(api libmachine.API) (string, error) {


### PR DESCRIPTION
Do not return an error when closing an interactive session.

See discussion on #660 