### PR TITLE
Issue #1474 Remove blank line from openshift version

### DIFF
--- a/cmd/minishift/cmd/openshift/version.go
+++ b/cmd/minishift/cmd/openshift/version.go
@@ -48,7 +48,7 @@ func runVersion(cmd *cobra.Command, args []string) {
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting the OpenShift cluster version: %s", err.Error()))
 	}
-	fmt.Fprintln(os.Stdout, version)
+	fmt.Fprint(os.Stdout, version)
 }
 
 func init() {


### PR DESCRIPTION
version output coming from DockerCommander already have a new line  so used `Fprintf` instead `Fprintln`.