### PR TITLE
Issue #1247 Extend status command to provide more details

### DIFF
--- a/cmd/minishift/cmd/openshift/version.go
+++ b/cmd/minishift/cmd/openshift/version.go
@@ -21,10 +21,9 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/minishift/docker"
+	openshiftVersions "github.com/minishift/minishift/pkg/minishift/openshift/version"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -45,11 +44,9 @@ func runVersion(cmd *cobra.Command, args []string) {
 	if err != nil {
 		atexit.ExitWithMessage(1, nonExistentMachineError)
 	}
-	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
-	dockerCommander := docker.NewVmDockerCommander(sshCommander)
-	version, err := dockerCommander.Exec(" ", "origin", "openshift", "version")
+	version, err := openshiftVersions.GetOpenshiftVersion(host)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error restarting the OpenShift cluster: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting the OpenShift cluster version: %s", err.Error()))
 	}
 	fmt.Fprintln(os.Stdout, version)
 }

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -335,7 +335,7 @@ func checkStorageMounted(driver drivers.Driver) bool {
 // checkStorageUsage checks if the peristent storage volume has enough storage
 // space available.
 func checkStorageUsage(driver drivers.Driver) bool {
-	usedPercentage := getDiskUsage(driver, StorageDisk)
+	_, usedPercentage := getDiskUsage(driver, StorageDisk)
 	fmt.Printf("%s used ", usedPercentage)
 	usage, err := strconv.Atoi(stringUtils.GetOnlyNumbers(usedPercentage))
 	if err != nil {
@@ -352,18 +352,20 @@ func checkStorageUsage(driver drivers.Driver) bool {
 }
 
 // isMounted checks returns usage of mountpoint known to the VM instance
-func getDiskUsage(driver drivers.Driver, mountpoint string) string {
+func getDiskUsage(driver drivers.Driver, mountpoint string) (string, string) {
 	cmd := fmt.Sprintf(
-		"df -h %s | awk 'FNR > 1 {print $5}'",
+		"df -h %s | awk 'FNR > 1 {print $2,$5}'",
 		mountpoint)
 
 	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
 
 	if err != nil {
-		return "ERR"
+		return "", "ERR"
 	}
-
-	return strings.Trim(out, "\n")
+	diskDetails := strings.Split(strings.Trim(out, "\n"), " ")
+	diskSize := diskDetails[0]
+	diskUsage := diskDetails[1]
+	return diskSize, diskUsage
 }
 
 // isMounted checks if mountpoint is mounted to the VM instance

--- a/pkg/minishift/openshift/version/openshift_versions.go
+++ b/pkg/minishift/openshift/version/openshift_versions.go
@@ -26,7 +26,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/pkg/minishift/clusterup"
+	"github.com/minishift/minishift/pkg/minishift/constants"
+	"github.com/minishift/minishift/pkg/minishift/docker"
 	"github.com/minishift/minishift/pkg/util"
 )
 
@@ -42,6 +46,12 @@ type ImageInfo struct {
 	Os           interface{} `json:"os"`
 	OsVersion    interface{} `json:"os_version"`
 	OsFeatures   interface{} `json:"os_features"`
+}
+
+func GetOpenshiftVersion(host *host.Host) (string, error) {
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+	dockerCommander := docker.NewVmDockerCommander(sshCommander)
+	return dockerCommander.Exec(" ", constants.OpenshiftContainerName, "openshift", "version")
 }
 
 func PrintDownStreamVersions(output io.Writer, minSupportedVersion string) error {

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -102,19 +102,16 @@ func (m *MinishiftRunner) IsCDK() bool {
 	return strings.Contains(cmdOut, "minishift setup-cdk [flags]")
 }
 
-func (m *MinishiftRunner) EnsureRunning() {
-	if m.GetStatus() != "Running" {
-		m.Start()
-	}
-	m.CheckStatus("Running")
+func (m *MinishiftRunner) IsMinishiftRunning() bool {
+	return strings.Contains(m.GetStatus(), "Minishift:  Running")
 }
 
-func (m *MinishiftRunner) IsRunning() bool {
-	return m.GetStatus() == "Running"
+func (m *MinishiftRunner) IsOpenshiftRunning() bool {
+	return strings.Contains(m.GetStatus(), "OpenShift:  Running")
 }
 
 func (m *MinishiftRunner) GetOcRunner() *OcRunner {
-	if m.IsRunning() {
+	if m.IsMinishiftRunning() {
 		return NewOcRunner()
 	}
 	return nil
@@ -152,7 +149,7 @@ func (m *MinishiftRunner) GetStatus() string {
 }
 
 func (m *MinishiftRunner) CheckStatus(desired string) bool {
-	return m.GetStatus() == desired
+	return strings.Contains(m.GetStatus(), desired)
 }
 
 func NewOcRunner() *OcRunner {


### PR DESCRIPTION
Have to include storage piece also.

Current output
```
$ ./minishift status
VM: Running
OpenShift: Running (openshift v3.6.0+c4dd4cf)
```