### PR TITLE
Fix for error: Network not found: no network with matching name 'default'

### DIFF
--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -37,7 +37,7 @@ KVM has a standing issue. You might face an error like
 ----
 error: Network not found: no network with matching name 'default'
 ----
-Start a default network using virt-manager(virt-manager > edit > connection details > virtual networks > default), more link:https://github.com/kubernetes/minikube/issues/828[here]
+If so, start a default network using virt-manager(virt-manager > edit > connection details > virtual networks > default), more link:https://github.com/kubernetes/minikube/issues/828[here]
 
 [[kvm-driver-debian]]
 === On Debian/Ubuntu

--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -32,12 +32,11 @@ $ sudo chmod +x /usr/local/bin/docker-machine-driver-kvm
 ----
 
 For more information, see the GitHub documentation of the link:https://github.com/dhiltgen/docker-machine-kvm#quick-start-instructions[docker machine KVM driver].
-KVM has a know issue. You might face an error like
-+
+
+KVM has a standing issue. You might face an error like
 ----
 error: Network not found: no network with matching name 'default'
 ----
-+
 Start a default network using virt-manager(virt-manager > edit > connection details > virtual networks > default), more link:https://github.com/kubernetes/minikube/issues/828[here]
 
 [[kvm-driver-debian]]

--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -32,6 +32,13 @@ $ sudo chmod +x /usr/local/bin/docker-machine-driver-kvm
 ----
 
 For more information, see the GitHub documentation of the link:https://github.com/dhiltgen/docker-machine-kvm#quick-start-instructions[docker machine KVM driver].
+KVM has a know issue. You might face an error like
++
+----
+error: Network not found: no network with matching name 'default'
+----
++
+Start a default network using virt-manager(virt-manager > edit > connection details > virtual networks > default), more link:https://github.com/kubernetes/minikube/issues/828[here]
 
 [[kvm-driver-debian]]
 === On Debian/Ubuntu


### PR DESCRIPTION
Fix for error: Network not found: no network with matching name 'default'

Related to: https://github.com/kubernetes/minikube/issues/828