### PR TITLE
Issue #1446 Add way to add GODOG options for 'make integration_all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ ifeq ($(GOOS),windows)
 endif
 MINISHIFT_BINARY ?= $(GOPATH)/bin/minishift$(IS_EXE)
 TIMEOUT ?= 3600s
-GODOG_OPTS ?= -tags basic
 PACKAGES := go list ./... | grep -v /vendor
 SOURCE_DIRS = cmd pkg test
 
@@ -184,12 +183,12 @@ test: vendor $(ADDON_ASSET_FILE)
 .PHONY: integration
 integration: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
-	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) $(GODOG_OPTS)
+	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) -tags basic $(GODOG_OPTS)
 
 .PHONY: integration_all
 integration_all: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
-	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) -tags ~coolstore
+	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) $(GODOG_OPTS) -tags ~coolstore
 
 .PHONY: fmt
 fmt:

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -265,7 +265,7 @@ function perform_release() {
   make prerelease
   exit_on_failure "$?" "Pre-release tests failed."
 
-  MINISHIFT_VM_DRIVER=kvm make integration GODOG_OPTS="-tags ~coolstore -format pretty"
+  MINISHIFT_VM_DRIVER=kvm make integration_all
   exit_on_failure "$?" "Integration tests failed."
 
   make link_check_docs IMAGE_UID=$(id -u) # Test docs builds and all links are valid
@@ -298,7 +298,7 @@ function build_and_test() {
   cd $GOPATH/src/github.com/minishift/minishift
   make prerelease synopsis_docs link_check_docs
   # Run integration test with 'kvm' driver
-  MINISHIFT_VM_DRIVER=kvm make integration GODOG_OPTS="-tags=basic,openshift,cmd-version,cmd-config,profile -format pretty"
+  MINISHIFT_VM_DRIVER=kvm make integration_all
   echo "CICO: Tests ran successfully"
 
   artifacts_upload_on_pr_and_master_trigger $1;

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -210,7 +210,7 @@ For example, _proxy.feature_ or _cmd-version.feature_.
 [[running-integration-tests]]
 ==== Running Integration Tests
 
-By default, the tests are being run against the binary created by `make build`, which is *_$GOPATH/bin/minishift_*. 
+By default, the tests are being run against the binary created by `make build`, which is *_$GOPATH/bin/minishift_*.
 To run the basic test, use the following command:
 
 ----
@@ -225,7 +225,8 @@ To run all the test, use the following command:
 $ make integration_all
 ----
 
-Flag *_TIMEOUT_* can be used to overwrite the default timeout 3600s. To run all the test with timeout 7200s, use the following command:
+Flag *_TIMEOUT_* can be used to override the default timeout `3600s`.
+To run all the test with timeout `7200s`, use the following command:
 
 ----
 $ make integration_all TIMEOUT=7200s
@@ -240,7 +241,7 @@ $ make integration MINISHIFT_BINARY=<path-to-custom-binary>
 [[godog-options]]
 ==== Using Tags and Other Godog Options
 
-Additional properties for Godog runner can be specified with the `GODOG_OPTS` argument. 
+Additional properties for Godog runner can be specified with the `GODOG_OPTS` argument.
 The following options are available:
 
 Tags::
@@ -252,7 +253,7 @@ This can be used to run feature files outside of the *_test/integration/features
 
 Format::
 Use `format` to change the format of Godog's output.
-For example, you can use `pretty` format instead of the native `progress`.
+For example, you can set `progress` format instead of the default `pretty`.
 
 Stop-on-failure::
 Set `stop-on-failure` to true to stop integration tests on failure.


### PR DESCRIPTION
Fix #1446 

* Also updated centos_ci.sh script to use friendlier version to run
  integration tests
