### PR TITLE
Issue #1527 Fix CentOS CI script to not fail when minibot URL is not reachable

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -291,7 +291,8 @@ function perform_release() {
   # Notify Minibot
   MESSAGE="Minishift v$RELEASE_VERSION successfully released by https://ci.centos.org/job/minishift-release/$BUILD_NUMBER."
   URL="https://github.com/$REPO_OWNER/minishift/releases/tag/v$RELEASE_VERSION"
-  curl http://minibot.19cf262c.svc.dockerapp.io:9009/hubot/centosci -H "Content-Type: application/json" -d '{"payload":{"status":"success","message":'"\"$MESSAGE\""',"url":'"\"$URL\""'}}'
+  # Do not abort build if minibot service is inaccessible
+  curl http://minibot.19cf262c.svc.dockerapp.io:9009/hubot/centosci -H "Content-Type: application/json" -d '{"payload":{"status":"success","message":'"\"$MESSAGE\""',"url":'"\"$URL\""'}}' || true
 }
 
 function build_and_test() {


### PR DESCRIPTION
Fix #1527 