### PR TITLE
Issue #1316 Set IP address (Hyper-V only)

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -120,6 +120,13 @@ var (
 	// Preflight values
 	CheckNetworkHttpHost = createConfigSetting("check-network-http-host", SetString, nil, nil, true)
 	CheckNetworkPingHost = createConfigSetting("check-network-ping-host", SetString, nil, nil, true)
+
+	// Network settings (Hyper-V only)
+	NetworkDevice = createConfigSetting("network-device", SetString, nil, nil, true)
+	IPAddress     = createConfigSetting("network-ipaddress", SetString, []setFn{validations.IsValidIPv4Address}, nil, true)
+	Netmask       = createConfigSetting("network-netmask", SetString, []setFn{validations.IsValidNetmask}, nil, true)
+	Gateway       = createConfigSetting("network-gateway", SetString, []setFn{validations.IsValidIPv4Address}, nil, true)
+	Nameserver    = createConfigSetting("network-nameserver", SetString, []setFn{validations.IsValidIPv4Address}, nil, true)
 )
 
 func createConfigSetting(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool) *Setting {

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -60,8 +60,6 @@ var viperWhiteList = []string{
 	"log_dir",
 }
 
-var hasEnabledExperimental bool
-
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "minishift",
@@ -98,7 +96,7 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		if hasEnabledExperimental {
+		if minishiftConfig.EnableExperimental {
 			glog.Info("Experimental features are enabled")
 		}
 
@@ -145,7 +143,8 @@ func processEnvVariables() {
 	if err == cmdUtil.BooleanFormatError {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error enabling experimental features: %s", err))
 	}
-	hasEnabledExperimental = enableExperimental
+
+	minishiftConfig.EnableExperimental = enableExperimental
 }
 
 func init() {

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -336,7 +336,7 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 	}
 
 	// Experimental features
-	if hasEnabledExperimental {
+	if minishiftConfig.EnableExperimental {
 		networkSettings := minishiftNetwork.NetworkSettings{
 			Device:    viper.GetString(configCmd.NetworkDevice.Name),
 			IPAddress: viper.GetString(configCmd.IPAddress.Name),
@@ -505,7 +505,7 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.AddFlag(registryMirrorFlag)
 	startFlagSet.AddFlag(cmdUtil.AddOnEnvFlag)
 
-	if hasEnabledExperimental && runtime.GOOS == "windows" {
+	if minishiftConfig.EnableExperimental && runtime.GOOS == "windows" {
 		startFlagSet.String(configCmd.NetworkDevice.Name, "eth0", "Specify the network device to use for the IP address. Ignored if no IP address specified (experimental - Hyper-V only)")
 		startFlagSet.String(configCmd.IPAddress.Name, "", "Specify IP address to assign to the instance (experimental - Hyper-V only)")
 		startFlagSet.String(configCmd.Netmask.Name, "24", "Specify netmask to use for the IP address. Ignored if no IP address specified (experimental - Hyper-V only)")
@@ -537,7 +537,7 @@ func initClusterUpFlags() *flag.FlagSet {
 	clusterUpFlagSet.AddFlag(cmdUtil.HttpProxyFlag)
 	clusterUpFlagSet.AddFlag(cmdUtil.HttpsProxyFlag)
 
-	if hasEnabledExperimental {
+	if minishiftConfig.EnableExperimental {
 		clusterUpFlagSet.Bool(configCmd.ServiceCatalog.Name, false, "Install service catalog (experimental)")
 		clusterUpFlagSet.String(configCmd.ExtraClusterUpFlags.Name, "", "Specify optional flags for use with 'cluster up' (unsupported)")
 	}

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
@@ -41,6 +42,7 @@ import (
 	"github.com/minishift/minishift/pkg/minishift/docker"
 	"github.com/minishift/minishift/pkg/minishift/docker/image"
 	"github.com/minishift/minishift/pkg/minishift/hostfolder"
+	minishiftNetwork "github.com/minishift/minishift/pkg/minishift/network"
 	"github.com/minishift/minishift/pkg/minishift/openshift"
 	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
 	"github.com/minishift/minishift/pkg/minishift/provisioner"
@@ -305,6 +307,7 @@ func determineInsecureRegistry(key string) []string {
 
 func startHost(libMachineClient *libmachine.Client) *host.Host {
 	progressDots := progressdots.New()
+
 	// Configuration used for creation/setup of the Virtual Machine
 	machineConfig := &cluster.MachineConfig{
 		MinikubeISO:      determineIsoUrl(viper.GetString(configCmd.ISOUrl.Name)),
@@ -330,6 +333,22 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 		fmt.Println("   Memory:   ", units.HumanSize(float64((machineConfig.Memory/units.KiB)*units.GB)))
 		fmt.Println("   vCPUs :   ", machineConfig.CPUs)
 		fmt.Println("   Disk size:", units.HumanSize(float64(machineConfig.DiskSize*units.MB)))
+	}
+
+	// Experimental features
+	if hasEnabledExperimental {
+		networkSettings := minishiftNetwork.NetworkSettings{
+			Device:    viper.GetString(configCmd.NetworkDevice.Name),
+			IPAddress: viper.GetString(configCmd.IPAddress.Name),
+			Netmask:   viper.GetString(configCmd.Netmask.Name),
+			Gateway:   viper.GetString(configCmd.Gateway.Name),
+			DNS1:      viper.GetString(configCmd.Nameserver.Name),
+		}
+
+		// Configure networking on startup only works on Hyper-V
+		if networkSettings.IPAddress != "" {
+			minishiftNetwork.ConfigureNetworking(constants.MachineName, networkSettings)
+		}
 	}
 
 	cacheMinishiftISO(machineConfig)
@@ -485,6 +504,14 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.AddFlag(insecureRegistryFlag)
 	startFlagSet.AddFlag(registryMirrorFlag)
 	startFlagSet.AddFlag(cmdUtil.AddOnEnvFlag)
+
+	if hasEnabledExperimental && runtime.GOOS == "windows" {
+		startFlagSet.String(configCmd.NetworkDevice.Name, "eth0", "Specify the network device to use for the IP address. Ignored if no IP address specified (experimental - Hyper-V only)")
+		startFlagSet.String(configCmd.IPAddress.Name, "", "Specify IP address to assign to the instance (experimental - Hyper-V only)")
+		startFlagSet.String(configCmd.Netmask.Name, "24", "Specify netmask to use for the IP address. Ignored if no IP address specified (experimental - Hyper-V only)")
+		startFlagSet.String(configCmd.Gateway.Name, "", "Specify gateway to use for the instance. Ignored if no IP address specified (experimental - Hyper-V only)")
+		startFlagSet.String(configCmd.Nameserver.Name, "8.8.8.8", "Specify nameserver to use for the instance. Ignored if no IP address specified (experimental - Hyper-V only)")
+	}
 
 	return startFlagSet
 }

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -28,7 +28,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
 	"github.com/minishift/minishift/pkg/minishift/shell/powershell"
-	miniUtil "github.com/minishift/minishift/pkg/minishift/util"
+	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
 
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/viper"
@@ -101,15 +101,6 @@ func preflightChecksAfterStartingHost(driver drivers.Driver) {
 		"Checking for IP address",
 		false, configCmd.WarnInstanceIP.Name,
 		"Error determining IP address")
-	/*
-		// This happens too late in the preflight, as provisioning needs an IP already
-			preflightCheckSucceedsOrFailsWithDriver(
-				configCmd.SkipCheckNetworkHost.Name,
-				checkVMConnectivity, driver,
-				"Checking if VM is reachable from host",
-				configCmd.WarnCheckNetworkHost.Name,
-				"Please check our troubleshooting guide")
-	*/
 	preflightCheckSucceedsOrFailsWithDriver(
 		configCmd.SkipCheckNetworkPing.Name,
 		checkIPConnectivity, driver,
@@ -341,20 +332,6 @@ func checkInstanceIP(driver drivers.Driver) bool {
 	return false
 }
 
-// checkVMConnectivity checks if VM instance IP is reachable from the host
-func checkVMConnectivity(driver drivers.Driver) bool {
-	// used to check if the host can reach the VM
-	ip, _ := driver.GetIP()
-
-	cmd := exec.Command("ping", "-n 1", ip)
-	stdoutStderr, err := cmd.CombinedOutput()
-	if err != nil {
-		return false
-	}
-	fmt.Printf("%s\n", stdoutStderr)
-	return false
-}
-
 // checkIPConnectivity checks if the VM has connectivity to the outside network
 func checkIPConnectivity(driver drivers.Driver) bool {
 	ipToPing := viper.GetString(configCmd.CheckNetworkPingHost.Name)
@@ -363,7 +340,7 @@ func checkIPConnectivity(driver drivers.Driver) bool {
 	}
 
 	fmt.Printf("\n   Pinging %s ... ", ipToPing)
-	return miniUtil.IsIPReachable(driver, ipToPing, false)
+	return minishiftUtil.IsIPReachable(driver, ipToPing, false)
 }
 
 // checkHttpConnectivity allows to test outside connectivity and possible proxy support
@@ -374,7 +351,7 @@ func checkHttpConnectivity(driver drivers.Driver) bool {
 	}
 
 	fmt.Printf("\n   Retrieving %s ... ", urlToRetrieve)
-	return miniUtil.IsRetrievable(driver, urlToRetrieve, false)
+	return minishiftUtil.IsRetrievable(driver, urlToRetrieve, false)
 }
 
 // checkStorageMounted checks if the peristent storage volume, storageDisk, is

--- a/docs/source/using/managing-minishift.adoc
+++ b/docs/source/using/managing-minishift.adoc
@@ -322,3 +322,59 @@ Enables provisioning the OpenShift link:https://docs.openshift.org/latest/archit
 
 `extra-clusterup-flags`::
 Enables passing flags that are not directly exposed in the Minishift CLI directly to `oc cluster up`.
+
+
+[[hyperv-static-ip]]
+=== Assign IP address to Hyper-V (experimental)
+
+Since the Internal Virtual Switch for Hyper-V does not provide a DHCP offer option, an IP address needs to be provided in a different way.
+For Hyper-V a functionality is provided to assign an IP address on startup using the Data Exchange Service.
+
+[IMPORTANT]
+====
+-  While the default image is B2D, this only works with the CentOS/RHEL based image in combination with Hyper-V. The B2D image experiences
+   a problem when the values are being send to the Minishift instance and consumed by the B2D iso. We are looking into the issue and hope
+   to provide a solution in the coming future.
+====
+
+To make this work you need to create a Virtual Switch using NAT
+
+- link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[Set up a NAT network]
+
+
+[NOTE]
+====
+WinNAT is limited to one NAT network per host. For more details about capabilities, and limitations, please see the link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[WinNAT capabilities and limitations blog]
+====
+
+The following command will attempt to assign an IP address for use on the Internal Virtual Switch 'MyInternal'.
+
+----
+PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
+PS> $env:HYPERV_VIRTUAL_SWITCH="MyInternal"
+PS> minishift.exe start `
+  --iso-url centos `
+  --network-ipaddress 192.168.1.10 `
+  --network-gateway 192.168.1.1 `
+  --network-nameserver 8.8.8.8
+----
+
+
+If you want to use the 'DockerNAT' network, the following commands are needed to setup the correct NAT networking and assigning an IP in the range expected.
+
+----
+PS> New-NetNat -Name SharedNAT -InternalIPInterfaceAddressPrefix 10.0.75.1/24
+PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
+PS> $env:HYPERV_VIRTUAL_SWITCH="DockerNAT"
+PS> minishift.exe start `
+  --iso-url centos `
+  --network-ipaddress 10.0.75.128 `
+  --network-gateway 10.0.75.1 `
+  --network-nameserver 8.8.8.8
+----
+
+[NOTE]
+====
+- Be sure to specify a valid gateway and nameserver. Failing to do so will result in connectivity issuesi
+====
+

--- a/glide.lock
+++ b/glide.lock
@@ -104,6 +104,8 @@ imports:
   version: bbd0c6e271208dce66d8fda4bc536453cd27fc4a
 - name: github.com/juju/errors
   version: c7d06af17c68cd34c835053720b21f6549d9b0ee
+- name: github.com/gbraad/go-hvkvp
+  version: a692e030379b6de28a10b7697decdf8109899f6e
 - name: github.com/kardianos/osext
   version: ae77be60afb1dcacde03767a8c37337fad28ac14
 - name: github.com/magiconair/properties

--- a/glide.yaml
+++ b/glide.yaml
@@ -65,6 +65,8 @@ import:
   version: 3bc7a60b1df80a5766820c4a53d59668f4553f75
 - package: github.com/juju/errors
   version: c7d06af17c68cd34c835053720b21f6549d9b0ee
+- package: github.com/gbraad/go-hvkvp
+  version: 0.3
 # The following repositories need to be specified explicitly, since the versions referenced by the openshift/origin dependency
 # refer to forks of these projects within the openshift organizaton
 # This needs to be manually updated after upgrading the openshift/origin dependnecy

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -35,6 +35,7 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/kubeconfig"
 	"github.com/minishift/minishift/pkg/minishift/addon/command"
 	"github.com/minishift/minishift/pkg/minishift/addon/manager"
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/minishift/oc"
 
 	"regexp"
@@ -90,13 +91,15 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string, runne
 		cmdArgs = append(cmdArgs, value)
 	}
 
-	// Deal with extra flags (add to command arguments)
-	if len(extraFlags) > 0 {
-		fmt.Println("-- Extra `oc` cluster up flags (experimental) ... ")
-		fmt.Printf("   '%s'\n", extraFlags)
-		extraFlagFields := strings.Fields(extraFlags)
-		for _, extraFlag := range extraFlagFields {
-			cmdArgs = append(cmdArgs, extraFlag)
+	if minishiftConfig.EnableExperimental {
+		// Deal with extra flags (add to command arguments)
+		if len(extraFlags) > 0 {
+			fmt.Println("-- Extra `oc` cluster up flags (experimental) ... ")
+			fmt.Printf("   '%s'\n", extraFlags)
+			extraFlagFields := strings.Fields(extraFlags)
+			for _, extraFlag := range extraFlagFields {
+				cmdArgs = append(cmdArgs, extraFlag)
+			}
 		}
 	}
 

--- a/pkg/minishift/config/featuretoggles.go
+++ b/pkg/minishift/config/featuretoggles.go
@@ -1,0 +1,21 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+var (
+	EnableExperimental bool
+)

--- a/pkg/minishift/config/validations.go
+++ b/pkg/minishift/config/validations.go
@@ -121,3 +121,36 @@ func IsValidUrl(_ string, isoURL string) error {
 	}
 	return nil
 }
+
+func IsValidIPv4Address(name string, address string) error {
+	ip := net.ParseIP(address).To4()
+	if ip == nil {
+		return fmt.Errorf("%s IPv4 address is not valid: %s", name, address)
+	}
+
+	return nil
+}
+
+func IsValidNetmask(name string, mask string) error {
+	err := fmt.Errorf("%s netmask is not valid: %s", name, mask)
+
+	if stringUtils.HasOnlyNumbers(mask) {
+		prefixSize, _ := strconv.Atoi(mask)
+		if prefixSize == 0 || prefixSize > 25 {
+			return err
+		}
+		return nil
+	}
+
+	// got something like '255.255.255.0' instead
+	ip := net.ParseIP(mask).To4()
+	if ip == nil {
+		return err
+	}
+	prefixSize, _ := net.IPMask(ip).Size()
+	if prefixSize == 0 {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/minishift/config/validations_test.go
+++ b/pkg/minishift/config/validations_test.go
@@ -188,3 +188,81 @@ func TestValidProxyURL(t *testing.T) {
 	}
 	runValidations(t, tests, "iso-url", IsValidProxy)
 }
+
+func TestValidIPv4Address(t *testing.T) {
+
+	var tests = []validationTest{
+		{
+			value:     "",
+			shouldErr: true,
+		},
+		{
+			value:     "10.0.75.128",
+			shouldErr: false,
+		},
+		{
+			value:     "localhost",
+			shouldErr: true,
+		},
+		{
+			value:     "::1",
+			shouldErr: true,
+		},
+		{
+			value:     "fe80::200:5aee:feaa:20a2",
+			shouldErr: true,
+		},
+	}
+	runValidations(t, tests, "ipaddress", IsValidIPv4Address)
+}
+
+func TestValidNetmask(t *testing.T) {
+
+	var tests = []validationTest{
+		{
+			value:     "",
+			shouldErr: true,
+		},
+		{
+			value:     "0",
+			shouldErr: true,
+		},
+		{
+			value:     "1",
+			shouldErr: false,
+		},
+		{
+			value:     "24",
+			shouldErr: false,
+		},
+		{
+			value:     "25",
+			shouldErr: false,
+		},
+		{
+			value:     "26",
+			shouldErr: true,
+		},
+		{
+			value:     "255.255.255.0",
+			shouldErr: false,
+		},
+		{
+			value:     "255.255.255.128",
+			shouldErr: false,
+		},
+		{
+			value:     "128.0.0.0",
+			shouldErr: false,
+		},
+		{
+			value:     "255.255.225.0",
+			shouldErr: true,
+		},
+		{
+			value:     "127.0.0.0",
+			shouldErr: true,
+		},
+	}
+	runValidations(t, tests, "netmask", IsValidNetmask)
+}

--- a/pkg/minishift/network/settings.go
+++ b/pkg/minishift/network/settings.go
@@ -1,0 +1,73 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+)
+
+const (
+	configureIPAddressMessage      = "-- Attempting to set network settings ..."
+	configureIPAddressFailure      = "FAIL\n   not supported on this platform or hypervisor"
+	configureNetworkScriptTemplate = `DEVICE={{.Device}}
+IPADDR={{.IPAddress}}
+NETMASK={{.Netmask}}
+GATEWAY={{.Gateway}}
+DNS1={{.DNS1}}
+DNS2={{.DNS2}}
+`
+)
+
+type NetworkSettings struct {
+	Device    string
+	IPAddress string
+	Netmask   string
+	Gateway   string
+	DNS1      string
+	DNS2      string
+}
+
+func printNetworkSettings(networkSettings NetworkSettings) {
+	fmt.Println(configureIPAddressMessage)
+	fmt.Println("   Device:     ", networkSettings.Device)
+	fmt.Println("   IP Address: ", fmt.Sprintf("%s/%s", networkSettings.IPAddress, networkSettings.Netmask))
+	if networkSettings.Gateway != "" {
+		fmt.Println("   Gateway:    ", networkSettings.Gateway)
+	}
+	if networkSettings.DNS1 != "" {
+		fmt.Println("   Nameservers:", fmt.Sprintf("%s %s", networkSettings.DNS1, networkSettings.DNS2))
+	}
+}
+
+func fillNetworkSettingsScript(networkSettings NetworkSettings) string {
+	result := &bytes.Buffer{}
+
+	tmpl, err := template.New("networkScript").Parse(configureNetworkScriptTemplate)
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating network script template: %s", err.Error()))
+	}
+	err = tmpl.Execute(result, networkSettings)
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error executing network script template:: %s", err.Error()))
+	}
+
+	return result.String()
+}

--- a/pkg/minishift/network/settings_darwin.go
+++ b/pkg/minishift/network/settings_darwin.go
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+)
+
+func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
+	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
+}

--- a/pkg/minishift/network/settings_linux.go
+++ b/pkg/minishift/network/settings_linux.go
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+)
+
+func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
+	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
+}

--- a/pkg/minishift/network/settings_test.go
+++ b/pkg/minishift/network/settings_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFillNetworkSettingsScript(t *testing.T) {
+	networkSettings := NetworkSettings{
+		Device:    "eth0",
+		IPAddress: "10.0.75.128",
+		Netmask:   "24",
+		Gateway:   "10.0.75.1",
+		DNS1:      "8.8.8.8",
+		DNS2:      "8.8.4.4",
+	}
+
+	actual := fillNetworkSettingsScript(networkSettings)
+
+	expected := `DEVICE=eth0
+IPADDR=10.0.75.128
+NETMASK=24
+GATEWAY=10.0.75.1
+DNS1=8.8.8.8
+DNS2=8.8.4.4
+`
+
+	if actual != expected {
+		t.Fatal(fmt.Sprintf("Actual: %s does not match expected: %s", actual, expected))
+	}
+}

--- a/pkg/minishift/network/settings_windows.go
+++ b/pkg/minishift/network/settings_windows.go
@@ -1,0 +1,101 @@
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	hvkvp "github.com/gbraad/go-hvkvp"
+	"github.com/golang/glog"
+	"github.com/minishift/minishift/pkg/minishift/shell/powershell"
+	"github.com/spf13/viper"
+)
+
+const (
+	resendInterval        = 5 * time.Second
+	resultSuccess         = "4096"
+	networkingMessageName = "PROVISION_NETWORKING"
+)
+
+func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
+	// Instruct the user that this does not work for other Hypervisors on Windows
+	if viper.GetString("vm-driver") != "hyperv" {
+		fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
+		return
+	}
+
+	printNetworkSettings(networkSettings)
+
+	networkScript := fillNetworkSettingsScript(networkSettings)
+	record := hvkvp.NewMachineKVPRecord(machineName,
+		networkingMessageName,
+		// to allow sending multiple lines in the value we encode the script
+		base64.StdEncoding.EncodeToString([]byte(networkScript)))
+
+	command := hvkvp.NewMachineKVPCommand(record)
+	b := newConfigBasher(doConfigure, command)
+	b.start()
+}
+
+func doConfigure(success chan bool, command string) {
+	posh := powershell.New()
+	result, _ := posh.Execute(command)
+
+	if strings.Contains(result, resultSuccess) {
+		if glog.V(5) {
+			fmt.Printf("*")
+		}
+		success <- true
+	}
+}
+
+type bashingFunc func(handler chan bool, command string)
+
+type configbasher struct {
+	interval time.Duration
+	handler  chan bool
+	bashing  bashingFunc
+	command  string
+}
+
+func newConfigBasher(bashing bashingFunc, command string) *configbasher {
+	return &configbasher{
+		interval: resendInterval,
+		handler:  make(chan bool),
+		bashing:  bashing,
+		command:  command,
+	}
+}
+
+func (b *configbasher) start() {
+	go func() {
+		for {
+			if glog.V(5) {
+				fmt.Printf("+")
+			}
+			b.bashing(b.handler, b.command)
+			time.Sleep(b.interval)
+		}
+	}()
+}
+
+func (b *configbasher) stop() {
+	b.handler <- true
+}

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -25,6 +25,7 @@ const (
 	lettersMatch       = "[a-zA-Z]+"
 	numbersMatch       = "[0-9]+"
 	signedNumbersMatch = "^[-+]?[0-9]+"
+	punctuationMatch   = "[.,/#!$%^&*;:{}=-_`~()]"
 )
 
 // Contains returns true, if the specified slice contains the specified element, false otherwise
@@ -55,7 +56,8 @@ func HasLetters(yourString string) bool {
 // HasOnlyLetters returns true when string contains only letters
 func HasOnlyLetters(yourString string) bool {
 	return checkForMatch(lettersMatch, yourString) &&
-		!checkForMatch(numbersMatch, yourString)
+		!checkForMatch(numbersMatch, yourString) &&
+		!checkForMatch(punctuationMatch, yourString)
 }
 
 // HasNumbers returns true when string contains a letter [0-9]
@@ -66,7 +68,8 @@ func HasNumbers(yourString string) bool {
 // HasOnlyNumbers returns true when string contains only numbers
 func HasOnlyNumbers(yourString string) bool {
 	return checkForMatch(numbersMatch, yourString) &&
-		!checkForMatch(lettersMatch, yourString)
+		!checkForMatch(lettersMatch, yourString) &&
+		!checkForMatch(punctuationMatch, yourString)
 }
 
 func getOnlyMatch(matcher string, strValue string) string {

--- a/pkg/util/strings/strings_test.go
+++ b/pkg/util/strings/strings_test.go
@@ -65,6 +65,8 @@ func TestHasMatcher(t *testing.T) {
 		{"!@#$%^&*()", HasNumbers, false},
 		{"!@#$%^&*()", HasOnlyLetters, false},
 		{"!@#$%^&*()", HasOnlyNumbers, false},
+		{"Hello, World!", HasOnlyLetters, false},
+		{"255.255.255.0", HasOnlyNumbers, false},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Fixes #1316

How to test:
  * CentOS ISO needed: http://artifacts.ci.centos.org/minishift/minishift-centos-iso/pr/164/

```powershell
PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
PS> $env:HYPERV_VIRTUAL_SWITCH="Wireless"
PS> minishift.exe start --network-ipaddress 10.0.21.40 --network-gateway 10.0.21.1
```

```powershell
PS> New-NetNat -Name SharedNAT -InternalIPInterfaceAddressPrefix 10.0.75.1/24
PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
PS> $env:HYPERV_VIRTUAL_SWITCH="DockerNAT"
PS> minishift.exe start --network-ipaddress 10.0.75.124 --network-gateway 10.0.75.1
```

Note 1: the `New-NetNat` preparation step is necessary when using DockerNAT.
Note 2: `--network-gateway` is needed for outside communication, else SSH will fail to respond to connection requests, and downloads would never start. A `--network-nameserver` is needed to resolve locations to pull containers, imagestreams, etc. (currently defaults to `8.8.8.8`)