### PR TITLE
Issue #1237 Don't show empty headers in release notes

### DIFF
--- a/scripts/release/issue-list.sh
+++ b/scripts/release/issue-list.sh
@@ -23,6 +23,13 @@ function usage()
     exit 1
 }
 
+function print_content_with_nonempty_issues() {
+  echo $1 | grep -q '[0-9]'
+  if [[ "$?" == 0 ]]; then
+    echo -e "$1"
+  fi
+}
+
 # Given a minishift repo name and a milestone, generates a sorted list of issues for this milestone.
 # Can be used to update the GitHub replease page as part of cutting a release.
 function milestone_issues()
@@ -55,7 +62,9 @@ function milestone_issues()
     if [[ "$line" == *"(task)"* ]]; then tasks="$tasks\n$line"; fi
   done <<< "$issue_list"
 
-  echo -e "$features\n$bugs\n$tasks"
+  for content in "$features" "$bugs" "$tasks"; do
+    print_content_with_nonempty_issues "$content"
+  done
 }
 
 while getopts ":r:m:" opt; do


### PR DESCRIPTION
Fix #1237 

## Examples

```
$ ./scripts/release/issue-list.sh -r minishift -m 23

# Bugs

- Issue [#1235](https://github.com/minishift/minishift/issues/1235) (bug) - Wrong version info in v1.4.0 binaries

$ ./scripts/release/issue-list.sh -r minishift -m 22
# Features

- Issue [#1133](https://github.com/minishift/minishift/issues/1133) (feature) - Function configContains in integration_test.go does not work properly

# Bugs

- Issue [#1121](https://github.com/minishift/minishift/issues/1121) (bug) - Possible error in delete/registration code
- Issue [#1123](https://github.com/minishift/minishift/issues/1123) (bug) - Instructions for manual installation of xhyve driver do not work on Sierra
- Issue [#1153](https://github.com/minishift/minishift/issues/1153) (bug) - Proxy not set for Docker engine
- Issue [#1161](https://github.com/minishift/minishift/issues/1161) (bug) - "developer document" on page "contribution Guidelines" show 404
- Issue [#1164](https://github.com/minishift/minishift/issues/1164) (bug) - Duplicate IDs in docs hamper downstreaming
- Issue [#1169](https://github.com/minishift/minishift/issues/1169) (bug) - Unsupported cluster up flags are not returned as error

# Tasks

- Issue [#1098](https://github.com/minishift/minishift/issues/1098) (task) - Update documentation: minishift.exe only works properly from C:""
- Issue [#1148](https://github.com/minishift/minishift/issues/1148) (task) - Reference the latest OpenShift doc in Minishift documentation
- Issue [#1152](https://github.com/minishift/minishift/issues/1152) (task) - Describe the issue of filling up the live root filesystem
- Issue [#1172](https://github.com/minishift/minishift/issues/1172) (task) - Fix Travis CI to run on Trusty
- Issue [#1177](https://github.com/minishift/minishift/issues/1177) (task) - Update to latest CentOS ISO

```