### PR TITLE
Issue #1192 Add test for version command

### DIFF
--- a/test/integration/features/cmd-version.feature
+++ b/test/integration/features/cmd-version.feature
@@ -1,0 +1,7 @@
+@minishift-only @command
+Feature: Version command
+Command "minishift version" shows version of minishift binary.
+
+  Scenario: User can get information about version of Minishift
+      When executing "minishift version" succeeds
+      Then stdout should match "^minishift v[0-9]\.[0-9]\.[0-9]\+[a-z0-9]{7}\n$"


### PR DESCRIPTION
Also adds support for regexp matching of stdout, stderr etc in format:
```
Then stdout should match "^minishift v\d\.\d\.\d\+[\w\d]{8}\n$"
And stderr should not match
"""
^minishift v\d\.\d\.\d\+[\w\d]{8}\n$
"""
```