### PR TITLE
Issue #1216 Improve `make integration` to be friendlier to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ ifeq ($(GOOS),windows)
 	IS_EXE := .exe
 endif
 MINISHIFT_BINARY ?= $(GOPATH)/bin/minishift$(IS_EXE)
-GODOG_OPTS ?= ""
+TIMEOUT ?= 3600s
+GODOG_OPTS ?= -tags basic
 PACKAGES := go list ./... | grep -v /vendor
 SOURCE_DIRS = cmd pkg test
 
@@ -183,7 +184,12 @@ test: vendor $(ADDON_ASSET_FILE)
 .PHONY: integration
 integration: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
-	go test -timeout 3600s $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) $(GODOG_OPTS)
+	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) $(GODOG_OPTS)
+
+.PHONY: integration_all
+integration_all: $(MINISHIFT_BINARY)
+	mkdir -p $(INTEGRATION_TEST_DIR)
+	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) -tags ~coolstore
 
 .PHONY: fmt
 fmt:

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -211,10 +211,24 @@ For example, _proxy.feature_ or _cmd-version.feature_.
 ==== Running Integration Tests
 
 By default, the tests are being run against the binary created by `make build`, which is *_$GOPATH/bin/minishift_*. 
-To run the tests, use the following command:
+To run the basic test, use the following command:
 
 ----
 $ make integration
+----
+
+NOTE: By default `make integration` only runs tests which are tagged as `@basic`.
+
+To run all the test, use the following command:
+
+----
+$ make integration_all
+----
+
+Flag *_TIMEOUT_* can be used to overwrite the default timeout 3600s. To run all the test with timeout 7200s, use the following command:
+
+----
+$ make integration_all TIMEOUT=7200s
 ----
 
 To run integration tests against a Minishift binary in a different location you can use the `MINISHIFT_BINARY` argument:


### PR DESCRIPTION
This pr comprises two make test functionality make integration_smoke and make integration_all. 

i have executed this functionality both with upstream and downstream. Coolsrore is not added to the integration_all as there is a ongoing issue #1327 and proxy feature has some problem i.e. it hangs in step ```oc rollout status deploymentconfig ruby-ex``` while run along with rest of the features sequentially  ```-tags basic,cmd-openshift,command,flags,openshift-version,proxy -format pretty```, however standalone proxy feature ```make integration GODOG_OPTS="-tags basic -format pretty"```runs successfully without any error. 

we can take the proxy feature in a separate issue atm.

Here are the some part of logs 

On master
```
$ make integration_smoke
.
.
14 scenarios (14 passed)
52 steps (52 passed)
3m52.331961232s
testing: warning: no tests to run
PASS
ok      github.com/minishift/minishift/test/integration 232.350s
✔ ~/go/src/github.com/minishift/minishift [master ↓·1|✚ 4]
16:52 $
```
```
$ make integration_all
.
.  
55 scenarios (55 passed)
202 steps (202 passed)
12m19.31757216s
testing: warning: no tests to run
PASS
ok      github.com/minishift/minishift/test/integration 739.333s
✔ ~/go/src/github.com/minishift/minishift [master ↓·2|✚ 4]
17:06 $
```
On cdk bits
```
$ make integration_smoke MINISHIFT_BINARY=/../../../minishift
.
.
. 

13 scenarios (13 passed)
50 steps (50 passed)
8m37.776753086s
testing: warning: no tests to run
PASS
ok      github.com/minishift/minishift/test/integration 517.793s
✔ ~/go/src/github.com/minishift/minishift [master ↓·2|✚ 4]
18:09 $
```
```
$ make integration_all MINISHIFT_BINARY=/../../../minishift
.
.
Output did not match. Expected: 'Default add-ons anyuid, admin-user, xpaas, registry-route installed', Actual: 'Default add-ons anyuid, admin-user, xpaas installed'

Output did not match. Expected: 'Namespace does-not-exist doesn't exist', Actual: 'Namespace does-not-exist doesn't exits'
.
.
.
--- Failed scenarios:

    features/basic.feature:8
    features/cmd-openshift.feature:75

48 scenarios (46 passed, 2 failed)
174 steps (172 passed, 2 failed)
15m29.34355887s
testing: warning: no tests to run
PASS
exit status 1
FAIL    github.com/minishift/minishift/test/integration 929.363s
make: *** [Makefile:186: integration_all] Error 1
✘-2 ~/go/src/github.com/minishift/minishift [master ↓·2|✚ 4]
18:28 $
```
These two failure has been fixed in latest minishift release. So it is expected in the downstream containing minishift v1.3.1