### PR TITLE
Issue #1254 Add Github API rate limit troubleshoot info

### DIFF
--- a/docs/source/using/troubleshooting.adoc
+++ b/docs/source/using/troubleshooting.adoc
@@ -314,3 +314,29 @@ You can configure the URL by running:
 $ minishift config set check-network-http-host <URL>
 ----
 
+[[github-api-rate-limit-exceeded]]
+== GitHub API rate limit exceeded
+
+When you run `minishift start` or `minishift update`, it makes requests to GitHub API to check for new version and potentially download new versions of the Minishift or OpenShift client tool `oc`.
+
+Sometimes, during these requests, you might receive a 403 forbidden status from GitHub if your request exceeds the rate limit for your IP address. In this case, the command will fail and you will receive an error message. For example:
+
+----
+Error starting the cluster: Error attempting to download and cache oc: Cannot get the OpenShift
+release version v3.6.0: GET https://api.github.com/repos/openshift/origin/releases/tags/v3.6.0:
+403 API rate limit exceeded for (your IP shows here). (But here's the good news: Authenticated
+requests get a higher rate limit. Check out the documentation for more details.); rate reset in
+17m2.462768522s
+----
+
+GitHub has a rate limiting policy, see link:https://developer.github.com/v3/#rate-limiting[Rate Limiting]. You may have reached this limit for various reasons. For example, your package manager may use GitHub API calls or you are behind a corporate network that makes a lot of GitHub unauthenticated API calls.
+
+Instead of waiting for GitHub to reset the limit for your IP address, you can create a link:https://GitHub.com/blog/1509-personal-api-tokens[Personal API Tokens] from your GitHub account. This gives you a higher rate limit.
+
+After you generate the API token, you need to set the `MINISHIFT_GITHUB_API_TOKEN` environment variable by running:
+
+----
+$ export MINISHIFT_GITHUB_API_TOKEN=<token_ID>
+----
+
+Replace `<token_ID>` with your token. You can also add this variable in your shell profile so you don't need to manually set the variable every time you run a Minishift command.


### PR DESCRIPTION
This commit adds an explanation into the documentation troubleshoot
section. It explains why we sometimes get the 403 status from Github
API calls and a solution to avoid this issue.

Closes #1254