### PR TITLE
Issue #1448 Allow GitLab CI to run against tagged runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 build:
   image: fedora:26
+  tags:
+    - docker
   script:
     - dnf install -y golang glide make git python
     - export CURRENT_BUILD_PATH=$PWD


### PR DESCRIPTION
Fix #1448 

Tested on:
  * https://gitlab.com/gbraad/minishift/commit/efbaad6e5c1275765536f376f647f1dd59033ba9/pipelines
  * https://gitlab.cee.redhat.com/gbraad/minishift/builds/203897