### PR TITLE
Issue #1436 - Add ability to manipulate config before features start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,12 +183,12 @@ test: vendor $(ADDON_ASSET_FILE)
 .PHONY: integration
 integration: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
-	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) -tags basic $(GODOG_OPTS)
+	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) --run-before-feature="$(RUN_BEFORE_FEATURE)" --tags basic $(GODOG_OPTS)
 
 .PHONY: integration_all
 integration_all: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
-	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) $(GODOG_OPTS) -tags ~coolstore
+	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) --run-before-feature="$(RUN_BEFORE_FEATURE)" $(GODOG_OPTS) --tags ~coolstore
 
 .PHONY: fmt
 fmt:

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -225,23 +225,39 @@ To run all the test, use the following command:
 $ make integration_all
 ----
 
-Flag *_TIMEOUT_* can be used to override the default timeout `3600s`.
-To run all the test with timeout `7200s`, use the following command:
+===== Additional Parameters
 
-----
-$ make integration_all TIMEOUT=7200s
-----
+To provide more flexibility the default targets `integration` and `integration_all` can be further customized using several parameters.
 
-To run integration tests against a Minishift binary in a different location you can use the `MINISHIFT_BINARY` argument:
+MINISHIFT_BINARY::
+Parameter `MINISHIFT_BINARY` can be used to run integration tests against Minishift binary located in different directory:
 
 ----
 $ make integration MINISHIFT_BINARY=<path-to-custom-binary>
 ----
 
-[[godog-options]]
-==== Using Tags and Other Godog Options
+TIMEOUT::
+Parameter `TIMEOUT` can be used to override the default timeout of `3600s`.
+To run all the tests with timeout `7200s`, use the following command:
 
-Additional properties for Godog runner can be specified with the `GODOG_OPTS` argument.
+----
+$ make integration_all TIMEOUT=7200s
+----
+
+RUN_BEFORE_FEATURE::
+Parameter `RUN_BEFORE_FEATURE` specifies Minishift commands to be run before each feature.
+This provides ability to run integration tests against Minishift which is not in default state.
+When multiple commands are specified, they must be delimited by a semicolon.
+For example, tests can be run against stopped Minishift with _image caching_ option turned on by running:
+
+----
+$ make integration_all RUN_BEFORE_FEATURE="start; stop; config set image-caching true"
+----
+
+[[godog-options]]
+==== Using GODOG_OPTS Parameter
+
+Parameter `GODOG_OPTS` specifies additional arguments for Godog runner.
 The following options are available:
 
 Tags::

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -50,6 +50,8 @@ var (
 	minishiftArgs   string
 	minishiftBinary string
 
+	runBeforeFeature string
+
 	testDir string
 	isoName string
 
@@ -60,6 +62,10 @@ var (
 	godogStopOnFailure       bool
 	godogNoColors            bool
 	godogPaths               string
+)
+
+const (
+	delimiterConst = ";"
 )
 
 func TestMain(m *testing.M) {
@@ -112,7 +118,7 @@ func TestMain(m *testing.M) {
 func parseFlags() {
 	flag.StringVar(&minishiftArgs, "minishift-args", "", "Arguments to pass to minishift")
 	flag.StringVar(&minishiftBinary, "binary", "", "Path to minishift binary")
-
+	flag.StringVar(&runBeforeFeature, "run-before-feature", "", "Set of minishift commands to be executed before every feature. Individual commands must be delimited by a semicolon.")
 	flag.StringVar(&testDir, "test-dir", "", "Path to the directory in which to execute the tests")
 
 	flag.StringVar(&godogFormat, "format", "pretty", "Sets which format godog will use")
@@ -262,6 +268,16 @@ func FeatureContext(s *godog.Suite) {
 			runner.CDKSetup()
 		} else {
 			runner.RunCommand("addons list")
+		}
+
+		var splittedCommands []string
+		if runBeforeFeature != "" {
+			splittedCommands = strings.Split(runBeforeFeature, delimiterConst)
+			fmt.Println("Running commands:", runBeforeFeature)
+		}
+
+		for index := range splittedCommands {
+			runner.RunCommand(splittedCommands[index])
 		}
 
 		util.LogMessage("info", fmt.Sprintf("----- Feature: %s -----", this.Name))


### PR DESCRIPTION
Provides ability to pass Minishift commands to be run before each feature.
This can be used to test Minishift in non-vanilla state easily without need
of use of environmental variables.