### PR TITLE
Issue #460 Add GitLab CI runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+build:
+  image: fedora:26
+  script:
+    - dnf install -y golang glide make git python
+    - export CURRENT_BUILD_PATH=$PWD
+    - mkdir -p $HOME/gopath
+    - export GOPATH=$HOME/gopath
+    - export PATH=$PATH:$GOPATH/bin
+    - mkdir -p $HOME/gopath/src/github.com/minishift
+    - ln -s $CURRENT_BUILD_PATH $HOME/gopath/src/github.com/minishift/minishift
+    - cd $HOME/gopath/src/github.com/minishift/minishift/
+    - make prerelease
+    - rm -rf $HOME/gopath/src/github.com/minishift/minishift/out/bindata
+    - mv $HOME/gopath/src/github.com/minishift/minishift/out/ $CURRENT_BUILD_PATH/public
+  artifacts:
+    paths:
+      - public
+

--- a/cmd/minishift/cmd/oc_env_test.go
+++ b/cmd/minishift/cmd/oc_env_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Test_unix_oc_path(t *testing.T) {
-	shellConfig, err := getOcShellConfig("/Users/john/.minishift/cache/oc/v1.5.0/oc", "")
+	shellConfig, err := getOcShellConfig("/Users/john/.minishift/cache/oc/v1.5.0/oc", "bash")
 	if err != nil {
 		t.Fatalf("Unexepcted error: %s", err)
 	}


### PR DESCRIPTION
Added GitLab CI runner definition to build on a GitLab instance. Example:
  * https://gitlab.com/gbraad/minishift/-/jobs/28627751
 * https://gitlab.com/minishift/minishift/-/jobs/28634280

`oc_env_test.go` needed to be given a forced shell, else the test fails with:
```
=== RUN   Test_unix_oc_path
The default lines below are for a sh/bash shell, you can specify the shell you're using, with the --shell flag.

--- FAIL: Test_unix_oc_path (0.00s)
	oc_env_test.go:28: Unexepcted error: Error: Unknown shell
```
Note: running with `bash -c "make test"` did not make a difference