### PR TITLE
Issue #1135 Provide notation for default variable values in add-on metadata

### DIFF
--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -171,7 +171,7 @@ $ minishift addons apply acme                                 // <2>
 If the environment variable is not set not, interpolation does not occur.
 <2> When the add-on is applied, each occurrence of `#{PROJECT_USER}` within an add-on command gets replaced with the value of the environment variable `USER`.
 
-As add-on developer, you can enforce that a variable value is provided when the add-on gets applied by adding the varaible name to the _Required-Vars_ metadata header.
+As an add-on developer, you can enforce that a variable value is provided when the add-on gets applied by adding the variable name to the _Required-Vars_ metadata header.
 Multiple variables need to be comma separated.
 
 ----
@@ -179,6 +179,21 @@ Multiple variables need to be comma separated.
 # Description: ACME add-on
 # Required-Vars: PROJECT_USER
 ----
+
+You can set a default value for a variable using the _Var-Defaults_ metadata header.
+_Var-Defaults_ needs to be specified in the format of `<key>=<value>`.
+Multiple default key/value pairs can be separated by comma.
+
+NOTE: `=` and `,` are metacharacters and cannot be used as part of keys or values.
+
+----
+# Name: acme
+# Description: ACME add-on
+# Required-Vars: PROJECT_USER
+# Var-Defaults: PROJECT_USER=john
+----
+
+NOTE: Variable values specified via the command line using the `--addon-env` or set via `minishift config set addon-env` have precedence over _Var-Defaults_.
 
 [[default-addons]]
 == Default Add-ons

--- a/pkg/minishift/addon/addon_meta.go
+++ b/pkg/minishift/addon/addon_meta.go
@@ -19,8 +19,8 @@ package addon
 import (
 	"errors"
 	"fmt"
+	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
 	"regexp"
-	"strings"
 )
 
 var requiredMetaTags = []string{NameMetaTagName, DescriptionMetaTagName}
@@ -31,13 +31,20 @@ const (
 	DescriptionMetaTagName   = "Description"
 	RequiredOpenShiftVersion = "OpenShift-Version"
 	anyOpenShiftVersion      = ""
+	varDefaults              = "Var-Defaults"
 )
+
+type RequiredVar struct {
+	Key   string
+	Value string
+}
 
 // AddOnMeta defines a set of meta data for an AddOn. Name and Description are required. Others are optional.
 type AddOnMeta interface {
 	Name() string
 	Description() []string
-	RequiredVars() []string
+	RequiredVars() ([]string, error)
+	VarDefaults() ([]RequiredVar, error)
 	GetValue(key string) string
 	OpenShiftVersion() string
 }
@@ -47,27 +54,14 @@ type DefaultAddOnMeta struct {
 }
 
 func NewAddOnMeta(headers map[string]interface{}) (AddOnMeta, error) {
-	for _, tag := range requiredMetaTags {
-		if headers[tag] == nil {
-			return nil, errors.New(fmt.Sprintf("Metadata does not contain an mandatory entry for '%s'", tag))
-		}
-		switch v := headers[tag].(type) {
-		case string:
-			if v == "" {
-				return nil, errors.New(fmt.Sprintf("Metadata does not contain an mandatory entry for '%s'", tag))
-			}
-		case []string:
-			if len(v) == 0 {
-				return nil, errors.New(fmt.Sprintf("Metadata does not contain an mandatory entry for '%s'", tag))
-			}
-		default:
-			return nil, nil
-		}
+	if err := requiredMetaTagsCheck(headers); err != nil {
+		return nil, err
 	}
-	if headers[RequiredOpenShiftVersion] != nil {
-		if !checkVersionSemantic(headers[RequiredOpenShiftVersion].(string)) {
-			return nil, errors.New("Add-on only support OpenShift version semantics eg. 3.6.0 or >3.6.0, <3.9.0 or >=3.5 etc.")
-		}
+	if err := requiredOpenShiftVersionCheck(headers); err != nil {
+		return nil, err
+	}
+	if err := varDefaultsCheck(headers); err != nil {
+		return nil, err
 	}
 
 	metaData := &DefaultAddOnMeta{headers: headers}
@@ -86,12 +80,28 @@ func (meta *DefaultAddOnMeta) Description() []string {
 	return meta.headers[requiredMetaTags[1]].([]string)
 }
 
-func (meta *DefaultAddOnMeta) RequiredVars() []string {
+func (meta *DefaultAddOnMeta) RequiredVars() ([]string, error) {
 	if val, contains := meta.headers[requiredVars].(string); contains {
-		return meta.splitAndTrim(val)
+		return minishiftStrings.SplitAndTrim(val, ",")
 	} else {
-		return []string{}
+		return []string{}, nil
 	}
+}
+
+func (meta *DefaultAddOnMeta) VarDefaults() ([]RequiredVar, error) {
+	// Ignore errors as checking has been done during varDefaultsCheck as part of NewAddOnMeta
+	if val, contains := meta.headers[varDefaults].(string); contains {
+		items, _ := minishiftStrings.SplitAndTrim(val, ",")
+		defaults := make([]RequiredVar, 0, len(items))
+		for _, item := range items {
+			varDefault, _ := minishiftStrings.SplitAndTrim(item, "=")
+			defaults = append(defaults, RequiredVar{Key: varDefault[0], Value: varDefault[1]})
+		}
+
+		return defaults, nil
+	}
+
+	return []RequiredVar{}, nil
 }
 
 func (meta *DefaultAddOnMeta) GetValue(key string) string {
@@ -105,20 +115,66 @@ func (meta *DefaultAddOnMeta) OpenShiftVersion() string {
 	return anyOpenShiftVersion
 }
 
-func (meta *DefaultAddOnMeta) splitAndTrim(s string) []string {
-	// Trims the stream and then splits
-	trimmed := strings.TrimSpace(s)
-	split := strings.Split(trimmed, ",")
-	cleanSplit := make([]string, len(split))
-	for i, val := range split {
-		cleanSplit[i] = strings.TrimSpace(val)
-	}
-	return cleanSplit
-}
-
 func checkVersionSemantic(version string) bool {
 	// Strict match for <major> or <major>.<minor> or <major>.<minor>.<patch>
 	// (>=|>|<|<=)3.6.0, (>=|>|<|<=)3.6.0
 	match, _ := regexp.MatchString("^(|>|>=|<|<=)[0-9]+(.[0-9]+){0,2}(|\\s*,\\s*(|>|>=|<|<=)[0-9]+(.[0-9]+){0,2})$", version)
 	return match
+}
+
+func requiredMetaTagsCheck(headers map[string]interface{}) error {
+	for _, tag := range requiredMetaTags {
+		if headers[tag] == nil {
+			return errors.New(fmt.Sprintf("Metadata does not contain a mandatory entry for '%s'", tag))
+		}
+		switch v := headers[tag].(type) {
+		case string:
+			if v == "" {
+				return errors.New(fmt.Sprintf("Metadata does not contain a mandatory entry for '%s'", tag))
+			}
+		case []string:
+			if len(v) == 0 {
+				return errors.New(fmt.Sprintf("Metadata does not contain a mandatory entry for '%s'", tag))
+			}
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func requiredOpenShiftVersionCheck(headers map[string]interface{}) error {
+	if headers[RequiredOpenShiftVersion] != nil {
+		if !checkVersionSemantic(headers[RequiredOpenShiftVersion].(string)) {
+			return errors.New("Add-on only support OpenShift version semantics eg. 3.6.0 or >3.6.0, <3.9.0 or >=3.5 etc.")
+		}
+	}
+
+	return nil
+}
+
+func varDefaultsCheck(headers map[string]interface{}) error {
+	if val, contains := headers[varDefaults].(string); contains {
+		items, err := minishiftStrings.SplitAndTrim(val, ",")
+		if err != nil {
+			return err
+		}
+
+		for _, item := range items {
+			varDefault, err := minishiftStrings.SplitAndTrim(item, "=")
+			if err != nil {
+				return err
+			}
+			// Expect varDefault to be only having key and value
+			if len(varDefault) != 2 {
+				return errors.New(fmt.Sprintf("'%s' is not well formed", val))
+			}
+
+			if varDefault[0] == "" || varDefault[1] == "" {
+				return errors.New(fmt.Sprintf("'%s' is not well formed", val))
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/minishift/addon/addon_meta_test.go
+++ b/pkg/minishift/addon/addon_meta_test.go
@@ -52,7 +52,7 @@ func Test_missing_name_returns_error(t *testing.T) {
 		t.Fatal("Expected an error, got none")
 	}
 
-	expectedError := "Metadata does not contain an mandatory entry for 'Name'"
+	expectedError := "Metadata does not contain a mandatory entry for 'Name'"
 	if err.Error() != expectedError {
 		t.Fatal(fmt.Sprintf("Expected error '%s', but got '%s'", expectedError, err.Error()))
 	}
@@ -70,7 +70,7 @@ func Test_missing_description_returns_error(t *testing.T) {
 		t.Fatal("Expected an error, got none")
 	}
 
-	expectedError := "Metadata does not contain an mandatory entry for 'Description'"
+	expectedError := "Metadata does not contain a mandatory entry for 'Description'"
 	if err.Error() != expectedError {
 		t.Fatal(fmt.Sprintf("Expected error '%s', but got '%s'", expectedError, err.Error()))
 	}
@@ -100,8 +100,8 @@ func Test_required_vars_meta_is_extracted(t *testing.T) {
 	testMap["Required-Vars"] = " USER, access_token "
 
 	addOnMeta := getAddOnMeta(testMap, t)
-
-	minishiftTesting.AssertEqualSlice(addOnMeta.RequiredVars(), []string{"USER", "access_token"}, t)
+	requiredVars, _ := addOnMeta.RequiredVars()
+	minishiftTesting.AssertEqualSlice(requiredVars, []string{"USER", "access_token"}, t)
 }
 
 func Test_required_vars_empty_if_not_specified(t *testing.T) {
@@ -110,15 +110,83 @@ func Test_required_vars_empty_if_not_specified(t *testing.T) {
 	testMap["Description"] = []string{"Acme Add-on"}
 
 	addOnMeta := getAddOnMeta(testMap, t)
+	requiredVars, _ := addOnMeta.RequiredVars()
+	minishiftTesting.AssertEqualSlice(requiredVars, []string{}, t)
+}
 
-	minishiftTesting.AssertEqualSlice(addOnMeta.RequiredVars(), []string{}, t)
+func Test_var_defaults_empty_if_not_specified(t *testing.T) {
+	testMap := make(map[string]interface{})
+	testMap["Name"] = "acme"
+	testMap["Description"] = []string{"Acme Add-on"}
+
+	addOnMeta := getAddOnMeta(testMap, t)
+	varDefaults, _ := addOnMeta.VarDefaults()
+	if len(varDefaults) != 0 {
+		t.Fatal(fmt.Sprintf("Expected empty var default, but got: '%s'", len(varDefaults)))
+	}
+}
+
+func Test_var_defaults_meta_is_extracted(t *testing.T) {
+	testMap := make(map[string]interface{})
+	testMap["Name"] = "acme"
+	testMap["Description"] = []string{"Acme Add-on"}
+	expectedDefaultEnv := "USER=foo"
+	testMap["Var-Defaults"] = expectedDefaultEnv
+
+	addOnMeta := getAddOnMeta(testMap, t)
+	varDefaults, _ := addOnMeta.VarDefaults()
+	if len(varDefaults) != 1 {
+		t.Fatal(fmt.Sprintf("Expected one var default, but got: '%s'", len(varDefaults)))
+	}
+}
+
+type varDefaultTestCase struct {
+	expectedVarDefault string
+	expectedError      string
+}
+
+func Test_invalid_var_defaults_meta(t *testing.T) {
+	testCases := []varDefaultTestCase{
+		{
+			expectedVarDefault: "",
+			expectedError:      "'' is not well formed",
+		},
+		{
+			expectedVarDefault: "USER=foo,,",
+			expectedError:      "'USER=foo,,' is not well formed",
+		},
+		{
+			expectedVarDefault: "=ABC",
+			expectedError:      "'=ABC' is not well formed",
+		},
+		{
+			expectedVarDefault: "USER=",
+			expectedError:      "'USER=' is not well formed",
+		},
+	}
+
+	testMap := make(map[string]interface{})
+	testMap["Name"] = "acme"
+	testMap["Description"] = []string{"Acme Add-on"}
+
+	for _, testCase := range testCases {
+		testMap["Var-Defaults"] = testCase.expectedVarDefault
+		_, err := NewAddOnMeta(testMap)
+		if err == nil {
+			t.Fatalf("Expected an error, got none for var default \"%s\"", testCase.expectedVarDefault)
+		}
+
+		if err.Error() != testCase.expectedError {
+			t.Fatalf("Expected error \"%s\", but got \"%s\"", testCase.expectedError, err.Error())
+		}
+	}
 }
 
 func getAddOnMeta(testMap map[string]interface{}, t *testing.T) AddOnMeta {
 	addOnMeta, err := NewAddOnMeta(testMap)
 
 	if err != nil {
-		t.Fatal(fmt.Sprintf("No error expected, but got: '%s'", err.Error()))
+		t.Fatal(fmt.Sprintf("No error expected, but got: \"%s\"", err.Error()))
 	}
 
 	return addOnMeta

--- a/pkg/minishift/addon/command/command.go
+++ b/pkg/minishift/addon/command/command.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package command
 
-// Command defines a single command to be executes as part of an addon definition.
+// Command defines a single command to be executed as part of an addon definition.
 // Minishift supports various types of commands as part of its addon DSL, eg oc, openshift or docker commands.
 type Command interface {
 	// Executes the command

--- a/pkg/minishift/addon/command/interpolation_context.go
+++ b/pkg/minishift/addon/command/interpolation_context.go
@@ -33,7 +33,7 @@ type InterpolationContext interface {
 	// Interpolate the cmd in the current context
 	Interpolate(cmd string) string
 
-	// Keys returns a list of variables  available for interpolation in a sorted slice
+	// Keys returns a list of variables available for interpolation in a sorted slice
 	Vars() []string
 }
 
@@ -44,8 +44,8 @@ type defaultInterpolationContext struct {
 }
 
 type regExpAndValue struct {
-	regexp      *regexp.Regexp
-	subsitution string
+	regexp       *regexp.Regexp
+	substitution string
 }
 
 // NewInterpolationContext creates a new interpolation context
@@ -59,7 +59,7 @@ func (c *defaultInterpolationContext) AddToContext(key string, value string) err
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Unable to add %s/%s to interpolation context", key, value))
 	}
-	c.context[key] = regExpAndValue{regexp: r, subsitution: value}
+	c.context[key] = regExpAndValue{regexp: r, substitution: value}
 	return nil
 }
 
@@ -70,13 +70,13 @@ func (c *defaultInterpolationContext) RemoveFromContext(key string) error {
 
 func (c *defaultInterpolationContext) Interpolate(cmd string) string {
 	for _, v := range c.context {
-		cmd = v.regexp.ReplaceAllLiteralString(cmd, v.subsitution)
+		cmd = v.regexp.ReplaceAllLiteralString(cmd, v.substitution)
 	}
 	return cmd
 }
 
 func (c *defaultInterpolationContext) Vars() []string {
-	keys := make([]string, len(c.context))
+	keys := make([]string, 0, len(c.context))
 	for k := range c.context {
 		keys = append(keys, k)
 	}

--- a/pkg/minishift/addon/manager/addon_manager_test.go
+++ b/pkg/minishift/addon/manager/addon_manager_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/minishift/minishift/pkg/minishift/addon"
+	"github.com/minishift/minishift/pkg/minishift/addon/command"
+	minishiftTesting "github.com/minishift/minishift/pkg/testing"
 )
 
 var (
@@ -128,6 +130,16 @@ func Test_invalid_addons_get_skipped(t *testing.T) {
 	expectedNumberOfAddOns := 1
 	actualNumberOfAddOns := len(addOns)
 	if actualNumberOfAddOns != expectedNumberOfAddOns {
-		t.Fatal(fmt.Sprintf("Unexpected number of addons. Expected %d, got %d", expectedNumberOfAddOns, actualNumberOfAddOns))
+		t.Fatal(fmt.Sprintf("Unexpected number of add-ons. Expected %d, got %d", expectedNumberOfAddOns, actualNumberOfAddOns))
 	}
+}
+
+func Test_add_var_defaults_to_context(t *testing.T) {
+	context, _ := command.NewExecutionContext(nil, nil)
+	expectedVarName := "foo"
+	varDefaults := []addon.RequiredVar{
+		{Key: expectedVarName, Value: "bar"},
+	}
+	addVarDefaultsToContext(context, varDefaults)
+	minishiftTesting.AssertEqualSlice(context.Vars(), []string{expectedVarName}, t)
 }

--- a/pkg/minishift/addon/parser/addon_parser.go
+++ b/pkg/minishift/addon/parser/addon_parser.go
@@ -71,7 +71,7 @@ func NewAddOnParser() *AddOnParser {
 }
 
 // Parse takes as parameter a reader containing an addon definition and returns an AddOn instance.
-// If an error occurs nil and the error are returned.
+// If an error occurs, the error is returned.
 func (parser *AddOnParser) Parse(addOnDir string) (addon.AddOn, error) {
 	addonInstallReader, err := parser.getAddOnContentReader(addOnDir, ".addon")
 	if err != nil {
@@ -116,7 +116,6 @@ func (parser *AddOnParser) getAddOnContentReader(addOnDir string, fileSuffix str
 	if err != nil {
 		return nil, NewParseError(fmt.Sprintf("Unexpected error reading addon content in '%s'", addOnDir), addOnDir, "")
 	}
-
 	var addOnFiles []string
 	for _, fileInfo := range files {
 		if strings.HasSuffix(fileInfo.Name(), fileSuffix) {

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -41,6 +41,7 @@ import (
 	"regexp"
 
 	"github.com/minishift/minishift/pkg/util"
+	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
 	"github.com/minishift/minishift/pkg/version"
 )
 
@@ -191,8 +192,13 @@ func GetExecutionContext(ip string, routingSuffix string, addOnEnv []string, ocR
 		if !match {
 			return nil, errors.New(fmt.Sprintf("Add-on interpolation variables need to be specified in the format <key>=<value>.'%s' is not.", env))
 		}
-		key, value := splitKeyValue(env, "=")
 
+		envTokens, err := minishiftStrings.SplitAndTrim(env, "=")
+		if err != nil {
+			return nil, err
+		}
+
+		key, value := envTokens[0], envTokens[1]
 		if strings.HasPrefix(value, envPrefix) {
 			if os.Getenv(strings.TrimPrefix(value, envPrefix)) != "" {
 				value = os.Getenv(strings.TrimPrefix(value, envPrefix))
@@ -205,11 +211,6 @@ func GetExecutionContext(ip string, routingSuffix string, addOnEnv []string, ocR
 	}
 
 	return context, nil
-}
-
-func splitKeyValue(s string, separator string) (string, string) {
-	x := strings.Split(s, separator)
-	return strings.TrimSpace(x[0]), strings.TrimSpace(x[1])
 }
 
 // TODO - persistent volume creation should really be fixed upstream, aka 'cluster up'. See https://github.com/openshift/origin/issues/14076 (HF)

--- a/pkg/minishift/clusterup/clusterup_test.go
+++ b/pkg/minishift/clusterup/clusterup_test.go
@@ -18,6 +18,7 @@ package clusterup
 
 import (
 	"fmt"
+	utilStrings "github.com/minishift/minishift/pkg/util/strings"
 	"github.com/pkg/errors"
 	"os"
 	"testing"
@@ -113,7 +114,7 @@ func assertInterpolation(variables []string, testString string, expectedResult s
 func resetEnv(env []string) {
 	os.Clearenv()
 	for _, envSetting := range env {
-		key, value := splitKeyValue(envSetting, "=")
-		os.Setenv(key, value)
+		envTokens, _ := utilStrings.SplitAndTrim(envSetting, "=")
+		os.Setenv(envTokens[0], envTokens[1])
 	}
 }

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -91,3 +91,16 @@ func GetOnlyNumbers(yourString string) string {
 func GetSignedNumbers(yourString string) string {
 	return getOnlyMatch(signedNumbersMatch, yourString)
 }
+
+// SplitAndTrim split the string based on the separator passed
+func SplitAndTrim(s string, separator string) ([]string, error) {
+	// Trims the spaces and then splits
+	trimmed := strings.TrimSpace(s)
+	split := strings.Split(trimmed, separator)
+	cleanSplit := make([]string, len(split))
+	for i, val := range split {
+		cleanSplit[i] = strings.TrimSpace(val)
+	}
+
+	return cleanSplit, nil
+}

--- a/pkg/util/strings/strings_test.go
+++ b/pkg/util/strings/strings_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package strings
 
 import (
+	minishiftTesting "github.com/minishift/minishift/pkg/testing"
 	"reflect"
 	"runtime"
 	"testing"
@@ -111,5 +112,24 @@ func TestEscapeSingleQuote(t *testing.T) {
 		if EscapeSingleQuote(pass) != expected {
 			t.Fatalf("Expected '%s' Got '%s'", expected, EscapeSingleQuote(pass))
 		}
+	}
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	var testCases = []struct {
+		testString    string
+		separator     string
+		expectedSlice []string
+	}{
+		{"foo bar", " ", []string{"foo", "bar"}},
+		{"foo=bar", "=", []string{"foo", "bar"}},
+		{"foobar", "", []string{"f", "o"}},
+		{"foo:bar-baz", "-", []string{"foo:bar", "baz"}},
+	}
+
+	for _, testCase := range testCases {
+		tokens, _ := SplitAndTrim(testCase.testString, testCase.separator)
+		actualSlice := []string{tokens[0], tokens[1]}
+		minishiftTesting.AssertEqualSlice(actualSlice, testCase.expectedSlice, t)
 	}
 }


### PR DESCRIPTION
Fix #1135

### Updated

Tested with
```
# ~/.minishift/addons/demo-addon/demo-addon.addon 
# Name: demo-addon
# Description: Demo addon
# Required-Vars: USER,NAMESPACE
# Var-Defaults: NAMESPACE=kube-system

echo User is #{USER} and namespace is #{NAMESPACE} and project is #{PROJECT}
```

#### Run as: 
- minishift addons install demo-addon
- minishift addons apply demo-addon --addon-env USER=foo

#### Expected Output
User is budhram and namespace is kube-system and project is #{PROJECT}

Since, `PROJECT` variable doesn't has any value from `--addon-env` or `minishift config set addon-env` and not required it is displayed as expected. [Was in wrong assumption that it will shown as empty]


