### PR TITLE
[WIP] Issue #126 Introducing profile feature to manage multiple instances of Minishift

### DIFF
--- a/cmd/minishift/cmd/delete.go
+++ b/cmd/minishift/cmd/delete.go
@@ -21,10 +21,12 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	cmdProfile "github.com/minishift/minishift/cmd/minishift/cmd/profile"
 	"github.com/minishift/minishift/cmd/minishift/cmd/util"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
 	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
@@ -46,7 +48,6 @@ var (
 func runDelete(cmd *cobra.Command, args []string) {
 	api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 	defer api.Close()
-
 	util.ExitIfUndefined(api, constants.MachineName)
 
 	// Unregistration, do not allow to be skipped
@@ -68,6 +69,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 	}
 
 	removeInstanceConfigs()
+	removeProfileFromConfig()
 
 	fmt.Println("Minishift VM deleted.")
 }
@@ -94,6 +96,16 @@ func removeInstanceConfigs() {
 	if exists {
 		if err := os.Remove(constants.KubeConfigPath); err != nil {
 			atexit.ExitWithMessage(1, fmt.Sprintf("Error deleting '%s'", constants.KubeConfigPath))
+		}
+	}
+}
+
+func removeProfileFromConfig() {
+	name := cmdProfile.GetProfileName()
+	if name != "" {
+		err := profileActions.RemoveProfile(name)
+		if err != nil {
+			atexit.ExitWithMessage(1, fmt.Sprintf("%s", err))
 		}
 	}
 }

--- a/cmd/minishift/cmd/profile/profile.go
+++ b/cmd/minishift/cmd/profile/profile.go
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var ProfileCmd = &cobra.Command{
+	Use:     "profile SUBCOMMAND [flags]",
+	Aliases: []string{"instance"},
+	Short:   "Manages Minishift profiles.",
+	Long:    "Manages Minishift profile. Use the sub-commands to list, set profile",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+//Checks viper or allinstanceconfg to say if profile is defined.
+func ProfileExists() bool {
+	if viper.GetString("profile") != "" {
+		return true
+	} else if minishiftConfig.AllInstancesConfig != nil {
+		if profileActions.GetActiveProfile() != "" {
+			return true
+		}
+	}
+	return false
+}
+
+//Returns the machine name after taking in to account if --profile or
+//profile information available in allinstance config
+func GetProfileName() string {
+	activeProfile := profileActions.GetActiveProfile()
+	if viper.GetString("profile") != "" {
+		return viper.GetString("profile")
+	} else if activeProfile != "" {
+		return activeProfile
+	} else {
+		return ""
+	}
+}

--- a/cmd/minishift/cmd/profile/profile_list.go
+++ b/cmd/minishift/cmd/profile/profile_list.go
@@ -1,0 +1,50 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"fmt"
+
+	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
+	"github.com/spf13/cobra"
+)
+
+var profileListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists profiles",
+	Long:  "Lists existing profiles for Minishift",
+	Run: func(cmd *cobra.Command, args []string) {
+		profiles := profileActions.GetProfileNameList()
+		if len(profiles) == 0 {
+			fmt.Println("There are no profiles defined")
+		} else {
+			displayProfiles(profiles)
+		}
+	},
+}
+
+//List existing profile information
+//TODO: Name, Status (running,stopped etc)
+func displayProfiles(profiles []string) {
+	for i := range profiles {
+		fmt.Println(fmt.Sprintf("- %s", profiles[i]))
+	}
+}
+
+func init() {
+	ProfileCmd.AddCommand(profileListCmd)
+}

--- a/cmd/minishift/cmd/profile/profile_reset.go
+++ b/cmd/minishift/cmd/profile/profile_reset.go
@@ -1,0 +1,47 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"fmt"
+
+	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/cobra"
+)
+
+var profileResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "resets the active profile",
+	Long:  "resets the active profile. After running this command there will not be any active profile",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			atexit.ExitWithMessage(1, extraArgumentError)
+		}
+
+		err := profileActions.ResetActiveProfile()
+		if err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		} else {
+			fmt.Println("Profile is reset successfully")
+		}
+	},
+}
+
+func init() {
+	ProfileCmd.AddCommand(profileResetCmd)
+}

--- a/cmd/minishift/cmd/profile/profile_set.go
+++ b/cmd/minishift/cmd/profile/profile_set.go
@@ -1,0 +1,73 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"fmt"
+
+	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/cobra"
+)
+
+const (
+	emptyProfileError  = "You must provide the profile name. Run `minishift profile list` to view profiles"
+	extraArgumentError = "You have provided more arguments than required. You must provide a single profile name"
+)
+
+var profileSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Sets the default profile for Minishift",
+	Long:  "Sets the default profile for Minishift. After you set the profile, all commands will use the profile by default",
+	Run: func(cmd *cobra.Command, args []string) {
+		var doesProfileExist = false
+		if len(args) == 0 {
+			atexit.ExitWithMessage(1, emptyProfileError)
+		} else if len(args) > 1 {
+			atexit.ExitWithMessage(1, extraArgumentError)
+		}
+
+		profileName := args[0]
+
+		//check if the profile is present in the AllInstancesConfig
+		profileList := profileActions.GetProfileNameList()
+		for i := range profileList {
+			if profileList[i] == profileName {
+				doesProfileExist = true
+			}
+		}
+		if !doesProfileExist {
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error: '%s' is not a valid profile", profileName))
+		}
+
+		//Check if the requested profile is already active
+		if profileName == profileActions.GetActiveProfile() {
+			atexit.ExitWithMessage(1, fmt.Sprintf("'%s' is already set as active profile", profileName))
+		}
+
+		err := profileActions.SetActiveProfile(profileName)
+		if err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		} else {
+			fmt.Println(fmt.Sprintf("Profile set to '%s' successfully", profileName))
+		}
+	},
+}
+
+func init() {
+	ProfileCmd.AddCommand(profileSetCmd)
+}

--- a/cmd/minishift/cmd/root_test.go
+++ b/cmd/minishift/cmd/root_test.go
@@ -23,10 +23,11 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/testing/cli"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/testing/cli"
 )
 
 var configTests = []cli.TestOption{

--- a/docs/source/using/profiles.adoc
+++ b/docs/source/using/profiles.adoc
@@ -1,0 +1,31 @@
+= Minishift Profiles
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+
+toc::[]
+
+
+[[create-multi-instances-of-minishift]]
+== Create multiple instances of Minishift
+
+With the help of profile feature you can create multiple instances of Minishift with xref:../command-ref/minishift_start.adoc#[`minishift start --profile`] command.
+
+[[manage-multi-instances-of-minishift]]
+== Manage multiple instances of Minishift
+
+When you have multiple profiles you can run Minishift commands  against a specific profile using `--profile` flag.
+
+If you do not want to pass `--profile` flag everytime with commands you can set a profile as the default with `minishift profile set` command.
+
+To remove a profile from default profile you need to use `minishift profile reset` command.
+
++
+----
+$ minishift profile list
+
+$ minishift profile set <profile_name>
+
+$ minishift profile reset
+----

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package cluster
 
 import (
+	"path/filepath"
+	"testing"
+
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/tests"
-	"path/filepath"
-	"testing"
 )
 
 func TestRemoteBoot2DockerURL(t *testing.T) {

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -20,12 +20,12 @@ import (
 	"os"
 	"path/filepath"
 
+	cmdProfile "github.com/minishift/minishift/cmd/minishift/cmd/profile"
 	"github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/version"
 )
 
 const (
-	MachineName                  = "minishift"      // Name to use for the VM
 	APIServerPort                = 8443             // Port that the API server should listen on
 	MiniShiftEnvPrefix           = "MINISHIFT"      // Prefix for the environmental variables
 	MiniShiftHomeEnv             = "MINISHIFT_HOME" // Environment variable used to change the Minishift home directory
@@ -35,14 +35,17 @@ const (
 	DefaultCPUS                  = 2
 	DefaultDiskSize              = "20g"
 	UpdateMarkerFileName         = "updated"
+	DefaultMachineName           = "minishift"
 )
 
 var (
 	// Fix for windows
-	Minipath = getMinishiftHomeDir()
+	Minipath    = GetMinishiftHomeDir()
+	MachineName = DefaultMachineName // Name to use for the VM
 
-	KubeConfigPath = filepath.Join(Minipath, "machines", MachineName+"_kubeconfig")
-	ConfigFile     = MakeMiniPath("config", "config.json")
+	KubeConfigPath        = filepath.Join(Minipath, "machines", MachineName+"_kubeconfig")
+	ConfigFile            = MakeMiniPath("config", "config.json")
+	AllInstanceConfigPath = filepath.Join(Minipath, "config", "allinstances.json")
 
 	DefaultB2dIsoUrl    = "https://github.com/minishift/minishift-b2d-iso/releases/download/" + version.GetB2dIsoVersion() + "/" + "minishift-b2d.iso"
 	DefaultCentOsIsoUrl = "https://github.com/minishift/minishift-centos-iso/releases/download/" + version.GetCentOsIsoVersion() + "/" + "minishift-centos7.iso"
@@ -58,10 +61,12 @@ func MakeMiniPath(fileName ...string) string {
 // getMinishiftHomeDir determines the Minishift home directory where all state information is kept.
 // The default directory is .minishift in the users HOME directory which can be overwritten by the MINISHIFT_HOME
 // environment variable
-func getMinishiftHomeDir() string {
+func GetMinishiftHomeDir() string {
 	homeEnv, ok := os.LookupEnv(MiniShiftHomeEnv)
 	if ok {
 		return homeEnv
+	} else if cmdProfile.ProfileExists() {
+		return filepath.Join(util.HomeDir(), ".minishift", cmdProfile.GetProfileName())
 	} else {
 		return filepath.Join(util.HomeDir(), ".minishift")
 	}

--- a/pkg/minikube/constants/constants_test.go
+++ b/pkg/minikube/constants/constants_test.go
@@ -17,16 +17,17 @@ limitations under the License.
 package constants
 
 import (
-	"github.com/minishift/minishift/pkg/util"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/minishift/minishift/pkg/util"
 )
 
 func TestDefaultMinishiftHome(t *testing.T) {
 	os.Unsetenv("MINISHIFT_HOME")
 	expectedMiniPath := filepath.Join(util.HomeDir(), ".minishift")
-	actualMiniPath := getMinishiftHomeDir()
+	actualMiniPath := GetMinishiftHomeDir()
 	if actualMiniPath != expectedMiniPath {
 		t.Fatalf("Expected Minishift home directory : '%s' Got: '%s'", expectedMiniPath, actualMiniPath)
 	}
@@ -37,7 +38,7 @@ func TestMinishiftHomeViaEnvironment(t *testing.T) {
 	os.Setenv("MINISHIFT_HOME", expectedMiniPath)
 	defer os.Unsetenv("MINISHIFT_HOME")
 
-	actualMiniPath := getMinishiftHomeDir()
+	actualMiniPath := GetMinishiftHomeDir()
 	if actualMiniPath != expectedMiniPath {
 		t.Fatalf("Expected Minishift home directory : '%s' Got: '%s'", expectedMiniPath, actualMiniPath)
 	}

--- a/pkg/minishift/config/allinstancesconfig.go
+++ b/pkg/minishift/config/allinstancesconfig.go
@@ -24,10 +24,16 @@ import (
 
 var AllInstancesConfig *GlobalConfigType
 
+type Profile struct {
+	Name  string
+	InUse bool
+}
+
 type GlobalConfigType struct {
 	FilePath string `json:"-"`
 
 	HostFolders []HostFolder
+	Profiles    []Profile
 }
 
 // Create new object with data if file exists or

--- a/pkg/minishift/profile/profile.go
+++ b/pkg/minishift/profile/profile.go
@@ -1,0 +1,123 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"fmt"
+
+	"github.com/minishift/minishift/pkg/minishift/config"
+)
+
+//Add profile information to allinstancesconfig
+func AddProfileToConfig(name string) error {
+	profile := newProfile(name)
+	config.AllInstancesConfig.Profiles = append(config.AllInstancesConfig.Profiles, profile)
+	err := config.AllInstancesConfig.Write()
+	if err != nil {
+		return fmt.Errorf("Error adding profile information. %s", err)
+	}
+	return nil
+}
+
+func newProfile(name string) config.Profile {
+	return config.Profile{
+		Name:  name,
+		InUse: false,
+	}
+}
+
+//Returns the list of profile names
+func GetProfileNameList() []string {
+	var profileList []string
+	profiles := config.AllInstancesConfig.Profiles
+	for i := range profiles {
+		profile := profiles[i]
+		profileList = append(profileList, profile.Name)
+	}
+	return profileList
+}
+
+//RemoveProfile
+func RemoveProfile(name string) error {
+	profiles := config.AllInstancesConfig.Profiles
+	for i := range profiles {
+		profile := profiles[i]
+		if profile.Name == name {
+			profiles = append(profiles[:i], profiles[i+1:]...)
+			break
+		}
+	}
+	config.AllInstancesConfig.Profiles = profiles
+	err := config.AllInstancesConfig.Write()
+	if err != nil {
+		return fmt.Errorf("Error removing profile information from config. %s", err)
+	}
+	return nil
+}
+
+//Set Active Profile and also it makes sure that we have one
+// active profile at one point of time.
+func SetActiveProfile(name string) error {
+	profiles := config.AllInstancesConfig.Profiles
+	for i := range profiles {
+		if profiles[i].Name == name {
+			profiles[i].InUse = true
+		} else {
+			profiles[i].InUse = false
+		}
+	}
+
+	config.AllInstancesConfig.Profiles = profiles
+	err := config.AllInstancesConfig.Write()
+	if err != nil {
+		return fmt.Errorf("Error updating profile information in config. %s", err)
+	}
+	return nil
+}
+
+//Unset Active Profile and also it makes sure that we have one
+// active profile at one point of time.
+func ResetActiveProfile() error {
+	profiles := config.AllInstancesConfig.Profiles
+
+	if GetActiveProfile() == "" {
+		return nil
+	}
+
+	for i := range profiles {
+		profiles[i].InUse = false
+	}
+
+	config.AllInstancesConfig.Profiles = profiles
+	err := config.AllInstancesConfig.Write()
+	if err != nil {
+		return fmt.Errorf("Error updating profile information in config. %s", err)
+	}
+	return nil
+}
+
+//Get Active Profile from AllInstancesConfig
+func GetActiveProfile() string {
+	profiles := config.AllInstancesConfig.Profiles
+	for i := range profiles {
+		profile := profiles[i]
+		if profile.InUse == true {
+			return profile.Name
+		}
+	}
+	return ""
+}

--- a/pkg/minishift/profile/profile_test.go
+++ b/pkg/minishift/profile/profile_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+)
+
+var (
+	testDir        string
+	configFilePath string
+)
+
+func TestAdditionOfProfileToConfig(t *testing.T) {
+	setup(t)
+	defer teardown()
+	profileName := "foo"
+
+	configFilePath = filepath.Join(testDir, "fake-machine.json")
+	minishiftConfig.AllInstancesConfig, _ = minishiftConfig.NewAllInstancesConfig(configFilePath)
+
+	AddProfileToConfig(profileName)
+	profileList := GetProfileNameList()
+	if len(profileList) > 1 {
+		t.Errorf("Number of profiles is more than expected")
+	}
+	if profileName != profileList[0] {
+		t.Errorf("Expected profile name %s but actual found %s", profileName, profileList[0])
+	}
+}
+
+func TestRemovableOfProfileToConfig(t *testing.T) {
+	setup(t)
+	defer teardown()
+	profileName := "foo"
+
+	AddProfileToConfig(profileName)
+	RemoveProfile(profileName)
+	profileList := GetProfileNameList()
+	if len(profileList) > 0 {
+		t.Errorf("There was no profile expected")
+	}
+}
+
+func TestSetingActiveProfile(t *testing.T) {
+	setup(t)
+	defer teardown()
+	profileName := "foo"
+
+	AddProfileToConfig(profileName)
+	SetActiveProfile(profileName)
+	actualProfileName := GetActiveProfile()
+	if actualProfileName != profileName {
+		t.Errorf("Expected profile name: %s does not match actual profile name: %s", profileName, actualProfileName)
+	}
+}
+
+//TBD: Will add some more unit tests
+
+func setup(t *testing.T) {
+	var err error
+	testDir, err = ioutil.TempDir("", "minishift-test-profile-")
+
+	if err != nil {
+		t.Error(err)
+	}
+	configFilePath = filepath.Join(testDir, "fake-machine.json")
+	minishiftConfig.AllInstancesConfig, _ = minishiftConfig.NewAllInstancesConfig(configFilePath)
+}
+
+func teardown() {
+	os.RemoveAll(testDir)
+}

--- a/pkg/testing/cli/harness.go
+++ b/pkg/testing/cli/harness.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"fmt"
+
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/viper"


### PR DESCRIPTION
Create multiple instances of Minishift. Have not added tests yet.  The PR still does not address the issues where we wanted the ~/.minishift/config/config.json  isolated for each instance. 

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>