### PR TITLE
Issue #613 Add tests for 'minishift openshift' sub command

### DIFF
--- a/test/integration/features/cmd-openshift.feature
+++ b/test/integration/features/cmd-openshift.feature
@@ -1,0 +1,119 @@
+@cmd-openshift
+Feature: Openshift commands
+Commands "minishift openshift [sub-command]" are used for interaction with Openshift
+cluster in VM provided by Minishift.
+
+  Scenario: Trying service command when Minishift is not running
+     Given Minishift has state "Does Not Exist"
+      When executing "minishift openshift service list" succeeds
+      Then stdout should contain
+      """
+      Running this command requires an existing 'minishift' VM, but no VM is defined.
+      """
+
+  Scenario: Minishift start
+  Minishift must be started in order to interact with OpenShift via "minishift openshift" command
+      When executing "minishift start" succeeds
+
+  Scenario: Service list sub-command
+     Given Minishift has state "Running"
+      When executing "minishift openshift service list" succeeds
+      Then stdout should contain "docker-registry"
+       And stdout should contain "kubernetes"
+       And stdout should contain "router"
+
+  Scenario: Restarting the OpenShift cluster
+  Note: This step is based on observation and might be unstable in some environments. It checks for the time when container
+        finished last time. When container is new and had never finished then this time value is set to 0001-01-01T00:00:00Z.
+        On restart of OpenShift cluster containers are terminated, which sets FinishedAt to actual time. This value persist
+        after next start of container.
+     Given stdout of command "minishift ssh -- docker inspect --format={{.State.FinishedAt}} origin" is equal to "0001-01-01T00:00:00Z"
+      When executing "minishift openshift restart" succeeds
+      Then stdout should contain "Restarting OpenShift"
+       And stdout of command "minishift ssh -- docker inspect --format={{.State.FinishedAt}} origin" is not equal to "0001-01-01T00:00:00Z"
+
+  Scenario: User deploys nodejs example application from OpenShift repository
+      When executing "oc new-app https://github.com/openshift/nodejs-ex -l name=myapp" succeeds
+      Then stdout should contain
+      """
+      Run 'oc status' to view your app.
+      """
+
+  @minishift-only
+  Scenario: Getting information about OpenShift and kubernetes versions
+  Prints the current running OpenShift version to the standard output.
+     Given Minishift has state "Running"
+      When executing "minishift openshift version" succeeds
+      Then stdout should match
+      """
+      ^openshift v[0-9]+\.[0-9]+\.[0-9]+\+[0-9a-z]{7}
+      kubernetes v[0-9]+\.[0-9]+\.[0-9]+\+[0-9a-z]{10}
+      etcd [0-9]+\.[0-9]+\.[0-9]+
+      """
+
+  Scenario: Getting address of internal docker registry
+  Prints the host name and port number of the OpenShift registry to the standard output.
+     Given Minishift has state "Running"
+      When executing "minishift openshift registry" succeeds
+      Then stdout should be valid IP with port number
+
+  Scenario: Getting existing service without route
+      When executing "minishift openshift service nodejs-ex" succeeds
+      Then stdout should contain "nodejs-ex"
+       And stdout should not match
+       """
+       ^http:\/\/nodejs-ex-myproject\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.nip\.io
+       """
+
+  Scenario: Getting non-existing service
+  If service does not exist, user gets an empty table.
+      When executing "minishift openshift service not-present" succeeds
+      Then stdout should not contain "not-present"
+
+  Scenario: Getting service from non-existing namespace
+      When executing "minishift openshift service nodejs-ex --namespace does-not-exist" fails
+      Then stderr should contain "Namespace does-not-exist doesn't exist"
+
+  Scenario: Forgotten service name
+      When executing "minishift openshift service --namespace myapp" fails
+      Then stderr should contain "You must specify the name of the service."
+
+  Scenario: User creates route to the service
+      When executing "oc expose svc/nodejs-ex" succeeds
+      Then stdout should contain
+      """
+      route "nodejs-ex" exposed
+      """
+
+  Scenario: Getting existing service with route
+      When executing "minishift openshift service nodejs-ex" succeeds
+      Then stdout should contain "nodejs-ex"
+       And stdout should match
+       """
+       http:\/\/nodejs-ex-myproject\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.nip\.io
+       """
+
+  Scenario: Getting URL of service using --url flag
+      When executing "minishift openshift service nodejs-ex --url" succeeds
+      Then stdout should be valid URL
+
+  Scenario: Seeing configuration of OpenShift master
+  Minishift openshift config view prints YAML configuration of OpenShift cluster.
+  Note: --target=master is default value for minishift openshift config command
+      When executing "minishift openshift config view" succeeds
+      Then stdout should be valid YAML
+
+  Scenario: Seeing configuration of OpenShift node
+      When executing "minishift openshift config view --target node" succeeds
+      Then stdout should be valid YAML
+
+  Scenario: Setting configuration on OpenShift master
+      When executing »minishift openshift config set --patch '{"assetConfig": {"logoutURL": "http://www.minishift.io"}}'« succeeds
+      Then stdout should contain "Patching OpenShift configuration"
+      When executing "minishift openshift config view" succeeds
+      Then stdout is YAML which contains key "assetConfig.logoutURL" with value matching "http://www\.minishift\.io"
+
+  Scenario: Deleting the Minishift instance
+     Given Minishift has state "Running"
+      When executing "minishift delete" succeeds
+      Then Minishift should have state "Does Not Exist"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/DATA-DOG/godog"
 	"github.com/DATA-DOG/godog/gherkin"
+	"gopkg.in/yaml.v2"
 
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	testProxy "github.com/minishift/minishift/test/integration/proxy"
@@ -150,11 +151,15 @@ func FeatureContext(s *godog.Suite) {
 		minishift.shouldHaveState)
 	s.Step(`^executing "minishift ([^"]*)"$`,
 		minishift.executingMinishiftCommand)
+	s.Step(`^executing »minishift ([^«]*)«$`,
+		minishift.executingMinishiftCommand)
 	s.Step(`^executing "minishift ([^"]*)" (succeeds|fails)$`,
 		executingMinishiftCommandSucceedsOrFails)
-	s.Step(`([^"]*) of command "minishift ([^"]*)" is equal to "([^"]*)"$`,
+	s.Step(`^executing »minishift ([^«]*)« (succeeds|fails)$`,
+		executingMinishiftCommandSucceedsOrFails)
+	s.Step(`([^"]*) of command "minishift ([^"]*)" (is equal|is not equal) to "([^"]*)"$`,
 		commandReturnEquals)
-	s.Step(`([^"]*) of command "minishift ([^"]*)" contains "([^"]*)"$`,
+	s.Step(`([^"]*) of command "minishift ([^"]*)" (contains|does not contain) "([^"]*)"$`,
 		commandReturnContains)
 
 	// steps to execute `oc` commands
@@ -223,10 +228,15 @@ func FeatureContext(s *godog.Suite) {
 		getRoutingUrlAndVerifyHTTPResponse)
 
 	// steps for verifying config file content
-	s.Step(`^JSON config file "([^"]*)" (contains|does not contain) key "(.*)" with value matching "(.*)"$`,
-		matchConfigValue)
-	s.Step(`^JSON config file "([^"]*)" (has|does not have) key "(.*)"$`,
-		checkConfigKey)
+	s.Step(`^(JSON|YAML) config file "([^"]*)" (contains|does not contain) key "(.*)" with value matching "(.*)"$`,
+		configFileContainsKeyMatchingValue)
+	s.Step(`^(JSON|YAML) config file "([^"]*)" (has|does not have) key "(.*)"$`,
+		configFileContainsKey)
+
+	s.Step(`^(stdout|stderr) is (JSON|YAML) which (contains|does not contain) key "(.*)" with value matching "(.*)"$`,
+		stdoutContainsKeyMatchingValue)
+	s.Step(`^(stdout|stderr) is (JSON|YAML) which (has|does not have) key "(.*)"$`,
+		stdoutContainsKey)
 
 	// iso dependent steps
 	s.Step(`^printing Docker daemon configuration to stdout$`,
@@ -283,30 +293,59 @@ func ensureTestDirEmpty() {
 //  To get values of nested keys, use following dot formating in Scenarios: key.nestedKey
 //  If an array is expected, then expect: "[value1 value2 value3]"
 //  If empty string, non existing value are expected, then expect "<nil>"
-func getConfigValue(configPath string, keyPath string) (string, error) {
+func getConfigKeyValue(configData []byte, format string, keyPath string) (string, error) {
+	var err error
 	var keyValue string
-	data, err := ioutil.ReadFile(testDir + "/" + configPath)
-	if err != nil {
-		return "", fmt.Errorf("Cannot read config file: %v", err)
-	}
 	var values map[string]interface{}
-	json.Unmarshal(data, &values)
+
+	if format == "JSON" {
+		err = json.Unmarshal(configData, &values)
+		if err != nil {
+			return "", fmt.Errorf("Error unmarshaling JSON: %s", err)
+		}
+	} else if format == "YAML" {
+		err = yaml.Unmarshal(configData, &values)
+		if err != nil {
+			return "", fmt.Errorf("Error unmarshaling YAML: %s", err)
+		}
+	}
+
 	keyPathArray := strings.Split(keyPath, ".")
 	for _, element := range keyPathArray {
 		switch value := values[element].(type) {
 		case map[string]interface{}:
 			values = value
-		case []interface{}, nil, string, float64:
+		case map[interface{}]interface{}:
+			retypedValue := make(map[string]interface{})
+			for x := range value {
+				retypedValue[x.(string)] = value[x]
+			}
+			values = retypedValue
+		case []interface{}, nil, string, int, float64, bool:
 			keyValue = fmt.Sprintf("%v", value)
 		default:
-			return "", errors.New("Unexpected type in JSON config, not supported by testsuite")
+			return "", errors.New("Unexpected type in config file, type not supported.")
 		}
 	}
 	return keyValue, nil
 }
 
-func matchConfigValue(configPath string, condition string, keyPath string, expectedValue string) error {
-	keyValue, err := getConfigValue(configPath, keyPath)
+func getFileContent(path string) ([]byte, error) {
+	data, err := ioutil.ReadFile(testDir + "/" + path)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot read file: %v", err)
+	}
+
+	return data, err
+}
+
+func configFileContainsKeyMatchingValue(format string, configPath string, condition string, keyPath string, expectedValue string) error {
+	config, err := getFileContent(configPath)
+	if err != nil {
+		return err
+	}
+
+	keyValue, err := getConfigKeyValue(config, format, keyPath)
 	if err != nil {
 		return err
 	}
@@ -323,8 +362,13 @@ func matchConfigValue(configPath string, condition string, keyPath string, expec
 	return nil
 }
 
-func checkConfigKey(configPath string, condition string, keyPath string) error {
-	keyValue, err := getConfigValue(configPath, keyPath)
+func configFileContainsKey(format string, configPath string, condition string, keyPath string) error {
+	config, err := getFileContent(configPath)
+	if err != nil {
+		return err
+	}
+
+	keyValue, err := getConfigKeyValue(config, format, keyPath)
 	if err != nil {
 		return err
 	}
@@ -333,6 +377,43 @@ func checkConfigKey(configPath string, condition string, keyPath string) error {
 		return fmt.Errorf("Config does not contain any value for key %s", keyPath)
 	} else if (condition == "does not have") && (keyValue != "<nil>") {
 		return fmt.Errorf("Config contains key %s with assigned value: %s", keyPath, keyValue)
+	}
+
+	return nil
+}
+
+func stdoutContainsKeyMatchingValue(commandField string, format string, condition string, keyPath string, expectedValue string) error {
+	config := []byte(selectFieldFromLastOutput(commandField))
+
+	keyValue, err := getConfigKeyValue(config, format, keyPath)
+	if err != nil {
+		return err
+	}
+
+	matches, err := performRegexMatch(expectedValue, keyValue)
+	if err != nil {
+		return err
+	} else if (condition == "contains") && !matches {
+		return fmt.Errorf("For key '%s' %s contains unexpected value '%s'", keyPath, commandField, keyValue)
+	} else if (condition == "does not contain") && matches {
+		return fmt.Errorf("For key '%s' %s contains value '%s', which it should not contain", keyPath, commandField, keyValue)
+	}
+
+	return nil
+}
+
+func stdoutContainsKey(commandField string, format string, condition string, keyPath string) error {
+	config := []byte(selectFieldFromLastOutput(commandField))
+
+	keyValue, err := getConfigKeyValue(config, format, keyPath)
+	if err != nil {
+		return err
+	}
+
+	if (condition == "has") && (keyValue == "<nil>") {
+		return fmt.Errorf("%s does not contain any value for key %s", commandField, keyPath)
+	} else if (condition == "does not have") && (keyValue != "<nil>") {
+		return fmt.Errorf("%s contains key %s with assigned value: %s", commandField, keyPath, keyValue)
 	}
 
 	return nil
@@ -422,28 +503,81 @@ func selectFieldFromLastOutput(commandField string) string {
 func shouldBeInValidFormat(commandField string, format string) error {
 	result := selectFieldFromLastOutput(commandField)
 	result = strings.TrimRight(result, "\n")
+	var err error
 	switch format {
 	case "URL":
-		_, err := url.ParseRequestURI(result)
-		if err != nil {
-			return fmt.Errorf("Command did not returned URL in valid format: %s", result)
-		}
+		_, err = validateURL(result)
 	case "IP":
-		if net.ParseIP(result) == nil {
-			return fmt.Errorf("%s of previous command is not a valid IP address: %s", commandField, result)
-		}
+		_, err = validateIP(result)
+	case "IP with port number":
+		_, err = validateIPWithPort(result)
+	case "YAML":
+		_, err = validateYAML(result)
+	default:
+		return fmt.Errorf("Format %s not implemented.", format)
 	}
-	return nil
+
+	return err
 }
 
-func commandReturnEquals(commandField string, command string, expected string) error {
-	minishift.executingMinishiftCommand(command)
-	return compareExpectedWithActualEquals(expected+"\n", selectFieldFromLastOutput(commandField))
+func validateIP(inputString string) (bool, error) {
+	if net.ParseIP(inputString) == nil {
+		return false, fmt.Errorf("IP address '%s' is not a valid IP address", inputString)
+	}
+
+	return true, nil
 }
 
-func commandReturnContains(commandField string, command string, expected string) error {
+func validateURL(inputString string) (bool, error) {
+	_, err := url.ParseRequestURI(inputString)
+	if err != nil {
+		return false, fmt.Errorf("URL '%s' is not an URL in valid format. Parsing error: %v", inputString, err)
+	}
+
+	return true, nil
+}
+
+func validateIPWithPort(inputString string) (bool, error) {
+	split := strings.Split(inputString, ":")
+	if len(split) != 2 {
+		return false, fmt.Errorf("String '%s' does not contain one ':' separator", inputString)
+	}
+	if _, err := strconv.Atoi(split[1]); err != nil {
+		return false, fmt.Errorf("Port must be an integer, in '%s' the port '%s' is not an integer. Conversion error: %v", inputString, split[1], err)
+	}
+	if net.ParseIP(split[0]) == nil {
+		return false, fmt.Errorf("In '%s' the IP part '%s' is not a valid IP address", inputString, split[0])
+	}
+
+	return true, nil
+}
+
+func validateYAML(inputString string) (bool, error) {
+	m := make(map[interface{}]interface{})
+	err := yaml.Unmarshal([]byte(inputString), &m)
+	if err != nil {
+		return false, fmt.Errorf("Error unmarshaling YAML: %s. YAML='%s'", err, inputString)
+	}
+
+	return true, nil
+}
+
+func commandReturnEquals(commandField string, command string, condition string, expected string) error {
 	minishift.executingMinishiftCommand(command)
-	return compareExpectedWithActualContains(expected, selectFieldFromLastOutput(commandField))
+	if condition == "is equal" {
+		return compareExpectedWithActualEquals(expected+"\n", selectFieldFromLastOutput(commandField))
+	} else {
+		return compareExpectedWithActualNotEquals(expected+"\n", selectFieldFromLastOutput(commandField))
+	}
+}
+
+func commandReturnContains(commandField string, command string, condition string, expected string) error {
+	minishift.executingMinishiftCommand(command)
+	if condition == "contains" {
+		return compareExpectedWithActualContains(expected, selectFieldFromLastOutput(commandField))
+	} else {
+		return compareExpectedWithActualNotContains(expected, selectFieldFromLastOutput(commandField))
+	}
 }
 
 func commandReturnShouldContain(commandField string, expected string) error {

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	instanceState "github.com/minishift/minishift/pkg/minishift/config"
+	utilCmd "github.com/minishift/minishift/pkg/util/cmd"
 )
 
 type MinishiftRunner struct {
@@ -42,7 +43,7 @@ type OcRunner struct {
 }
 
 func runCommand(command string, commandPath string) (stdOut string, stdErr string, exitCode int) {
-	commandArr := strings.Split(command, " ")
+	commandArr := utilCmd.SplitCmdString(command)
 	path, _ := filepath.Abs(commandPath)
 	cmd := exec.Command(path, commandArr...)
 


### PR DESCRIPTION
This adds integration test for `minishift openshift service` and other subcommands of `minishift openshift` command. This is first bigger command I am trying to cover, so I will be thankful for any feedback. Can this be the way we could go in parallel to user story based tests?

To remove WIP there is need to at least add `minishift openshift config set` subcommand for which I need to do changes in "executing xyz succeeds" as I need to insert for example this: `minishift openshift config set --patch '{"assetConfig": {"logoutURL": "http://www.minishift.io"}}'` and right now it is not really quotes welcoming.