### PR TITLE
Issue #607 Integration tests should log to file

### DIFF
--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -258,6 +258,14 @@ $ make integration GODOG_OPTS="-paths ~/tests/custom.feature,~/my.feature -tags 
 NOTE: When multiple values are used for options in `GODOG_OPTS`, then they have to be separated by a comma without whitespace.
 While `-tags basic,openshift` will be parsed properly by make, `-tags basic, openshift` will result in only `@basic` being used.
 
+==== Viewing Results
+
+Integration test logs its progress directly into a console with accent of providing additional useful information when failures of individual Gherkin steps happen.
+This information is often enough to find and debug the reason of failure.
+
+However for cases which needs further investigation the integration test also logs more detailed progress into a log file. This file is located at `$GOPATH/github.com/minishift/minishift/out/integration-test/integration.log`.
+Please note that this file is being deleted on start of each subsequent test run.
+
 [[format-source-code]]
 === Formatting the Source Code
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -244,12 +244,27 @@ func FeatureContext(s *godog.Suite) {
 			runner.CDKSetup()
 		}
 
+		util.StartLog(testDir)
+
 		fmt.Println("Running Integration test in:", testDir)
 		fmt.Println("Using binary:", minishiftBinary)
 	})
 
 	s.AfterSuite(func() {
+		util.LogMessage("info", "----- Cleaning Up -----")
 		minishift.runner.EnsureDeleted()
+		util.CloseLog()
+	})
+
+	s.BeforeScenario(func(this interface{}) {
+		switch this.(type) {
+		case *gherkin.Scenario:
+			scenario := *this.(*gherkin.Scenario)
+			util.LogMessage("info", fmt.Sprintf("----- Scenario: %s -----", scenario.ScenarioDefinition.Name))
+		case *gherkin.ScenarioOutline:
+			scenario := *this.(*gherkin.ScenarioOutline)
+			util.LogMessage("info", fmt.Sprintf("----- Scenario Outline: %s -----", scenario.ScenarioDefinition.Name))
+		}
 	})
 
 	s.AfterScenario(func(interface{}, error) {

--- a/test/integration/minishift.go
+++ b/test/integration/minishift.go
@@ -133,6 +133,7 @@ func (m *Minishift) processVariables(command string) string {
 func (m *Minishift) executingOcCommand(command string) error {
 	ocRunner := m.runner.GetOcRunner()
 	if ocRunner == nil {
+		util.LogMessage("warning", "OC binary can't be detected, minishift is not Running")
 		return errors.New("Minishift is not Running")
 	}
 

--- a/test/integration/util/integration_logger.go
+++ b/test/integration/util/integration_logger.go
@@ -1,0 +1,103 @@
+// +build integration
+
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+)
+
+const (
+	messageInfoMaxLength = 7
+	timeHeaderLength     = 16
+)
+
+var (
+	IntegrationLog *log.Logger
+	logFile        *os.File
+)
+
+func init() {
+	IntegrationLog = log.New(ioutil.Discard, "", 0)
+}
+
+func StartLog(logPath string) error {
+	logPath = path.Join(logPath, "integration.log")
+	logFile, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+
+	IntegrationLog = log.New(logFile, "", log.Ltime|log.Lmicroseconds)
+	LogMessage("info", "Log Initiated")
+	fmt.Println("Log successfully started, logging into:", logPath)
+
+	return nil
+}
+
+func CloseLog() error {
+	err := logFile.Close()
+	return err
+}
+
+func LogMessage(messageInfo, message string) error {
+	messageInfo = formatMessageInfo(messageInfo)
+	message = formatMessage(message)
+	IntegrationLog.Print(messageInfo + message)
+
+	return nil
+}
+
+func formatMessage(message string) string {
+	formattedMessage := ": "
+	offsetLength := timeHeaderLength + messageInfoMaxLength + len(formattedMessage)
+
+	splittedMessage := strings.Split(message, "\n")
+	for index, line := range splittedMessage {
+		switch index {
+		case 0:
+			formattedMessage += line + "\n"
+		case (len(splittedMessage) - 1):
+			if line == "" {
+				continue
+			}
+			fallthrough
+		default:
+			offSet := strings.Repeat(" ", offsetLength)
+			formattedMessage += offSet + line + "\n"
+		}
+	}
+
+	return formattedMessage
+}
+
+func formatMessageInfo(messageInfo string) string {
+	if len(messageInfo) > messageInfoMaxLength {
+		messageInfo = messageInfo[0:messageInfoMaxLength]
+	} else if len(messageInfo) < messageInfoMaxLength {
+		difference := messageInfoMaxLength - len(messageInfo)
+		messageInfo = strings.Repeat(" ", difference) + messageInfo
+	}
+
+	return messageInfo
+}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -19,6 +19,7 @@ limitations under the License.
 package util
 
 import (
+	//"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -51,7 +52,9 @@ func runCommand(command string, commandPath string) (stdOut string, stdErr strin
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
 
+	LogMessage("command", fmt.Sprintf("%s %s", commandPath, command))
 	err := cmd.Run()
+
 	stdOut = outbuf.String()
 	stdErr = errbuf.String()
 
@@ -68,6 +71,11 @@ func runCommand(command string, commandPath string) (stdOut string, stdErr strin
 	} else {
 		ws := cmd.ProcessState.Sys().(syscall.WaitStatus)
 		exitCode = ws.ExitStatus()
+	}
+
+	LogMessage("stdout", stdOut)
+	if stdErr != "" {
+		LogMessage("stderr", stdErr)
 	}
 
 	return


### PR DESCRIPTION
Adds possibility to log into file with package`test/integration/util`. One can use util.IntegrationTest.Print() or other functions to log, but recommended is to use LogMessage(info string, message string) which will take care of formatting and also adds info about the message, like if it is warning, stdout, stderr, info or anything else. With this function the should be hopefully nicely readable.

This PR also implemented the logging possibilities into actual tests.