### PR TITLE
Issue #1279 Reduce time used in CI by using a prebuilt docs image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ serve_docs: synopsis_docs build_docs_container
 	cd docs && docker run $(DOC_VARIABLES) -p 35729:35729 -p 4567:4567 -tiv $(shell pwd)/docs:/home/docs:Z minishift/docs serve[--watcher-force-polling]
 
 .PHONY: link_check_docs
-link_check_docs: synopsis_docs build_docs_container
+link_check_docs: synopsis_docs
 	cd docs && docker run $(DOC_VARIABLES) -tiv $(shell pwd)/docs:/home/docs:Z minishift/docs link_check
 
 $(DOCS_SYNOPISIS_DIR)/*.md: vendor $(ADDON_ASSET_FILE)

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -81,7 +81,8 @@ function install_docker() {
 
 # Create a docs user which has NOPASSWD sudoer role
 function prepare_ci_user() {
-  groupadd -r minishift_ci && useradd -g minishift_ci minishift_ci
+  # 1000 as id of user in docker image (https://github.com/minishift/minishift/blob/master/docs/Dockerfile#L25)
+  groupadd -g 1000 -r minishift_ci && useradd -g minishift_ci -u 1000 minishift_ci
   chmod +w /etc/sudoers && echo "minishift_ci ALL=(ALL)    NOPASSWD: ALL" >> /etc/sudoers && chmod -w /etc/sudoers
 
   # Copy centos_ci.sh to newly created user home dir
@@ -296,7 +297,8 @@ function perform_release() {
 function build_and_test() {
   setup_kvm_docker_machine_driver;
   cd $GOPATH/src/github.com/minishift/minishift
-  make prerelease synopsis_docs link_check_docs
+  make prerelease
+  make link_check_docs
   # Run integration test with 'kvm' driver
   MINISHIFT_VM_DRIVER=kvm make integration_all
   echo "CICO: Tests ran successfully"


### PR DESCRIPTION
Fix #1279 

Using pre-built image - https://hub.docker.com/r/minishift/docs/