### PR TITLE
Issue #1281 Update word 'Mac' with 'macOS'

### DIFF
--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -20,7 +20,7 @@ Verify that the hypervisor of your choice is installed and enabled on your syste
 
 Depending on your host operating system, you have the choice of the following hypervisors:
 
-Mac macOS::
+macOS::
 - link:https://github.com/mist64/xhyve[xhyve] (default)
 +
 NOTE: xhyve requires specific installation and configuration steps that are described in the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.

--- a/docs/source/using/host-folders.adoc
+++ b/docs/source/using/host-folders.adoc
@@ -203,11 +203,11 @@ No host folders defined
 NOTE: This host folder type is not supported by the `minishift hostfolder` command and requires manual configuration.
 
 You can use SSHFS-based host folders if you have an SSH daemon running on your host.
-Normally, this prerequisite is met by default on Linux and Mac macOS.
+Normally, this prerequisite is met by default on Linux and macOS.
 
 Most Linux distributions have an SSH daemon installed. If not, follow the instructions for your specific distribution to install an SSH daemon.
 
-Mac macOS also has a built-in SSH server.
+macOS also has a built-in SSH server.
 To use it, make sure that *Remote Login* is enabled in *System Preferences > Sharing*.
 
 On Windows, you can install link:https://winscp.net/eng/docs/guide_windows_openssh_server[OpenSSH for Windows].


### PR DESCRIPTION
Fix #1281 

I have searched through all documentation. Could only found these many occurances.