### PR TITLE
Issue #1332 Add integration tests for docker-env and oc-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ TIMEOUT ?= 3600s
 PACKAGES := go list ./... | grep -v /vendor | grep -v /out
 SOURCE_DIRS = cmd pkg test
 
+# defines non-default shell name to be used in godog steps which use instance of shell
+TEST_WITH_SPECIFIED_SHELL ?=
+
 # Linker flags
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/version.minishiftVersion=$(MINISHIFT_VERSION) \
 	-X $(REPOPATH)/pkg/version.b2dIsoVersion=$(B2D_ISO_VERSION) \
@@ -202,21 +205,21 @@ integration: GODOG_OPTS = --tags=basic
 integration: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
-	--run-before-feature="$(RUN_BEFORE_FEATURE)" $(GODOG_OPTS)
+	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" $(GODOG_OPTS)
 
 .PHONY: integration_all
 integration_all: GODOG_OPTS = --tags=~coolstore
 integration_all: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
-	--run-before-feature="$(RUN_BEFORE_FEATURE)" $(GODOG_OPTS)
+	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" $(GODOG_OPTS)
 
 .PHONY: integration_pr
 integration_pr: GODOG_OPTS = --tags=~coolstore\&\&~addon-xpaas
 integration_pr: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
-	--run-before-feature="$(RUN_BEFORE_FEATURE)" $(GODOG_OPTS)
+	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" $(GODOG_OPTS)
 
 .PHONY: fmt
 fmt:

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -274,11 +274,28 @@ RUN_BEFORE_FEATURE::
 The `RUN_BEFORE_FEATURE` parameter specifies {project} commands to be run before each feature.
 This provides the ability to run integration tests against a {project} instance which is not in its default state.
 When multiple commands are specified, they must be delimited by a semicolon.
-For example, tests can be run against a stopped {project} instance with the image caching option turned on by running the following:
+For example, tests can be run against a stopped {project} instance with the image caching option turned on by running the following: 
 
 ----
 $ make integration_all RUN_BEFORE_FEATURE="start; stop; config set image-caching true"
 ----
+
+TEST_WITH_SHELL::
+
+About:::
+The majority of {project} integration tests pass command line arguments directly to the `minishift` or `oc` binaries via Go's `os/exec` package.
+However, some integration tests first start persistent instance of the shell to pass commands into later, for example: `When user starts shell instance on host machine`.
+Due to persistency of the shell instance all changes done in it will be present until its closure, for example, changed environmental variables.
+This allows testing of commands which are dependent on the shell they are being executed in.
+The steps using this approach have the `shell` keyword in their definition, for example: `When executing "minishift oc-env" in host shell succeeds`.
+
+Usage:::
+`TEST_WITH_SPECIFIED_SHELL` is an optional parameter.
+If nothing is passed with `TEST_WITH_SPECIFIED_SHELL`, then the shell type is automatically determined.
+By default, the shell will be PowerShell on Windows, Bash on macOS and Linux.
+The `TEST_WITH_SPECIFIED_SHELL` parameter can be used to run the tests with different shells.
+To run the tests using the Windows Command Prompt, for example, run `make integration_all TEST_WITH_SPECIFIED_SHELL=cmd`.
+The `TEST_WITH_SPECIFIED_SHELL` parameter supports the `powershell`, `cmd`, `bash`, `tcsh` and `zsh` options.
 
 [[godog-options]]
 ==== Using the GODOG_OPTS Parameter

--- a/test/integration/features/cmd-docker-env.feature
+++ b/test/integration/features/cmd-docker-env.feature
@@ -1,0 +1,38 @@
+@cmd-docker-env @command
+Feature: Command docker-env
+Command docker-env sets docker environment variables for supported shells.
+INFO: This feature runs against a shell instance. To use a non-default shell, please select
+one from: bash, cmd, powershell, tcsh, zsh with TEST_WITH_SPECIFIED_SHELL parameter of make integration.
+
+  Scenario: Docker client is not set up
+  INFO: This scenario starts interactive shell instance, which will be closed in the end of this feature.
+    Given user starts shell instance on host machine
+     When executing "docker info" in host shell
+     Then stdout of host shell should not contain "Operating System: Minishift Boot2Docker ISO Version"
+      And stdout of host shell should not contain "Name: minishift"
+
+  Scenario: Starting minishift
+    Given Minishift has state "Does Not Exist"
+     When executing "minishift start" succeeds
+     Then Minishift has state "Running"
+
+  Scenario: Setting Docker client using docker-env command
+     When executing "minishift docker-env" in host shell succeeds
+      And evaluating stdout of the previous command in host shell
+     Then executing "docker info" in host shell succeeds
+      And stdout of host shell should contain "OSType: linux"
+      And stdout of host shell should contain "Name: minishift"
+
+  Scenario: Unsetting Docker client using --unset flag of docker-env command
+     When executing "minishift docker-env --unset" in host shell succeeds
+      And evaluating stdout of the previous command in host shell
+      And executing "docker info" in host shell
+     Then stdout of host shell should not contain "Operating System: Minishift Boot2Docker ISO Version"
+      And stdout of host shell should not contain "Name: minishift"
+
+  Scenario: Deleting Minishift
+  INFO: Removes the interactive shell instance.
+    Given user closes shell instance on host machine
+      And Minishift has state "Running"
+     When executing "minishift delete --force" succeeds
+     Then Minishift has state "Does Not Exist"

--- a/test/integration/features/cmd-oc-env.feature
+++ b/test/integration/features/cmd-oc-env.feature
@@ -1,0 +1,29 @@
+@cmd-oc-env @command
+Feature: Command oc-env
+Command oc-env sets the path to oc binary.
+INFO: This feature runs against a shell instance. To use a non-default shell, please select
+one from: bash, cmd, powershell, tcsh, zsh with TEST_WITH_SPECIFIED_SHELL parameter of make integration.
+
+  Scenario: User starts shell instance without oc in PATH
+  INFO: This scenario starts interactive shell instance, which will be closed in the end of this feature.
+    Given user starts shell instance on host machine
+     When executing "unset PATH" in host shell
+     Then executing "oc status" in host shell fails
+
+  Scenario: Starting minishift
+    Given Minishift has state "Does Not Exist"
+     When executing "minishift start" succeeds
+     Then Minishift has state "Running"
+
+  Scenario: Setting oc binary to PATH with oc-env command
+     When executing "minishift oc-env" in host shell succeeds
+      And evaluating stdout of the previous command in host shell
+     Then executing "oc status" in host shell succeeds
+      And stdout of host shell contains "In project My Project (myproject)"
+
+  Scenario: Deleting Minishift
+  INFO: Removes the interactive shell instance.
+    Given user closes shell instance on host machine
+      And Minishift has state "Running"
+     When executing "minishift delete --force" succeeds
+     Then Minishift has state "Does Not Exist"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -55,6 +55,7 @@ var (
 	isoName       string
 
 	runBeforeFeature string
+	testWithShell    string
 
 	// Godog options
 	godogFormat              string
@@ -120,6 +121,7 @@ func parseFlags() {
 	flag.StringVar(&minishiftArgs, "minishift-args", "", "Arguments to pass to minishift")
 	flag.StringVar(&minishiftBinary, "binary", "", "Path to minishift binary")
 	flag.StringVar(&runBeforeFeature, "run-before-feature", "", "Set of minishift commands to be executed before every feature. Individual commands must be delimited by a semicolon.")
+	flag.StringVar(&testWithShell, "test-with-specified-shell", "", "Name of shell to be used for steps which executes commands directly in persistent shell instance.")
 	flag.StringVar(&testDir, "test-dir", "", "Path to the directory in which to execute the tests")
 
 	flag.StringVar(&godogFormat, "format", "pretty", "Sets which format godog will use")
@@ -180,6 +182,8 @@ func FeatureContext(s *godog.Suite) {
 	// steps for scenario variables
 	s.Step(`^setting scenario variable "(.*)" to the stdout from executing "oc (.*)"$`,
 		minishift.setVariableExecutingOcCommand)
+	s.Step(`^setting scenario variable "(.*)" to the stdout from executing "minishift (.*)"$`,
+		minishift.setVariableExecutingMinishiftCommand)
 	s.Step(`^scenario variable "(.*)" should not be empty$`,
 		variableShouldNotBeEmpty)
 
@@ -252,6 +256,34 @@ func FeatureContext(s *godog.Suite) {
 	// steps for download of minishift-addons repository
 	s.Step(`^file from "(.*)" is downloaded into location "(.*)"$`,
 		downloadFileIntoLocation)
+
+	// steps for executing commands in shell
+	s.Step(`^user starts shell instance on host machine$`,
+		startHostShellInstance)
+	s.Step(`^user closes shell instance on host machine$`,
+		util.CloseHostShellInstance)
+	s.Step(`^executing "minishift (.*)" in host shell$`,
+		util.ExecuteMinishiftInHostShell)
+	s.Step(`^executing "minishift (.*)" in host shell (succeeds|fails)$`,
+		util.ExecuteMinishiftInHostShellSucceedsOrFails)
+	s.Step(`^executing "(.*)" in host shell$`,
+		util.ExecuteInHostShell)
+	s.Step(`^executing "(.*)" in host shell (succeeds|fails)$`,
+		util.ExecuteInHostShellSucceedsOrFails)
+	s.Step(`^(stdout|stderr) of host shell (?:should contain|contains) "(.*)"$`,
+		util.HostShellCommandReturnShouldContain)
+	s.Step(`^(stdout|stderr) of host shell (?:should not contain|does not contain) "(.*)"$`,
+		util.HostShellCommandReturnShouldNotContain)
+	s.Step(`^(stdout|stderr) of host shell (?:should contain|contains)$`,
+		util.HostShellCommandReturnShouldContainContent)
+	s.Step(`^(stdout|stderr) of host shell (?:should not contain|does not contain)$`,
+		util.HostShellCommandReturnShouldNotContainContent)
+	s.Step(`^(stdout|stderr) of host shell (?:should equal|equals) "(.*)"$`,
+		util.HostShellCommandReturnShouldEqual)
+	s.Step(`^(stdout|stderr) of host shell (?:should equal|equals)$`,
+		util.HostShellCommandReturnShouldEqualContent)
+	s.Step(`^evaluating stdout of the previous command in host shell$`,
+		util.ExecuteInHostShellLineByLine)
 
 	s.BeforeSuite(func() {
 		testDir = setUp()
@@ -435,7 +467,7 @@ func configFileContainsKeyMatchingValue(format string, configPath string, condit
 		return err
 	}
 
-	matches, err := performRegexMatch(expectedValue, keyValue)
+	matches, err := util.PerformRegexMatch(expectedValue, keyValue)
 	if err != nil {
 		return err
 	} else if (condition == "contains") && !matches {
@@ -475,7 +507,7 @@ func stdoutContainsKeyMatchingValue(commandField string, format string, conditio
 		return err
 	}
 
-	matches, err := performRegexMatch(expectedValue, keyValue)
+	matches, err := util.PerformRegexMatch(expectedValue, keyValue)
 	if err != nil {
 		return err
 	} else if (condition == "contains") && !matches {
@@ -499,69 +531,6 @@ func stdoutContainsKey(commandField string, format string, condition string, key
 		return fmt.Errorf("%s does not contain any value for key %s", commandField, keyPath)
 	} else if (condition == "does not have") && (keyValue != "<nil>") {
 		return fmt.Errorf("%s contains key %s with assigned value: %s", commandField, keyPath, keyValue)
-	}
-
-	return nil
-}
-
-func compareExpectedWithActualContains(expected string, actual string) error {
-	if !strings.Contains(actual, expected) {
-		return fmt.Errorf("Output did not match. Expected: '%s', Actual: '%s'", expected, actual)
-	}
-
-	return nil
-}
-
-func compareExpectedWithActualNotContains(notexpected string, actual string) error {
-	if strings.Contains(actual, notexpected) {
-		return fmt.Errorf("Output did match. Not expected: '%s', Actual: '%s'", notexpected, actual)
-	}
-
-	return nil
-}
-
-func compareExpectedWithActualEquals(expected string, actual string) error {
-	if actual != expected {
-		return fmt.Errorf("Output did not match. Expected: '%s', Actual: '%s'", expected, actual)
-	}
-
-	return nil
-}
-
-func compareExpectedWithActualNotEquals(notexpected string, actual string) error {
-	if actual == notexpected {
-		return fmt.Errorf("Output did match. Not expected: '%s', Actual: '%s'", notexpected, actual)
-	}
-
-	return nil
-}
-
-func performRegexMatch(regex string, input string) (bool, error) {
-	compRegex, err := regexp.Compile(regex)
-	if err != nil {
-		return false, fmt.Errorf("Expected value must be a valid regular expression statement: ", err)
-	}
-
-	return compRegex.MatchString(input), nil
-}
-
-func compareExpectedWithActualMatchesRegex(expected string, actual string) error {
-	matches, err := performRegexMatch(expected, actual)
-	if err != nil {
-		return err
-	} else if !matches {
-		return fmt.Errorf("Output did not match. Expected: '%s', Actual: '%s'", expected, actual)
-	}
-
-	return nil
-}
-
-func compareExpectedWithActualNotMatchesRegex(notexpected string, actual string) error {
-	matches, err := performRegexMatch(notexpected, actual)
-	if err != nil {
-		return err
-	} else if matches {
-		return fmt.Errorf("Output did match. Not expected: '%s', Actual: '%s'", notexpected, actual)
 	}
 
 	return nil
@@ -650,71 +619,71 @@ func validateYAML(inputString string) (bool, error) {
 func commandReturnEquals(commandField string, command string, condition string, expected string) error {
 	minishift.executingMinishiftCommand(command)
 	if condition == "is equal" {
-		return compareExpectedWithActualEquals(expected+"\n", selectFieldFromLastOutput(commandField))
+		return util.CompareExpectedWithActualEquals(expected+"\n", selectFieldFromLastOutput(commandField))
 	} else {
-		return compareExpectedWithActualNotEquals(expected+"\n", selectFieldFromLastOutput(commandField))
+		return util.CompareExpectedWithActualNotEquals(expected+"\n", selectFieldFromLastOutput(commandField))
 	}
 }
 
 func commandReturnContains(commandField string, command string, condition string, expected string) error {
 	minishift.executingMinishiftCommand(command)
 	if condition == "contains" {
-		return compareExpectedWithActualContains(expected, selectFieldFromLastOutput(commandField))
+		return util.CompareExpectedWithActualContains(expected, selectFieldFromLastOutput(commandField))
 	} else {
-		return compareExpectedWithActualNotContains(expected, selectFieldFromLastOutput(commandField))
+		return util.CompareExpectedWithActualNotContains(expected, selectFieldFromLastOutput(commandField))
 	}
 }
 
 func commandReturnShouldContain(commandField string, expected string) error {
-	return compareExpectedWithActualContains(expected, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualContains(expected, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldNotContain(commandField string, notexpected string) error {
-	return compareExpectedWithActualNotContains(notexpected, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualNotContains(notexpected, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldContainContent(commandField string, expected *gherkin.DocString) error {
-	return compareExpectedWithActualContains(expected.Content, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualContains(expected.Content, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldNotContainContent(commandField string, notexpected *gherkin.DocString) error {
-	return compareExpectedWithActualNotContains(notexpected.Content, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualNotContains(notexpected.Content, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldEqual(commandField string, expected string) error {
-	return compareExpectedWithActualEquals(expected, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualEquals(expected, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldEqualContent(commandField string, expected *gherkin.DocString) error {
-	return compareExpectedWithActualEquals(expected.Content, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualEquals(expected.Content, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldBeEmpty(commandField string) error {
-	return compareExpectedWithActualEquals("", selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualEquals("", selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldNotBeEmpty(commandField string) error {
-	return compareExpectedWithActualNotEquals("", selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualNotEquals("", selectFieldFromLastOutput(commandField))
 }
 
 func variableShouldNotBeEmpty(variableName string) error {
-	return compareExpectedWithActualNotEquals("", minishift.GetVariableByName(variableName).Value)
+	return util.CompareExpectedWithActualNotEquals("", minishift.GetVariableByName(variableName).Value)
 }
 
 func commandReturnShouldMatchRegex(commandField string, expected string) error {
-	return compareExpectedWithActualMatchesRegex(expected, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualMatchesRegex(expected, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldNotMatchRegex(commandField string, notexpected string) error {
-	return compareExpectedWithActualNotMatchesRegex(notexpected, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualNotMatchesRegex(notexpected, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldMatchRegexContent(commandField string, expected *gherkin.DocString) error {
-	return compareExpectedWithActualMatchesRegex(expected.Content, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualMatchesRegex(expected.Content, selectFieldFromLastOutput(commandField))
 }
 
 func commandReturnShouldNotMatchRegexContent(commandField string, notexpected *gherkin.DocString) error {
-	return compareExpectedWithActualNotMatchesRegex(notexpected.Content, selectFieldFromLastOutput(commandField))
+	return util.CompareExpectedWithActualNotMatchesRegex(notexpected.Content, selectFieldFromLastOutput(commandField))
 }
 
 type commandRunner func(string) error
@@ -806,11 +775,11 @@ func getRoutingUrlAndVerifyHTTPResponse(partOfResponse string, urlRoot string, s
 }
 
 func proxyLogShouldContain(expected string) error {
-	return compareExpectedWithActualContains(expected, testProxy.GetLog())
+	return util.CompareExpectedWithActualContains(expected, testProxy.GetLog())
 }
 
 func proxyLogShouldContainContent(expected *gherkin.DocString) error {
-	return compareExpectedWithActualContains(expected.Content, testProxy.GetLog())
+	return util.CompareExpectedWithActualContains(expected.Content, testProxy.GetLog())
 }
 
 func catDockerConfigFile() error {
@@ -857,4 +826,8 @@ func downloadFileIntoLocation(downloadURL string, destinationFolder string) erro
 	}
 
 	return nil
+}
+
+func startHostShellInstance() error {
+	return util.StartHostShellInstance(testWithShell, minishiftBinary)
 }

--- a/test/integration/minishift.go
+++ b/test/integration/minishift.go
@@ -93,6 +93,10 @@ func (m *Minishift) setVariableExecutingOcCommand(name string, command string) e
 	return m.setVariableFromExecution(name, minishift.executingOcCommand, command)
 }
 
+func (m *Minishift) setVariableExecutingMinishiftCommand(name string, command string) error {
+	return m.setVariableFromExecution(name, minishift.executingMinishiftCommand, command)
+}
+
 func (m *Minishift) SetVariable(name string, value string) {
 	commandVariables = append(commandVariables,
 		CommandVariable{

--- a/test/integration/util/checks.go
+++ b/test/integration/util/checks.go
@@ -1,0 +1,88 @@
+// +build integration
+
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func CompareExpectedWithActualContains(expected string, actual string) error {
+	if !strings.Contains(actual, expected) {
+		return fmt.Errorf("Output did not match. Expected: '%s', Actual: '%s'", expected, actual)
+	}
+
+	return nil
+}
+
+func CompareExpectedWithActualNotContains(notexpected string, actual string) error {
+	if strings.Contains(actual, notexpected) {
+		return fmt.Errorf("Output did match. Not expected: '%s', Actual: '%s'", notexpected, actual)
+	}
+
+	return nil
+}
+
+func CompareExpectedWithActualEquals(expected string, actual string) error {
+	if actual != expected {
+		return fmt.Errorf("Output did not match. Expected: '%s', Actual: '%s'", expected, actual)
+	}
+
+	return nil
+}
+
+func CompareExpectedWithActualNotEquals(notexpected string, actual string) error {
+	if actual == notexpected {
+		return fmt.Errorf("Output did match. Not expected: '%s', Actual: '%s'", notexpected, actual)
+	}
+
+	return nil
+}
+
+func PerformRegexMatch(regex string, input string) (bool, error) {
+	compRegex, err := regexp.Compile(regex)
+	if err != nil {
+		return false, fmt.Errorf("Expected value must be a valid regular expression statement: ", err)
+	}
+
+	return compRegex.MatchString(input), nil
+}
+
+func CompareExpectedWithActualMatchesRegex(expected string, actual string) error {
+	matches, err := PerformRegexMatch(expected, actual)
+	if err != nil {
+		return err
+	} else if !matches {
+		return fmt.Errorf("Output did not match. Expected: '%s', Actual: '%s'", expected, actual)
+	}
+
+	return nil
+}
+
+func CompareExpectedWithActualNotMatchesRegex(notexpected string, actual string) error {
+	matches, err := PerformRegexMatch(notexpected, actual)
+	if err != nil {
+		return err
+	} else if matches {
+		return fmt.Errorf("Output did match. Not expected: '%s', Actual: '%s'", notexpected, actual)
+	}
+
+	return nil
+}

--- a/test/integration/util/shell.go
+++ b/test/integration/util/shell.go
@@ -1,0 +1,298 @@
+// +build integration
+
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/DATA-DOG/godog/gherkin"
+	"github.com/minishift/minishift/pkg/util/os"
+)
+
+const (
+	exitCodeIdentifier = "exitCodeOfLastCommandInShell="
+
+	bashExitCodeCheck       = "echo %v$?"
+	fishExitCodeCheck       = "echo %v$status"
+	tcshExitCodeCheck       = "echo %v$?"
+	zshExitCodeCheck        = "echo %v$?"
+	cmdExitCodeCheck        = "echo %v%%errorlevel%%"
+	powershellExitCodeCheck = "echo %v$lastexitcode"
+)
+
+var (
+	shell shellInstance
+)
+
+type shellInstance struct {
+	startArgument    []string
+	name             string
+	checkExitCodeCmd string
+
+	minishiftPath string
+
+	instance *exec.Cmd
+	outbuf   bytes.Buffer
+	errbuf   bytes.Buffer
+	excbuf   bytes.Buffer
+
+	outPipe io.ReadCloser
+	errPipe io.ReadCloser
+	inPipe  io.WriteCloser
+
+	outScanner *bufio.Scanner
+	errScanner *bufio.Scanner
+
+	stdoutChannel   chan string
+	stderrChannel   chan string
+	exitCodeChannel chan string
+}
+
+func (shell shellInstance) getLastShellOutput(stdType string) string {
+	var returnValue string
+	switch stdType {
+	case "stdout":
+		returnValue = shell.outbuf.String()
+	case "stderr":
+		returnValue = shell.errbuf.String()
+	case "exitcode":
+		returnValue = shell.excbuf.String()
+	default:
+		fmt.Printf("Field '%s' of shell's output is not supported. Only 'stdout', 'stderr' and 'exitcode' are supported.", stdType)
+	}
+
+	return returnValue
+}
+
+func (shell *shellInstance) scanPipe(scanner *bufio.Scanner, buffer *bytes.Buffer, stdType string, channel chan string) {
+	for scanner.Scan() {
+		str := scanner.Text()
+		LogMessage(stdType, str)
+		buffer.WriteString(str + "\n")
+
+		if strings.Contains(str, exitCodeIdentifier) && !strings.Contains(str, shell.checkExitCodeCmd) {
+			exitCode := strings.Split(str, "=")[1]
+			shell.exitCodeChannel <- exitCode
+		}
+	}
+
+	return
+}
+
+func (shell *shellInstance) close() error {
+	closingCmd := "exit\n"
+	io.WriteString(shell.inPipe, closingCmd)
+	err := shell.instance.Wait()
+	if err != nil {
+		fmt.Println("Error closing shell instance:", err)
+	}
+
+	shell.instance = nil
+
+	return err
+}
+
+func (shell *shellInstance) configureTypeOfShell(shellName string) {
+	switch shellName {
+	case "bash":
+		shell.name = shellName
+		shell.checkExitCodeCmd = fmt.Sprintf(bashExitCodeCheck, exitCodeIdentifier)
+	case "tcsh":
+		shell.name = shellName
+		shell.checkExitCodeCmd = fmt.Sprintf(tcshExitCodeCheck, exitCodeIdentifier)
+	case "zsh":
+		shell.name = shellName
+		shell.checkExitCodeCmd = fmt.Sprintf(zshExitCodeCheck, exitCodeIdentifier)
+	case "cmd":
+		shell.name = shellName
+		shell.checkExitCodeCmd = fmt.Sprintf(cmdExitCodeCheck, exitCodeIdentifier)
+	case "powershell":
+		shell.name = shellName
+		shell.startArgument = []string{"-Command", "-"}
+		shell.checkExitCodeCmd = fmt.Sprintf(powershellExitCodeCheck, exitCodeIdentifier)
+	case "fish":
+		shell.name = "default"
+		fmt.Println("Fish shell is currently not supported by integration tests. Default shell for the OS will be used.")
+		fallthrough
+	default:
+		if shell.name != "" {
+			fmt.Printf("Shell %v is not supported, will set the default shell for the OS to be used.\n", shell.name)
+		}
+		switch os.CurrentOS() {
+		case "darwin", "linux":
+			shell.name = "bash"
+			shell.checkExitCodeCmd = fmt.Sprintf(bashExitCodeCheck, exitCodeIdentifier)
+		case "windows":
+			shell.name = "powershell"
+			shell.startArgument = []string{"-Command", "-"}
+			shell.checkExitCodeCmd = fmt.Sprintf(powershellExitCodeCheck, exitCodeIdentifier)
+		}
+	}
+
+	return
+}
+
+func (shell *shellInstance) start(shellName string, minishiftPath string) error {
+	var err error
+
+	shell.configureTypeOfShell(shellName)
+	shell.minishiftPath = minishiftPath
+	shell.stdoutChannel = make(chan string)
+	shell.stderrChannel = make(chan string)
+	shell.exitCodeChannel = make(chan string)
+
+	shell.instance = exec.Command(shell.name, shell.startArgument...)
+
+	shell.outPipe, err = shell.instance.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	shell.errPipe, err = shell.instance.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	shell.inPipe, err = shell.instance.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	shell.outScanner = bufio.NewScanner(shell.outPipe)
+	shell.errScanner = bufio.NewScanner(shell.errPipe)
+
+	go shell.scanPipe(shell.outScanner, &shell.outbuf, "stdout", shell.stdoutChannel)
+	go shell.scanPipe(shell.errScanner, &shell.errbuf, "stderr", shell.stderrChannel)
+
+	err = shell.instance.Start()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("The %v instance has been started and will be used for testing.\n", shell.name)
+	return err
+}
+
+func StartHostShellInstance(shellName string, minishiftPath string) error {
+	return shell.start(shellName, minishiftPath)
+}
+
+func CloseHostShellInstance() error {
+	return shell.close()
+}
+
+func ExecuteInHostShell(command string) error {
+	var err error
+
+	if shell.instance == nil {
+		return errors.New("Shell instance is started.")
+	}
+
+	shell.outbuf.Reset()
+	shell.errbuf.Reset()
+	shell.excbuf.Reset()
+
+	LogMessage(shell.name, command)
+
+	_, err = io.WriteString(shell.inPipe, command+"\n")
+	if err != nil {
+		return err
+	}
+
+	_, err = shell.inPipe.Write([]byte(shell.checkExitCodeCmd + "\n"))
+	if err != nil {
+		return err
+	}
+
+	exitCode := <-shell.exitCodeChannel
+	shell.excbuf.WriteString(exitCode)
+
+	return err
+}
+
+func ExecuteInHostShellSucceedsOrFails(command string, expectedResult string) error {
+	err := ExecuteInHostShell(command)
+	if err != nil {
+		return err
+	}
+
+	exitCode := shell.excbuf.String()
+
+	if expectedResult == "succeeds" && exitCode != "0" {
+		err = fmt.Errorf("Command '%s', expected to succeed, exited with exit code: %s\n", command, exitCode)
+	}
+	if expectedResult == "fails" && exitCode == "0" {
+		err = fmt.Errorf("Command '%s', expected to fail, exited with exit code: %s\n", command, exitCode)
+	}
+
+	return err
+}
+
+func ExecuteInHostShellLineByLine() error {
+	var err error
+	stdout := shell.getLastShellOutput("stdout")
+	commandArray := strings.Split(stdout, "\n")
+	for index := range commandArray {
+		if !strings.Contains(commandArray[index], exitCodeIdentifier) {
+			err = ExecuteInHostShell(commandArray[index])
+		}
+	}
+
+	return err
+}
+
+func ExecuteMinishiftInHostShell(commandField string) error {
+	command := shell.minishiftPath + " " + commandField
+	return ExecuteInHostShell(command)
+}
+
+func ExecuteMinishiftInHostShellSucceedsOrFails(commandField string, expected string) error {
+	command := shell.minishiftPath + " " + commandField
+	return ExecuteInHostShellSucceedsOrFails(command, expected)
+}
+
+func HostShellCommandReturnShouldContain(commandField string, expected string) error {
+	return CompareExpectedWithActualContains(expected, shell.getLastShellOutput(commandField))
+}
+
+func HostShellCommandReturnShouldNotContain(commandField string, notexpected string) error {
+	return CompareExpectedWithActualNotContains(notexpected, shell.getLastShellOutput(commandField))
+}
+
+func HostShellCommandReturnShouldContainContent(commandField string, expected *gherkin.DocString) error {
+	return CompareExpectedWithActualContains(expected.Content, shell.getLastShellOutput(commandField))
+}
+
+func HostShellCommandReturnShouldNotContainContent(commandField string, notexpected *gherkin.DocString) error {
+	return CompareExpectedWithActualNotContains(notexpected.Content, shell.getLastShellOutput(commandField))
+}
+
+func HostShellCommandReturnShouldEqual(commandField string, expected string) error {
+	return CompareExpectedWithActualEquals(expected, shell.getLastShellOutput(commandField))
+}
+
+func HostShellCommandReturnShouldEqualContent(commandField string, expected *gherkin.DocString) error {
+	return CompareExpectedWithActualEquals(expected.Content, shell.getLastShellOutput(commandField))
+}


### PR DESCRIPTION
Changes:
- adds ability to run commands in shell instance - for now just bash
- adds feature for docker-env command
- moves some check functions to util package

TBD:
- add support for other shells (shouldn't be hard)
- add feature for oc-env command (shouldn't be hard)

I will appreciate any feedback on this PR.