### PR TITLE
[WIP] Issue #1432 Network not found: no network with matching name 'default'

### DIFF
--- a/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
+++ b/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
@@ -134,6 +134,28 @@ $ sudo virsh undefine minishift
 
 In case all of this fails, you might want to xref:../getting-started/uninstalling.adoc#[uninstall Minishift] and do a fresh install of Minishift.
 
+[[Network-not-found-no-network-with-matching-name-default]]
+=== Network not found: no network with matching name 'default'
+
+At present, the KVM driver doesn't attempt to create the default network - it assumes it's already present. If you create a VM with another tool like virt-manager first it will create it (or you can create it from the command line.) Try the following to create the network
+
+[[using-command-line]]
+==== Using Commnad Line
+----
+virsh net-undefine default
+virsh net-destroy default
+virsh net-list # This will list all the networks
+virsh net-define /usr/share/libvirt/networks/default.xml
+virsh net-start default
+virsh net-autostart default
+----
+
+[[using-virt-manager]]
+==== Using virt-manager
+----
+virt-manager > edit > connection details > virtual networks > default
+----
+
 [[troubleshooting-driver-xhyve]]
 == xhyve
 


### PR DESCRIPTION
Addresses #1432 :Troubleshooting: Network not found: no network with matching name 'default'
Referred https://github.com/minishift/minishift/pull/1403, https://github.com/kubernetes/minikube/issues/828, https://github.com/dhiltgen/docker-machine-kvm/issues/24#issuecomment-249050583