### PR TITLE
Issue #1202 Changing the default version of OpenShift to v3.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 # Various versions - Minishift, default OpenShift, default B2D ISO
 MINISHIFT_VERSION = 1.3.1
-OPENSHIFT_VERSION = v1.5.1
+OPENSHIFT_VERSION = v3.6.0
 B2D_ISO_VERSION = v1.0.2
 CENTOS_ISO_VERSION = v1.1.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)

--- a/cmd/minishift/cmd/start_test.go
+++ b/cmd/minishift/cmd/start_test.go
@@ -131,9 +131,9 @@ func (r *RecordingRunner) Output(command string, args ...string) ([]byte, error)
 
 var (
 	testConfig = &clusterup.ClusterUpConfig{
-		OpenShiftVersion: "v1.5.1",
+		OpenShiftVersion: "v3.6.0",
 		Ip:               "192.168.99.42",
-		OcPath:           "/home/john/.minishift/cache/oc/1.5.1/oc",
+		OcPath:           "/home/john/.minishift/cache/oc/3.6.0/oc",
 		RoutingSuffix:    "192.168.99.42.nip.io",
 	}
 	testDir    string


### PR DESCRIPTION
Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>