### PR TITLE
Issue #1103 Variable quoting for fish shell

### DIFF
--- a/pkg/util/shell/shell.go
+++ b/pkg/util/shell/shell.go
@@ -95,7 +95,7 @@ func GetPrefixSuffixDelimiterForSet(userShell string, pathVar bool) (prefix, suf
 		suffix = "\";\n"
 		delimiter = " \""
 		if pathVar {
-			suffix = "\" \"$PATH\";\n"
+			suffix = "\" $PATH;\n"
 		}
 	case "powershell":
 		prefix = "$Env:"


### PR DESCRIPTION
Removes the quotes around $PATH so that the existing $PATH variable is expanded
as a list and then appended to the new PATH. When quoted, the variable does not
expand, and `minishift oc-env` would blow away a user's $PATH.

Fixes: https://github.com/minishift/minishift/issues/1103