### PR TITLE
Issue #1547 Use adoc attributes for project

### DIFF
--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -10,6 +10,7 @@ ADOC_VARIABLES     = FileList.new('source/variables.adoc',
  'source/contributing/variables.adoc',
  'source/getting-started/variables.adoc',
  'source/openshift/variables.adoc',
+ 'source/troubleshooting/variables.adoc',
  'source/using/variables.adoc'
 )
 GENERATED_ADOC_DIR = "source/command-ref"
@@ -98,15 +99,18 @@ end
 
 desc 'Create adoc variables'
 task :adoc_variables => :init do
-  minishift_version  = ENV['MINISHIFT_VERSION'] || 'unset'
-  openshift_version  = ENV['OPENSHIFT_VERSION'] || 'unset'
-  centos_iso_version = ENV['CENTOS_ISO_VERSION'] || 'unset'
+  minishift_version    = ENV['MINISHIFT_VERSION']    || 'unset'
+  openshift_version    = ENV['OPENSHIFT_VERSION']    || 'unset'
+  centos_iso_version   = ENV['CENTOS_ISO_VERSION']   || 'unset'
+  minikube_iso_version = ENV['MINIKUBE_ISO_VERSION'] || 'unset'
 
   ADOC_VARIABLES.each do |f|
     File.open(f, "w+") do |f|
+      f.write(":project: Minishift\n")
       f.write(":minishift-version: #{minishift_version}\n")
       f.write(":openshift-version: #{openshift_version}\n")
       f.write(":centos-iso-version: #{centos_iso_version}\n")
+      f.write(":minikube-iso-version: #{minikube_iso_version}\n")
     end
   end
 end

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -1,4 +1,6 @@
-= Developing Minishift
+include::variables.adoc[]
+
+= Developing {project}
 :icons:
 :toc: macro
 :toc-title:
@@ -9,7 +11,7 @@ toc::[]
 [[developing-overview]]
 == Overview
 
-The following sections describe how to build and test Minishift.
+The following sections describe how to build and test {project}.
 
 [[develop-prerequisites]]
 == Prerequisites
@@ -17,7 +19,7 @@ The following sections describe how to build and test Minishift.
 - Git
 - A recent Go distribution (>1.7)
 
-NOTE: You should be able to develop Minishift on any operating system, such as GNU/Linux, macOS or Windows.
+NOTE: You should be able to develop {project} on any operating system, such as GNU/Linux, macOS or Windows.
 The Windows operating system might require additional steps or have some limitations.
 
 [[set-up-dev-env]]
@@ -58,7 +60,7 @@ NOTE: On Windows operating systems, you use the UI or use `setx` to set the envi
 [[cloning-repository]]
 === Cloning the Repository
 
-Get the Minishift sources from GitHub:
+Get the {project} sources from GitHub:
 
 ----
 $ cd $GOPATH/src
@@ -69,7 +71,7 @@ $ git clone https://github.com/minishift/minishift.git github.com/minishift/mini
 === Using an IDE
 
 You can use any editor you want.
-However, most of the core maintainers of Minishift use IntelliJ link:https://www.jetbrains.com/idea/[IDEA] with the latest Go plug-in.
+However, most of the core maintainers of {project} use IntelliJ link:https://www.jetbrains.com/idea/[IDEA] with the latest Go plug-in.
 This IDE indexes your whole workspace and allows for easy navigation of the sources, and also integrates with the Go debugger link:https://github.com/derekparker/delve[Delve].
 
 For instructions on setting up IDEA, see link:http://hadihariri.com/2015/09/30/setting-up-go-on-intellij/[Setting up Go on IntelliJ].
@@ -77,7 +79,7 @@ For instructions on setting up IDEA, see link:http://hadihariri.com/2015/09/30/s
 [[manage-dependencies]]
 == Dependency Management
 
-Minishift uses link:https://github.com/Masterminds/glide[Glide] for dependency management.
+{project} uses link:https://github.com/Masterminds/glide[Glide] for dependency management.
 
 [[install-glide]]
 === Installing Glide
@@ -94,7 +96,7 @@ Make sure to use Glide version 0.12.3 or later.
 [[bootstrap-dependencies]]
 === Bootstrapping Dependencies
 
-After a clean checkout or after a `make clean`, there won't be a *_vendor_* directory containing the needed Minishift dependencies.
+After a clean checkout or after a `make clean`, there won't be a *_vendor_* directory containing the needed {project} dependencies.
 
 To install the dependencies, you can run the following command:
 
@@ -127,10 +129,10 @@ TIP: In some cases the Glide cache located under *_~/.glide/cache_* can get corr
 If you seeing Glide errors during `make vendor`, you can clear the Glide cache via `glide cc`.
 
 [[build-minishift]]
-== Building Minishift
+== Building {project}
 
 [[build-minishift-binary]]
-=== Building the Minishift Binary
+=== Building the {project} Binary
 
 Run the following command to create a platform-specific binary and copy it to *_$GOPATH/bin_*.
 
@@ -141,7 +143,7 @@ $ make
 NOTE: Use `make cross` to cross-compile for other platforms.
 
 [[run-minishift-binary]]
-=== Running the Minishift Binary
+=== Running the {project} Binary
 
 Start the OpenShift cluster with your built minishift binary:
 
@@ -149,7 +151,7 @@ Start the OpenShift cluster with your built minishift binary:
 $ minishift start
 ----
 
-This command will run Minishift from *_$GOPATH/bin/minishift_*, if you set up your Go workspace as described in the xref:create-go-workspace[Creating the Go workspace] section.
+This command will run {project} from *_$GOPATH/bin/minishift_*, if you set up your Go workspace as described in the xref:create-go-workspace[Creating the Go workspace] section.
 
 You can also execute the binaries directly from the *_out_* directory of the checkout.
 Depending on your operating system, the binary is in one of the following directories:
@@ -158,7 +160,7 @@ Depending on your operating system, the binary is in one of the following direct
 * *_out/linux-amd64_*
 * *_out/windows-amd64_*
 
-For more Minishift commands and flags, see the xref:../command-ref/minishift.adoc#[Minishift command reference] documentation.
+For more {project} commands and flags, see the xref:../command-ref/minishift.adoc#[{project} command reference] documentation.
 
 [[unit-tests]]
 === Unit Tests
@@ -196,14 +198,14 @@ For more information about test options, run the `go test --help` command and re
 
 Integration tests utilize link:https://github.com/DATA-DOG/godog[Godog], which uses Gherkin (Cucumber) to define sets of test cases, in Gherkin terminology known as _features_.
 The features are located in *_test/integration/features_* folder.
-Features for Minishift follow these basic concepts:
+Features for {project} follow these basic concepts:
 
 User stories::
 Features which follow a happy path of user.
 For example, _basic.feature_ or _coolstore.feature_.
 
 Feature and command coverage::
-Features which focuses on specific fields of Minishift functionality or individual commands.
+Features which focuses on specific fields of {project} functionality or individual commands.
 For example, _proxy.feature_ or _cmd-version.feature_.
 
 
@@ -230,7 +232,7 @@ $ make integration_all
 To provide more flexibility the default targets `integration` and `integration_all` can be further customized using several parameters.
 
 MINISHIFT_BINARY::
-Parameter `MINISHIFT_BINARY` can be used to run integration tests against Minishift binary located in different directory:
+Parameter `MINISHIFT_BINARY` can be used to run integration tests against {project} binary located in different directory:
 
 ----
 $ make integration MINISHIFT_BINARY=<path-to-custom-binary>
@@ -245,10 +247,10 @@ $ make integration_all TIMEOUT=7200s
 ----
 
 RUN_BEFORE_FEATURE::
-Parameter `RUN_BEFORE_FEATURE` specifies Minishift commands to be run before each feature.
-This provides ability to run integration tests against Minishift which is not in default state.
+Parameter `RUN_BEFORE_FEATURE` specifies {project} commands to be run before each feature.
+This provides ability to run integration tests against {project} which is not in default state.
 When multiple commands are specified, they must be delimited by a semicolon.
-For example, tests can be run against stopped Minishift with _image caching_ option turned on by running:
+For example, tests can be run against stopped {project} with _image caching_ option turned on by running:
 
 ----
 $ make integration_all RUN_BEFORE_FEATURE="start; stop; config set image-caching true"
@@ -299,7 +301,7 @@ However for cases which needs further investigation the integration test also lo
 [[format-source-code]]
 === Formatting the Source Code
 
-Minishift adheres to the Go link:https://golang.org/doc/effective_go.html#formatting[formatting guidelines].
+{project} adheres to the Go link:https://golang.org/doc/effective_go.html#formatting[formatting guidelines].
 Code with incorrect formatting will fail the CI builds.
 You can check whether any of your files violate the guidelines with the following command:
 
@@ -325,6 +327,6 @@ $ make clean
 [[godoc]]
 == Godoc
 
-When developing Minishift, it is encouraged to use link:https://godoc.org/golang.org/x/tools/cmd/godoc[Godoc] to document the source code.
+When developing {project}, it is encouraged to use link:https://godoc.org/golang.org/x/tools/cmd/godoc[Godoc] to document the source code.
 You can find guidelines on how to use godoc in link:https://blog.golang.org/godoc-documenting-go-code[this blog post].
-You can browse the Minishift Godoc documentation under link:https://godoc.org/github.com/minishift/minishift[https://godoc.org/github.com/minishift/minishift].
+You can browse the {project} Godoc documentation under link:https://godoc.org/github.com/minishift/minishift[https://godoc.org/github.com/minishift/minishift].

--- a/docs/source/contributing/index.adoc
+++ b/docs/source/contributing/index.adoc
@@ -1,14 +1,16 @@
-= Contributing to Minishift
+include::variables.adoc[]
+
+= Contributing to {project}
 :icons:
 
-Join the Minishift community! Learn about the link:https://github.com/minishift/minishift/blob/master/README.adoc[project] and how to link:https://github.com/minishift/minishift/blob/master/CONTRIBUTING.adoc[contribute].
+Join the {project} community! Learn about the link:https://github.com/minishift/minishift/blob/master/README.adoc[project] and how to link:https://github.com/minishift/minishift/blob/master/CONTRIBUTING.adoc[contribute].
 
-- xref:../contributing/developing.adoc#[Developing Minishift]
-- xref:../contributing/ci.adoc#[Minishift CI]
+- xref:../contributing/developing.adoc#[Developing {project}]
+- xref:../contributing/ci.adoc#[{project} CI]
 - xref:../contributing/writing-docs.adoc#[Writing Documentation]
-- xref:../contributing/releasing.adoc#[Releasing Minishift]
+- xref:../contributing/releasing.adoc#[Releasing {project}]
 
-You can reach the Minishift community by:
+You can reach the {project} community by:
 
 - Signing up to our link:https://lists.minishift.io/admin/lists/minishift.lists.minishift.io[mailing list]
 - Joining the #minishift channel on link:https://freenode.net/[Freenode IRC]

--- a/docs/source/contributing/releasing.adoc
+++ b/docs/source/contributing/releasing.adoc
@@ -1,4 +1,6 @@
-= Releasing Minishift
+include::variables.adoc[]
+
+= Releasing {project}
 :icons:
 :toc: macro
 :toc-title:
@@ -9,7 +11,7 @@ toc::[]
 [[releasing-overview]]
 == Overview
 
-The following sections describe how to release Minishift either via automated job or manually.
+The following sections describe how to release {project} either via automated job or manually.
 
 [[preparing-github-milestone]]
 == Preparing the GitHub Milestone
@@ -32,7 +34,7 @@ $ make ci_release API_KEY=<api-key> RELEASE_VERSION=<version>
 
 where
 
-  - `api-key` : Minishift CentOS CI API key
+  - `api-key` : {project} CentOS CI API key
   - `version` : Expected release version. Eg : 1.0.0 (without 'v')
 
 Once triggered you can follow the release process link:https://ci.centos.org/job/minishift-release/[here].
@@ -61,7 +63,7 @@ defined in your environment as _GITHUB_ACCESS_TOKEN_.
 $ make prerelease
 ----
 
-. Bump the Minishift version in the link:https://github.com/minishift/minishift/blob/master/Makefile[Makefile].
+. Bump the {project} version in the link:https://github.com/minishift/minishift/blob/master/Makefile[Makefile].
 
 . Commit and push your changes with a message of the form `cut v1.0.0`.
 
@@ -80,7 +82,7 @@ $ curl -H "$(curl --user minishift:$API_KEY 'https://ci.centos.org//crumbIssuer/
 ----
 
 This will build link:http://artifacts.ci.centos.org/minishift/minishift/docs/latest/[minishift-adoc.tar], which will be consumed by *docs.openshift.org* during the next nightly build.
-For more information, see xref:../contributing/writing-docs.adoc#[Writing and Publishing Minishift Documentation].
+For more information, see xref:../contributing/writing-docs.adoc#[Writing and Publishing {project} Documentation].
 
 [[post-release-tasks]]
 === Post-Release Tasks

--- a/docs/source/contributing/writing-docs.adoc
+++ b/docs/source/contributing/writing-docs.adoc
@@ -1,4 +1,6 @@
-= Writing and Publishing Minishift Documentation
+include::variables.adoc[]
+
+= Writing and Publishing {project} Documentation
 :icons:
 :toc: macro
 :toc-title:
@@ -9,24 +11,24 @@ toc::[]
 [[writing-docs-overview]]
 == Overview
 
-Minishift documentation is located in the *_docs_* sub-directory of the Minishift repository.
+{project} documentation is located in the *_docs_* sub-directory of the {project} repository.
 The documentation is a mix of auto-generated https://en.wikipedia.org/wiki/Markdown[Markdown] files and manually maintained https://en.wikipedia.org/wiki/AsciiDoc[AsciiDoc] files.
 
 [[contribute-to-docs]]
 == Contributing to the Documentation
 
-Minishift is an open-source project and we welcome contributions.
-Similar to code contributions, if you want to add or edit Minishift documentation, you can create an issue in our link:https://github.com/minishift/minishift/issues[Github issue tracker] and submit a pull request with the changes.
+{project} is an open-source project and we welcome contributions.
+Similar to code contributions, if you want to add or edit {project} documentation, you can create an issue in our link:https://github.com/minishift/minishift/issues[Github issue tracker] and submit a pull request with the changes.
 
 [[docs-conventions-guidelines]]
 == Conventions and Guidelines
 
-Minishift documentation is authored in the link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference[AsciiDoc] markup format.
-Since Minishift is closely related to the OpenShift Origin project, we follow the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc[OpenShift Documentation Guidelines] for tagging, formatting, and structure wherever possible.
+{project} documentation is authored in the link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference[AsciiDoc] markup format.
+Since {project} is closely related to the OpenShift Origin project, we follow the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc[OpenShift Documentation Guidelines] for tagging, formatting, and structure wherever possible.
 
-The documentation source structure follows a modular format, where each file is called a _topic_ and each topic is stored under a sub-folder based on the relevant category, such as Getting Started, Using Minishift, or Command Reference.
+The documentation source structure follows a modular format, where each file is called a _topic_ and each topic is stored under a sub-folder based on the relevant category, such as Getting Started, Using {project}, or Command Reference.
 
-TIP: You can check out the link:https://raw.githubusercontent.com/minishift/minishift/master/docs/source/contributing/writing-docs.adoc[raw file] of this topic or other existing Minishift topics to see examples of how the information is structured and which tags to use.
+TIP: You can check out the link:https://raw.githubusercontent.com/minishift/minishift/master/docs/source/contributing/writing-docs.adoc[raw file] of this topic or other existing {project} topics to see examples of how the information is structured and which tags to use.
 
 [[common-conventions]]
 === Commonly-Used Conventions
@@ -62,7 +64,7 @@ Make sure to add the new topic in the same order in all of the locations.
 By default, the documentation is built in a Docker container.
 This way you do not need to install all the required dependencies on your development machine.
 All you need is a running Docker daemon.
-In case you don't have one, use Minishift itself.
+In case you don't have one, use {project} itself.
 For more information, see xref:../using/docker-daemon.adoc#reusing-docker-daemon[reusing the Docker daemon].
 
 To generate the documentation into the *_docs/build_* directory, run:
@@ -120,15 +122,15 @@ $ make clean_docs
 [[integration-with-docs-openshift-org]]
 == Integration with docs.openshift.org
 
-The Minishift documentation is deployed on *docs.openshift.org* under link:https://docs.openshift.org/latest/minishift[https://docs.openshift.org/latest/minishift].
+The {project} documentation is deployed on *docs.openshift.org* under link:https://docs.openshift.org/latest/minishift[https://docs.openshift.org/latest/minishift].
 
-To integrate with *docs.openshift.org*, we deliver a tarball that contains the Minishift AsciiDoc files as well as some link:http://www.asciibinder.org/[AsciiBinder] metadata files.
+To integrate with *docs.openshift.org*, we deliver a tarball that contains the {project} AsciiDoc files as well as some link:http://www.asciibinder.org/[AsciiBinder] metadata files.
 This tarball is generated with a Jenkins job on link:https://ci.centos.org/job/minishift-docs[CentOS CI] and is triggered as part of a xref:./releasing.adoc#cut-release[release].
 
 [[manually-building-openshift-docs]]
 === Manually Building the OpenShift Documentation
 
-To view the Minishift documentation integrated into the OpenShift documentation, you can follow the following steps.
+To view the {project} documentation integrated into the OpenShift documentation, you can follow the following steps.
 
 [NOTE]
 ====
@@ -136,16 +138,16 @@ To view the Minishift documentation integrated into the OpenShift documentation,
 You need all the tooling to build openshift-docs.
 See the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/tools_and_setup.adoc[Install and set up the tools and software] section, which is part of the _openshift-docs_ repository.
 
-- Make sure that the `rake build` commands succeeds before integrating the Minishift documentation.
+- Make sure that the `rake build` commands succeeds before integrating the {project} documentation.
 ====
 
-. In the local Minishift repository, build the Minishift documentation tarball.
+. In the local {project} repository, build the {project} documentation tarball.
 
 ----
 $ make gen_adoc_tar
 ----
 
-After the build completes there will be a *_minishift-adoc.tar_* file in the *_docs/build_* directory of the local Minishift repository.
+After the build completes there will be a *_minishift-adoc.tar_* file in the *_docs/build_* directory of the local {project} repository.
 
 . In the local openshift-docs repository, run the following commands:
 

--- a/docs/source/getting-started/index.adoc
+++ b/docs/source/getting-started/index.adoc
@@ -1,10 +1,12 @@
-= Getting Started with Minishift
+include::variables.adoc[]
+
+= Getting Started with {project}
 :icons:
 
-This section contains information about installing Minishift, quickstart steps, and sample application deployment.
+This section contains information about installing {project}, quickstart steps, and sample application deployment.
 
-- xref:../getting-started/installing.adoc#[Installing Minishift]
-- xref:../getting-started/quickstart.adoc#[Minishift Quickstart]
+- xref:../getting-started/installing.adoc#[Installing {project}]
+- xref:../getting-started/quickstart.adoc#[{project} Quickstart]
 - xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in]
-- xref:../getting-started/updating.adoc#[Updating Minishift]
-- xref:../getting-started/uninstalling.adoc#[Uninstalling Minishift]
+- xref:../getting-started/updating.adoc#[Updating {project}]
+- xref:../getting-started/uninstalling.adoc#[Uninstalling {project}]

--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -1,5 +1,7 @@
+include::variables.adoc[]
+
 [[installing-minishift]]
-= Installing Minishift
+= Installing {project}
 :icons:
 :toc: macro
 :toc-title:
@@ -10,13 +12,13 @@ toc::[]
 [[installing-overview]]
 == Overview
 
-The following section describes how to install Minishift and the required dependencies.
+The following section describes how to install {project} and the required dependencies.
 
 [[install-prerequisites]]
 == Prerequisites
 
-Minishift requires a hypervisor to start the virtual machine on which the OpenShift cluster is provisioned.
-Verify that the hypervisor of your choice is installed and enabled on your system before you start Minishift.
+{project} requires a hypervisor to start the virtual machine on which the OpenShift cluster is provisioned.
+Verify that the hypervisor of your choice is installed and enabled on your system before you start {project}.
 
 Depending on your host operating system, you have the choice of the following hypervisors:
 
@@ -40,7 +42,7 @@ Windows::
 +
 [NOTE]
 ====
-To use Minishift with Hyper-V ensure that, after you link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v[install Hyper-V], you also link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/connect-to-network[add a Virtual Switch] using the Hyper-V Manager.
+To use {project} with Hyper-V ensure that, after you link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v[install Hyper-V], you also link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/connect-to-network[add a Virtual Switch] using the Hyper-V Manager.
 For specific configuration steps see the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.
 ====
 
@@ -53,11 +55,11 @@ If you encounter issues related to the hypervisor, see the xref:../troubleshooti
 ====
 
 [[installing-instructions]]
-== Installing Minishift
+== Installing {project}
 
 === Manually
 
-.  Download the archive for your operating system from the link:https://github.com/minishift/minishift/releases[Minishift releases page] and unpack it.
+.  Download the archive for your operating system from the link:https://github.com/minishift/minishift/releases[{project} releases page] and unpack it.
 
 .  Copy the contents of the directory to your preferred location.
 
@@ -65,10 +67,10 @@ If you encounter issues related to the hypervisor, see the xref:../troubleshooti
 
 [NOTE]
 ====
-- On Windows operating system, due to issue link:https://github.com/minishift/minishift/issues/236[#236], you need to execute the Minishift binary from your local C:/ drive.
-You cannot run Minishift from a network drive.
+- On Windows operating system, due to issue link:https://github.com/minishift/minishift/issues/236[#236], you need to execute the {project} binary from your local C:/ drive.
+You cannot run {project} from a network drive.
 
-- Automatic update of the Minishift binary and the virtual machine ISO is currently disabled.
+- Automatic update of the {project} binary and the virtual machine ISO is currently disabled.
 See also issue link:https://github.com/minishift/minishift/issues/204[#204].
 ====
 
@@ -78,7 +80,7 @@ See also issue link:https://github.com/minishift/minishift/issues/204[#204].
 [[homebrew-stable-install]]
 ==== Stable
 
-On macOS you can also use link:https://caskroom.github.io[Homebrew Cask] to install the stable version of Minishift:
+On macOS you can also use link:https://caskroom.github.io[Homebrew Cask] to install the stable version of {project}:
 
 ----
   $ brew cask install minishift

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -1,7 +1,7 @@
 include::variables.adoc[]
 
 [[quickstart]]
-= Minishift Quickstart
+= {project} Quickstart
 :icons:
 :toc: macro
 :toc-title:
@@ -12,18 +12,18 @@ toc::[]
 [[quickstart-overview]]
 == Overview
 
-This section contains a brief demo of Minishift and of the provisioned OpenShift cluster.
-For details on the usage of Minishift, see the xref:../using/managing-minishift.adoc#[Managing Minishift] section.
+This section contains a brief demo of {project} and of the provisioned OpenShift cluster.
+For details on the usage of {project}, see the xref:../using/managing-minishift.adoc#[Managing {project}] section.
 
 The interaction with OpenShift is with the command-line tool _oc_ which is copied to your host.
-For more information on how Minishift can assist you in interacting with and configuring your local OpenShift instance, see the xref:../openshift/openshift-client-binary.adoc#[OpenShift Client Binary] section.
+For more information on how {project} can assist you in interacting with and configuring your local OpenShift instance, see the xref:../openshift/openshift-client-binary.adoc#[OpenShift Client Binary] section.
 
 For more information about the OpenShift cluster architecture, see link:https://docs.openshift.org/latest/architecture/index.html[Architecture Overview] in the OpenShift documentation.
 
-The following steps describe how to get started with Minishift on a GNU/Linux operating system with the KVM hypervisor driver.
+The following steps describe how to get started with {project} on a GNU/Linux operating system with the KVM hypervisor driver.
 
 [[starting-minishift]]
-== Starting Minishift
+== Starting {project}
 
 . Run the `minishift start` command.
 +
@@ -47,10 +47,10 @@ $ minishift start
 ====
 - The IP is dynamically generated for each OpenShift cluster.
 To check the IP, run the `minishift ip` command.
-- By default, Minishift uses the driver most relevant to the host OS.
+- By default, {project} uses the driver most relevant to the host OS.
 To use a different driver, set the `--vm-driver` flag in `minishift start`.
 For example, to use VirtualBox instead of KVM on GNU/Linux operating systems, run `minishift start --vm-driver=virtualbox`.
-- While Minishift starts it runs several checks to make sure that the Minishift VM and the OpenShift cluster are able to start correctly.
+- While {project} starts it runs several checks to make sure that the {project} VM and the OpenShift cluster are able to start correctly.
 If any startup checks fail, see the xref:../troubleshooting/troubleshooting-getting-started.adoc#minshift-startup-check-failed[Troubleshooting Getting Started] topic for information about possible causes and solutions.
 
 For more information about `minishift start` options, see the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
@@ -98,7 +98,7 @@ $ oc expose svc/nodejs-ex
 $ minishift openshift service nodejs-ex --in-browser
 ----
 
-.  To stop Minishift, use the following command:
+.  To stop {project}, use the following command:
 +
 ----
 $ minishift stop

--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 [[set-up-driver-plugin]]
 = Setting Up the Driver Plug-in
 :icons:
@@ -9,15 +11,15 @@ toc::[]
 
 [[setup-driver-plugin-overview]]
 == Overview
-Minishift uses Docker Machine and its driver plug-in architecture to provide a consistent way to manage the OpenShift VM.
-Minishift embeds VirtualBox and VMware Fusion drivers so no additional steps are required to use them.
+{project} uses Docker Machine and its driver plug-in architecture to provide a consistent way to manage the OpenShift VM.
+{project} embeds VirtualBox and VMware Fusion drivers so no additional steps are required to use them.
 
 However, other drivers require manual installation and setup that are described in the following sections.
 
 [[kvm-driver-install]]
 == KVM Driver
 
-Minishift is currently tested against *docker-machine-driver-kvm* version 0.7.0.
+{project} is currently tested against *docker-machine-driver-kvm* version 0.7.0.
 
 . Install the KVM binary as follows:
 +
@@ -78,7 +80,7 @@ $ newgrp libvirt
 [[xhyve-driver-install]]
 == xhyve Driver
 
-Minishift is currently tested against *docker-machine-driver-xhyve* version 0.3.1.
+{project} is currently tested against *docker-machine-driver-xhyve* version 0.3.1.
 
 [[homebrew-install-xhyve]]
 === Homebrew Install
@@ -155,7 +157,7 @@ For more information, see the link:https://github.com/zchee/docker-machine-drive
 ====
 
 == Hyper-V Driver
-To use Minishift with Hyper-V:
+To use {project} with Hyper-V:
 
 . Install link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v[Hyper-V].
 
@@ -168,7 +170,7 @@ For more information, see xref:../troubleshooting/troubleshooting-driver-plugins
 +
 NOTE: Verify that you pair the virtual switch with a network card (wired or wireless) that is connected to the network.
 
-. Set the environment variable `HYPERV_VIRTUAL_SWITCH` to the name of the external virtual switch you want to use for Minishift.
+. Set the environment variable `HYPERV_VIRTUAL_SWITCH` to the name of the external virtual switch you want to use for {project}.
 For more information, see xref:../using/managing-minishift.adoc#driver-specific-environment-variables[driver-specific environment variables].
 +
 For example, on Command Prompt use:

--- a/docs/source/getting-started/uninstalling.adoc
+++ b/docs/source/getting-started/uninstalling.adoc
@@ -1,5 +1,7 @@
+include::variables.adoc[]
+
 [[uninstall-minishift]]
-= Uninstalling Minishift
+= Uninstalling {project}
 :icons:
 :toc: macro
 :toc-title:
@@ -9,12 +11,12 @@ toc::[]
 
 [[uninstall-overview]]
 == Overview
-This section describes how you can uninstall Minishift and delete associated files.
+This section describes how you can uninstall {project} and delete associated files.
 
 [[uninstall-instructions]]
-== Uninstalling Minishift
+== Uninstalling {project}
 
-.  Delete the Minishift VM and any VM-specific files.
+.  Delete the {project} VM and any VM-specific files.
 +
 ----
 $ minishift delete
@@ -23,12 +25,12 @@ $ minishift delete
 This command deletes everything in the *_MINISHIFT_HOME/.minishift/machines/minishift_* directory.
 Other cached data and the xref:../using/managing-minishift.adoc#persistent-configuration[persistent configuration] are not removed.
 
-.  To completely uninstall Minishift, delete everything in the *_MINISHIFT_HOME_* directory (default *_~/.minishift_*) and *_~/.kube_*, run the following commands:
+.  To completely uninstall {project}, delete everything in the *_MINISHIFT_HOME_* directory (default *_~/.minishift_*) and *_~/.kube_*, run the following commands:
 +
 ----
 $ rm -rf ~/.minishift
 $ rm -rf ~/.kube
 ----
 
-.  With your hypervisor management tool, confirm that there are no remaining artifacts related to the Minishift VM.
+.  With your hypervisor management tool, confirm that there are no remaining artifacts related to the {project} VM.
 For example, if you use KVM, you need to run the `virsh` command.

--- a/docs/source/index.adoc
+++ b/docs/source/index.adoc
@@ -1,24 +1,24 @@
 include::variables.adoc[]
 
 [[minishift-index]]
-= Minishift
+= {project}
 :icons:
 :toc: macro
 :toc-title:
 :toclevels: 1
 
 [[welcome-minishift]]
-== Welcome to Minishift {minishift-version}!
+== Welcome to {project} {minishift-version}!
 
-Minishift is a tool that helps you run OpenShift locally by running a single-node OpenShift
+{project} is a tool that helps you run OpenShift locally by running a single-node OpenShift
 cluster inside a VM.
 
 This documentation library contains the following sections to help you get started with, use, and
-extend Minishift:
+extend {project}:
 
 - xref:./getting-started/index.adoc#[Getting Started]
-- xref:./using/index.adoc#[Using Minishift]
+- xref:./using/index.adoc#[Using {project}]
 - xref:./openshift/index.adoc#[Interacting with OpenShift]
-- xref:./troubleshooting/index.adoc#[Troubleshooting Minishift]
-- xref:./contributing/index.adoc#[Contributing to Minishift]
+- xref:./troubleshooting/index.adoc#[Troubleshooting {project}]
+- xref:./contributing/index.adoc#[Contributing to {project}]
 - xref:./command-ref/minishift.adoc#[Command Reference]

--- a/docs/source/openshift/exposing-services.adoc
+++ b/docs/source/openshift/exposing-services.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 = Exposing Services
 :icons:
 :toc: macro
@@ -23,17 +25,17 @@ You can create a route using the Web console or the CLI:
 oc expose svc/frontend --hostname=www.example.com
 ----
 
-To see a full example of creating an application and exposing it with a route, see the xref:../getting-started/quickstart.adoc#deploy-sample-app[Minishift Quickstart] section.
+To see a full example of creating an application and exposing it with a route, see the xref:../getting-started/quickstart.adoc#deploy-sample-app[{project} Quickstart] section.
 
 [[nodeport-services]]
 == NodePort Services
 
 In case the service you want to expose is not HTTP based, you can create a link:https://docs.openshift.org/latest/architecture/core_concepts/pods_and_services.html#service-nodeport[*NodePort*] service.
 In this case, each OpenShift node will proxy that port into your service.
-To access this port on your Minishift VM, you need to configure an link:https://docs.openshift.org/latest/dev_guide/getting_traffic_into_cluster.html#using-ingress-IP-self-service[Ingress IP Self-Service] using `oc expose` with the parameter `type=LoadBalancer`.
+To access this port on your {project} VM, you need to configure an link:https://docs.openshift.org/latest/dev_guide/getting_traffic_into_cluster.html#using-ingress-IP-self-service[Ingress IP Self-Service] using `oc expose` with the parameter `type=LoadBalancer`.
 
 A common use-case for Ingress IP Self-Service is the ability to expose a database service.
-The following example shows the complete workflow to create and expose a link:https://mariadb.org[MariaDB] instance using Minishift:
+The following example shows the complete workflow to create and expose a link:https://mariadb.org[MariaDB] instance using {project}:
 
 ----
 $ minishift start
@@ -48,7 +50,7 @@ ports:
  ....
 ----
 
-After the service is exposed, you can access MariaDB with the `mysql` CLI using the Minishift VM IP and the exposed NodePort service.
+After the service is exposed, you can access MariaDB with the `mysql` CLI using the {project} VM IP and the exposed NodePort service.
 
 ----
 $ mysql --user=root --password=foo --host=$(minishift ip) --port=30907

--- a/docs/source/openshift/index.adoc
+++ b/docs/source/openshift/index.adoc
@@ -1,10 +1,12 @@
+include::variables.adoc[]
+
 = Interacting with OpenShift
 :icons:
 
-Minishift creates a virtual machine and provisions a local, single-node OpenShift cluster in this VM.
-The following sections describe how Minishift can assist you in interacting and configuring your local OpenShift cluster.
+{project} creates a virtual machine and provisions a local, single-node OpenShift cluster in this VM.
+The following sections describe how {project} can assist you in interacting and configuring your local OpenShift cluster.
 
-For details about managing the Minishift VM, see the xref:../using/managing-minishift.adoc#[Managing Minishift] section.
+For details about managing the {project} VM, see the xref:../using/managing-minishift.adoc#[Managing {project}] section.
 
 - xref:../openshift/openshift-client-binary.adoc#[Using the OpenShift Client Binary]
 - xref:../openshift/exposing-services.adoc#[Exposing Services]

--- a/docs/source/openshift/openshift-client-binary.adoc
+++ b/docs/source/openshift/openshift-client-binary.adoc
@@ -14,7 +14,7 @@ toc::[]
 The `minishift start` command creates an OpenShift cluster using the link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[cluster up] approach.
 For this purpose it copies the *oc* binary onto your host.
 
-The *oc* binary is located in the  *_~/.minishift/cache/oc/{openshift-version}_* directory, assuming that you use Minishift's default version of OpenShift.
+The *oc* binary is located in the  *_~/.minishift/cache/oc/{openshift-version}_* directory, assuming that you use {project}'s default version of OpenShift.
 You can add this binary to your `PATH` using xref:../command-ref/minishift_oc-env.adoc#[`minishift oc-env`], which displays the command you need to type into your shell.
 
 The output of `minishift oc-env` differs depending on the operating system and the shell type.
@@ -27,12 +27,12 @@ export PATH="/Users/john/.minishift/cache/oc/v1.5.0:$PATH"
 ----
 
 [[minishift-oc-context]]
-== Minishift CLI Profile
+== {project} CLI Profile
 
-As a part of the `minishift start` command, a Minishift https://docs.openshift.org/latest/cli_reference/manage_cli_profiles.html[CLI profile] is also created.
+As part of the `minishift start` command, a https://docs.openshift.org/latest/cli_reference/manage_cli_profiles.html[CLI profile] named *minishift* is also created.
 This profile, also known as a _context_, contains the configuration to communicate with your OpenShift cluster.
 
-Minishift activates this context automatically, but if you need to switch back to it after, for example, logging into another OpenShift instance, you can run:
+{project} activates this context automatically, but if you need to switch back to it after, for example, logging into another OpenShift instance, you can run:
 
 ----
 $ oc config use-context minishift
@@ -74,13 +74,13 @@ $ oc config view
 [[access-web-console]]
 == Accessing the Web Console
 
-To access the link:https://docs.openshift.org/latest/architecture/infrastructure_components/web_console.html[OpenShift Web console], you can run this command in a shell after starting Minishift to get the URL of the Web console:
+To access the link:https://docs.openshift.org/latest/architecture/infrastructure_components/web_console.html[OpenShift Web console], you can run this command in a shell after starting {project} to get the URL of the Web console:
 
 ----
 $ minishift console --url
 ----
 
-Alternatively, after starting Minishift, you can use the following command to directly open the console in a browser:
+Alternatively, after starting {project}, you can use the following command to directly open the console in a browser:
 
 ----
 $ minishift console
@@ -100,7 +100,7 @@ For more information refer also to xref:../openshift/exposing-services.adoc#[Exp
 [[view-openshift-logs]]
 == Viewing OpenShift Logs
 
-To access OpenShift logs, run the `logs` command after starting Minishift:
+To access OpenShift logs, run the `logs` command after starting {project}:
 
 ----
 $ minishift logs
@@ -161,7 +161,7 @@ $ minishift openshift config set --patch "{\"corsAllowedOrigins\": [\".*\"]}"
 In this example, you change the OpenShift routing suffix in the master configuration.
 
 If you use a static routing suffix, you can set the `routing-suffix` flag as part of the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
-By default, Minishift uses a dynamic routing prefix based on http://nip.io/[nip.io], in which the IP address of the VM is a part of the routing suffix, for example *192.168.99.103.nip.io*.
+By default, {project} uses a dynamic routing prefix based on http://nip.io/[nip.io], in which the IP address of the VM is a part of the routing suffix, for example *192.168.99.103.nip.io*.
 
 If you experience issues with *nip.io*, you can use http://xip.io/[xip.io], which is based on the same principles.
 
@@ -171,5 +171,5 @@ To set the routing suffix to *xip.io*, run the following command:
 $ minishift openshift config set --patch '{"routingConfig": {"subdomain": "<IP-ADDRESS>.xip.io"}}'
 ----
 
-Make sure to replace `IP-ADDRESS` in the above example with the IP address of your Minishift VM.
+Make sure to replace `IP-ADDRESS` in the above example with the IP address of your {project} VM.
 You can retrieve the IP address by running the xref:../command-ref/minishift_ip.adoc#[`minishift ip`] command.

--- a/docs/source/openshift/openshift-docker-registry.adoc
+++ b/docs/source/openshift/openshift-docker-registry.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 = Accessing the OpenShift Docker Registry
 :icons:
 :toc: macro
@@ -15,8 +17,8 @@ Images present in the registry can directly be used for applications, speeding u
 [[login-to-registry]]
 == Logging Into the Registry
 
-. Start Minishift and add the *oc* binary to the PATH. For a detailed example, see the xref:../getting-started/quickstart.adoc#[Minishift Quickstart] section.
-. Make sure your shell is configured to xref:../using/docker-daemon.adoc#[reuse the Minishift docker daemon].
+. Start {project} and add the *oc* binary to the PATH. For a detailed example, see the xref:../getting-started/quickstart.adoc#[{project} Quickstart] section.
+. Make sure your shell is configured to xref:../using/docker-daemon.adoc#[reuse the {project} docker daemon].
 . Log into the OpenShift Docker registry.
 +
 ----
@@ -29,7 +31,7 @@ Images present in the registry can directly be used for applications, speeding u
 The following example shows how to deploy an OpenShift application directly from a locally-built docker image.
 This example uses the OpenShift project *myproject*. This project is automatically created by `minishift start`.
 
-. Make sure your shell is configured to xref:../using/docker-daemon.adoc#[reuse the Minishift docker daemon].
+. Make sure your shell is configured to xref:../using/docker-daemon.adoc#[reuse the {project} docker daemon].
 . Build the docker image as usual.
 . Tag the image against the OpenShift registry.
 +

--- a/docs/source/troubleshooting/index.adoc
+++ b/docs/source/troubleshooting/index.adoc
@@ -1,10 +1,12 @@
-= Troubleshooting Minishift
+include::variables.adoc[]
+
+= Troubleshooting {project}
 :icons:
 
 [[troubleshooting-overview]]
 == Overview
 
-This section contains solutions to common problems that you might encounter while setting up and using Minishift.
+This section contains solutions to common problems that you might encounter while setting up and using {project}.
 
 - xref:../troubleshooting/troubleshooting-getting-started.adoc#[Troubleshooting Getting Started]
 - xref:../troubleshooting/troubleshooting-driver-plugins.adoc#[Troubleshooting Driver Plug-ins]

--- a/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
+++ b/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 [[troubleshooting-driver-plugins]]
 = Troubleshooting Driver Plug-ins
 :icons:
@@ -10,7 +12,7 @@ toc::[]
 [[troubleshooting-driver-plugins-overview]]
 == Overview
 
-This section contains solutions to common problems that you might encounter while configuring the driver plug-ins for Minishift.
+This section contains solutions to common problems that you might encounter while configuring the driver plug-ins for {project}.
 
 [[troubleshooting-driver-kvm]]
 == KVM/libvirt
@@ -22,7 +24,7 @@ If you use `virsh` on KVM/libvirt to create snapshots in your development workfl
 
 ----
 $ minishift delete
-Deleting the Minishift VM...
+Deleting the {project} VM...
 Error deleting the VM:  [Code-55] [Domain-10] Requested operation is not valid: cannot delete inactive domain with 4 snapshots
 ----
 
@@ -37,7 +39,7 @@ Workaround: To delete the snapshots, you need to perform the following steps.
 $ sudo virsh snapshot-delete --metadata minishift <snapshot-name>
 ----
 
-.  Undefine the Minishift domain.
+.  Undefine the {project} domain.
 +
 
 ----
@@ -45,7 +47,7 @@ $ sudo virsh undefine minishift
 ----
 +
 
-You can now run `minishft delete` to delete the VM and restart Minishift.
+You can now run `minishift delete` to delete the VM and restart {project}.
 
 [NOTE]
 ====
@@ -102,16 +104,16 @@ $ systemctl enable virtlogd
 === Domain 'minishift' already exists...
 
 If you try `minishift start` and the this error appears, ensure that you use `minishift delete` to delete the VMs that you created earlier.
-However, if this fails and you want to completely clean up Minishift and start fresh, do the following:
+However, if this fails and you want to completely clean up {project} and start fresh, do the following:
 
-. Check if any existing Minishift VM are running:
+. Check if any existing {project} VM are running:
 +
 
 ----
 $ sudo virsh list --all
 ----
 
-. If any Minishift VM is running, stop it:
+. If any {project} VM is running, stop it:
 +
 
 ----
@@ -132,7 +134,7 @@ $ sudo virsh undefine minishift
  $ rm -rf ~/.minishift/machines
 ----
 
-In case all of this fails, you might want to xref:../getting-started/uninstalling.adoc#[uninstall Minishift] and do a fresh install of Minishift.
+In case all of this fails, you might want to xref:../getting-started/uninstalling.adoc#[uninstall {project}] and do a fresh install of {project}.
 
 [[troubleshooting-driver-xhyve]]
 == xhyve
@@ -146,7 +148,7 @@ The problem is likely that the xhyve driver is not able to clean up *vmnet* when
 * *_/var/db/dhcpd_leases_*
 * *_/Library/Preferences/SystemConfiguration/com.apple.vmnet.plist_*
 
-Reset the Minishift-specific IP database, ensure that you remove the `minishift` entry section from the `dhcpd_leases` file, and reboot your system.
+Reset the {project}-specific IP database, ensure that you remove the `minishift` entry section from the `dhcpd_leases` file, and reboot your system.
 
 ----
 {
@@ -177,7 +179,7 @@ To avoid this issue, it is recommended to use VirtualBox 5.1.12 or later.
 [[insufficient-privileges]]
 === Hyper-V commands must be run as an Administrator
 
-If you run Minishift with Hyper-V on Windows as a normal user or as a user with Administrator privileges, you might encounter the following error:
+If you run {project} with Hyper-V on Windows as a normal user or as a user with Administrator privileges, you might encounter the following error:
 
 ----
 Error starting the VM: Error creating the VM. Error with pre-create check: "Hyper-V commands must be run as an Administrator".
@@ -207,9 +209,9 @@ Now you can run the Hyper-V commands as a normal user.
 For more options for Hyper-V see link:https://blogs.msdn.microsoft.com/virtual_pc_guy/2010/09/28/creating-a-hyper-v-administrators-local-group-through-powershell[creating Hyper-V administrators local group].
 
 [[hyperv-fails-openvpn]]
-=== Minishift running with Hyper-V fails when connected to OpenVPN
+=== {project} running with Hyper-V fails when connected to OpenVPN
 
-If you try to use Minishift with Hyper-V using an external virtual switch while you are connected to a VPN such as OpenVPN, Minishift might fail to provision the VM.
+If you try to use {project} with Hyper-V using an external virtual switch while you are connected to a VPN such as OpenVPN, {project} might fail to provision the VM.
 
 Cause: Hyper-V networking might not route the network traffic in both directions properly when connected to a VPN.
 

--- a/docs/source/troubleshooting/troubleshooting-getting-started.adoc
+++ b/docs/source/troubleshooting/troubleshooting-getting-started.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 [[troubleshooting-getting-started]]
 = Troubleshooting Getting Started
 :icons:
@@ -10,12 +12,12 @@ toc::[]
 [[troubleshooting-getting-started-overview]]
 == Overview
 
-This section contains solutions to common problems that you might encounter while installing, configuring, and updating Minishift.
+This section contains solutions to common problems that you might encounter while installing, configuring, and updating {project}.
 
 [[github-api-rate-limit-exceeded]]
 == GitHub API rate limit exceeded
 
-When you run `minishift start` or `minishift update`, it makes requests to the GitHub API to check for new version and potentially download new versions of Minishift or the OpenShift client tool `oc`.
+When you run `minishift start` or `minishift update`, it makes requests to the GitHub API to check for new version and potentially download new versions of {project} or the OpenShift client tool `oc`.
 
 Sometimes, during these requests, you might receive a 403 forbidden status from GitHub if your request exceeds the rate limit for your IP address. In this case, the command will fail and you will receive an error message. For example:
 
@@ -37,13 +39,13 @@ After you generate the API token, you need to set the `MINISHIFT_GITHUB_API_TOKE
 $ export MINISHIFT_GITHUB_API_TOKEN=<token_ID>
 ----
 
-Replace `<token_ID>` with your token. You can also add this variable in your shell profile so you don't need to manually set the variable every time you run a Minishift command.
+Replace `<token_ID>` with your token. You can also add this variable in your shell profile so you don't need to manually set the variable every time you run a {project} command.
 
 [[minshift-startup-check-failed]]
-== Minishift startup check failed
+== {project} startup check failed
 
-While Minishift starts, it runs several startup checks to make sure that the Minishift VM and the OpenShift Cluster are able to start without any issues.
-If any configuration is incorrect or missing, the startup checks fail and Minishift does not start.
+While {project} starts, it runs several startup checks to make sure that the {project} VM and the OpenShift Cluster are able to start without any issues.
+If any configuration is incorrect or missing, the startup checks fail and {project} does not start.
 
 The following sections describe the different startup checks.
 
@@ -53,7 +55,7 @@ The following sections describe the different startup checks.
 One of the startup checks verifies that the relevant driver plug-in is configured correctly.
 If this startup check fails, review the xref:../getting-started/setting-up-driver-plugin.adoc#[setting up the driver plug-in] topic and configure the driver.
 
-If you want to force Minishift to start despite a failing driver plugin-in check, you can instruct Minishift to treat these errors as warnings:
+If you want to force {project} to start despite a failing driver plugin-in check, you can instruct {project} to treat these errors as warnings:
 
 - For KVM/Libvirt on Linux, run the following command:
 +
@@ -76,10 +78,10 @@ $ minishift config set warn-check-hyperv-driver true
 [[persistent-storage-check]]
 === Persistent storage volume configuration and usage
 
-Minishift checks whether the persistent storage volume is mounted and that enough disk space is available.
-If the persistent storage volume, for example, uses more than 95% of the available disk space, Minishift will not start.
+{project} checks whether the persistent storage volume is mounted and that enough disk space is available.
+If the persistent storage volume, for example, uses more than 95% of the available disk space, {project} will not start.
 
-If you want to recover the data, you can skip this test and start Minishift to access the persistent volume:
+If you want to recover the data, you can skip this test and start {project} to access the persistent volume:
 
 ----
 $ minishift config set skip-check-storage-usage true
@@ -88,7 +90,7 @@ $ minishift config set skip-check-storage-usage true
 [[external-network-check]]
 === External network connectivity
 
-After the Minishift VM starts, it runs several network checks to verify whether external connectivity is possible from within the Minishift VM.
+After the {project} VM starts, it runs several network checks to verify whether external connectivity is possible from within the {project} VM.
 
 By default, network checks are configured to treat any errors as warnings, because of the diversity of the development environments.
 You can configure the network checks to optimize them for your environment.
@@ -109,13 +111,13 @@ $ minishift config set check-network-http-host <URL>
 ----
 
 [[minshift-update-failed-due-to-permission-denied]]
-== Permission denied error when updating Minishift
+== Permission denied error when updating {project}
 
-When updating Minishift using `minishift update`, the update process needs write permissions for the Minishift binary as well as the directory in which it is located.
+When updating {project} using `minishift update`, the update process needs write permissions for the {project} binary as well as the directory in which it is located.
 Without these permisions `minishift update` will fail.
-For example, this issue might occur when installing Minishift as root.
+For example, this issue might occur when installing {project} as root.
 
-Workaround: When updating minishift, use `sudo minishift update` (Linux/macOS).
+Workaround: When updating {project}, use `sudo minishift update` (Linux/macOS).
 
 ----
 $ which minishift

--- a/docs/source/troubleshooting/troubleshooting-misc.adoc
+++ b/docs/source/troubleshooting/troubleshooting-misc.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 [[troubleshooting-general]]
 = Troubleshooting Miscellaneous 
 :icons:
@@ -10,20 +12,20 @@ toc::[]
 [[troubleshooting-general-overview]]
 == Overview
 
-This section contains solutions to common problems that you might encounter while using various components of Minishift.
+This section contains solutions to common problems that you might encounter while using various components of {project}.
 
 [[root-filesystem-exceeds-overlay-size]]
-== The root filesystem of the Minishift VM exceeds overlay size
+== The root filesystem of the {project} VM exceeds overlay size
 
-Installing additional packages or copying large files to the root filesystem of the Minishift VM might exceed the allocated overlay size and lock the Minishift VM.
+Installing additional packages or copying large files to the root filesystem of the {project} VM might exceed the allocated overlay size and lock the {project} VM.
 
-Cause: The Minishift VM root filesystem contains core packages that are configured to optimize running the Minishift VM and containers.
+Cause: The {project} VM root filesystem contains core packages that are configured to optimize running the {project} VM and containers.
 The available storage on the root filesystem is determined by the overlay size, which is smaller than the total available storage.
 
-Workaround: Avoid installing packages or storing large files in the root filesystem of the Minishift VM.
-Instead, you can create a sub-directory in the *_mnt/sda1/_* persistent storage volume or define and mount xref:../using/host-folders.adoc#[host folders] that can share storage space between the host and the Minishift VM.
+Workaround: Avoid installing packages or storing large files in the root filesystem of the {project} VM.
+Instead, you can create a sub-directory in the *_mnt/sda1/_* persistent storage volume or define and mount xref:../using/host-folders.adoc#[host folders] that can share storage space between the host and the {project} VM.
 
-If you want to perform development tasks inside the Minishift VM, it is recommended that you use containers, which are stored in persistent storage volumes, and reuse the xref:../using/docker-daemon.adoc#[Minishift Docker daemon].
+If you want to perform development tasks inside the {project} VM, it is recommended that you use containers, which are stored in persistent storage volumes, and reuse the xref:../using/docker-daemon.adoc#[{project} Docker daemon].
 
 [[special-characters-passwords]]
 == Special characters cause passwords to fail

--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 = Add-ons
 :icons:
 :toc: macro
@@ -11,7 +13,7 @@ toc::[]
 
 NOTE: This feature is still considered experimental and might change in future releases.
 
-Minishift allows to extend the vanilla OpenShift setup provided by *cluster up* with an add-on mechanism.
+{project} allows to extend the vanilla OpenShift setup provided by *cluster up* with an add-on mechanism.
 
 Add-ons are directories that contain a text file with the *_.addon_* extension.
 The directory can also contain other resource files such as JSON template files.
@@ -42,12 +44,12 @@ Enabled add-ons are applied during xref:../command-ref/minishift_start.adoc#[`mi
 == Add-on Commands
 
 This section describes the commands that an add-on file can contain.
-They are forming a mini-DSL for Minishift add-ons:
+They are forming a mini-DSL for {project} add-ons:
 
 ssh::
-If the add-on command starts with `ssh`, you can run any command within the Minishift-managed VM.
+If the add-on command starts with `ssh`, you can run any command within the {project}-managed VM.
 This is similar to running xref:../command-ref/minishift_ssh.adoc#[`minishift ssh`] and then executing any command on the VM.
-For more information about the `minishift ssh` command usage, see xref:../using/managing-minishift.adoc#connecting-with-ssh[Connecting to the Minishift VM with SSH].
+For more information about the `minishift ssh` command usage, see xref:../using/managing-minishift.adoc#connecting-with-ssh[Connecting to the {project} VM with SSH].
 
 oc::
 If the add-on command starts with `oc`, it uses the *oc* binary that is cached on your host to execute the specified `oc` command.
@@ -60,7 +62,7 @@ If the add-on command starts with `openshift`, you can run the *openshift* binar
 This means that any file parameters or other system-specific parameters must match the environment of the container instead of your host.
 
 docker::
-If the add-on command starts with `docker`, it executes a `docker` command against the Docker daemon within the Minishift VM.
+If the add-on command starts with `docker`, it executes a `docker` command against the Docker daemon within the {project} VM.
 This is the same daemon on which the single-node OpenShift cluster is running as well.
 This is similar to running `eval $(minishift docker-env)` on your host and then executing any `docker` command.
 See also xref:../command-ref/minishift_docker-env.adoc#[`minishift docker-env`].
@@ -78,7 +80,7 @@ NOTE: Trying to use an undefined command will cause an error when the add-on get
 [[addon-variable-interpolation]]
 == Variable Interpolation
 
-Minishift allows the use of variables within the add-on commands.
+{project} allows the use of variables within the add-on commands.
 Variables have the format `#{<variable-name>}`.
 The following example shows how the OpenShift routing suffix can be interpolated into an `openshift` command to create a new certificate as part of securing the OpenShift registry.
 The used variable `#{routing-suffix}` is part of the built-in add-on variables.
@@ -109,7 +111,7 @@ The following table shows these variables.
 |Variable |Description
 
 |ip
-|IP of the Minishift VM.
+|IP of the {project} VM.
 
 |routing-suffix
 |OpenShift routing suffix for the application.
@@ -160,7 +162,7 @@ Multiple variables need to be comma separated.
 [[default-addons]]
 == Default Add-ons
 
-Minishift provides a set of built-in add-ons that offer some common OpenShift customization to assist with development.
+{project} provides a set of built-in add-ons that offer some common OpenShift customization to assist with development.
 To install the default add-ons, run:
 
 ----
@@ -326,7 +328,7 @@ You can also write metadata in multiple line.
 ----
 ====
 
-NOTE: You can also edit your add-on directly in the Minishift add-on install directory *_$MINISHIFT_HOME/addons_*.
+NOTE: You can also edit your add-on directly in the {project} add-on install directory *_$MINISHIFT_HOME/addons_*.
 Be aware that if there is an error in the add-on, it will not show when you run any `addons` commands, and it will not be applied during the `minishift start` process.
 
 To provide add-on remove instructions, you can create text file with the extension *_.addon.remove_*, for example *_admin-user.addon.remove_*.

--- a/docs/source/using/docker-daemon.adoc
+++ b/docs/source/using/docker-daemon.adoc
@@ -1,4 +1,6 @@
-= Minishift Docker daemon
+include::variables.adoc[]
+
+= {project} Docker daemon
 :icons:
 :toc: macro
 :toc-title:
@@ -9,15 +11,15 @@ toc::[]
 [[reusing-docker-daemon]]
 == Reusing the Docker Daemon
 
-When running OpenShift in a single VM, you can reuse the Docker daemon managed by Minishift for other Docker use-cases as well.
-By using the same docker daemon as Minishift, you can speed up your local development.
+When running OpenShift in a single VM, you can reuse the Docker daemon managed by {project} for other Docker use-cases as well.
+By using the same docker daemon as {project}, you can speed up your local development.
 
-In order to configure your console to reuse the Minishift Docker dameon, follow these steps:
+In order to configure your console to reuse the {project} Docker dameon, follow these steps:
 
 . Make sure that you have the Docker client binary installed on your machine.
 For information about specific binary installations for your operating system, see the link:https://docs.docker.com/engine/installation/[Docker installation] site.
 
-. Start Minishift with the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
+. Start {project} with the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
 
 . Run the xref:../command-ref/minishift_docker-env.adoc#[`minishift docker-env`] command to display the command you need to type into your shell in order to configure your Docker client.
 The command output will differ depending on OS and shell type.

--- a/docs/source/using/host-folders.adoc
+++ b/docs/source/using/host-folders.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 = Host Folders
 :icons:
 :toc: macro
@@ -9,7 +11,7 @@ toc::[]
 [[host-folders-overview]]
 == Overview
 
-Host folders are directories on the host which are shared between the host and the Minishift VM.
+Host folders are directories on the host which are shared between the host and the {project} VM.
 They allow for a two way file synchronization between host and VM.
 The following sections discuss the various types of host folders, driver provided host folders, as well as the `minishift hostfolder` command.
 
@@ -46,9 +48,9 @@ It requires VirtualBox link:https://www.virtualbox.org/manual/ch04.html[Guest Ad
 ====
 
 [[minishift-hostfolder-command]]
-== Minishift hostfolder Command
+== {project} hostfolder Command
 
-Minishift provides the xref:../command-ref/minishift_hostfolder.adoc#[`minishift hostfolder`] command to list, add, mount, unmount and remove host folders.
+{project} provides the xref:../command-ref/minishift_hostfolder.adoc#[`minishift hostfolder`] command to list, add, mount, unmount and remove host folders.
 In contrast to the driver-provided host folders, you can use the `hostfolder` command to mount multiple shared folders onto custom specified mount points.
 
 [NOTE]
@@ -84,7 +86,7 @@ Name        Mountpoint            Remote path              Mounted
 myshare     /mnt/sda1/myshare     //192.168.1.82/MYSHARE   N
 ----
 
-In this example, there is a host folder with the name *_myshare_* which mounts *_//192.168.1.82/MYSHARE_* onto *_/mnt/sda1/myshare_* in the Minishift VM.
+In this example, there is a host folder with the name *_myshare_* which mounts *_//192.168.1.82/MYSHARE_* onto *_/mnt/sda1/myshare_* in the {project} VM.
 The share is currently not mounted.
 
 NOTE: The remote path must be reachable from within the VM.
@@ -124,9 +126,9 @@ WARNING: When you use the Boot2Docker ISO with the VirtualBox driver, VirtualBox
 ==== Instance-Specific Host Folders
 
 By default, host folder definitions are persistent, similar to other xref:../using/managing-minishift.adoc#persistent-configuration[persistent configuration] options.
-This means that these host folder definitions will survive the deletion and subsequent re-creation of a Minishift VM.
+This means that these host folder definitions will survive the deletion and subsequent re-creation of a {project} VM.
 
-In some cases you might want to define a host folder just for a specific Minishift instance.
+In some cases you might want to define a host folder just for a specific {project} instance.
 To do so, you can use the `instance-only` flag of the xref:../command-ref/minishift_hostfolder_add.adoc#[`minishift hostfolder add`] command.
 Host folder definition that are created with the `instance-only` flag will be removed together with any other instance-specific state during xref:../command-ref/minishift_delete.adoc#[`minishift delete`].
 
@@ -158,13 +160,13 @@ $ minishift ssh "ls -al /mnt/sda1/myshare"
 ==== Auto-Mounting Host Folders
 
 Host folders can also be mounted automatically each time you run xref:../command-ref/minishift_start.adoc#[`minishift start`].
-To set auto-mounting, you need to set the `hostfolder-automount` option in the Minishift configuration file.
+To set auto-mounting, you need to set the `hostfolder-automount` option in the {project} configuration file.
 
 ----
 $ minishift config set hostfolders-automount true
 ----
 
-After the `hostfolders-automount` option is set, Minishift will attempt to mount all defined host folders during `minishift start`.
+After the `hostfolders-automount` option is set, {project} will attempt to mount all defined host folders during `minishift start`.
 
 [[umounting-host-folders]]
 === Unmounting Host Folders
@@ -214,7 +216,7 @@ On Windows, you can install link:https://winscp.net/eng/docs/guide_windows_opens
 
 The following steps demonstrate how to mount host folders with SSHFS.
 
-. Run `ifconfig` (or `Get-NetIPAddress` on Windows) to determine the local IP address from the same network segment as your Minishift instance.
+. Run `ifconfig` (or `Get-NetIPAddress` on Windows) to determine the local IP address from the same network segment as your {project} instance.
 
 . Create a mountpoint and mount the shared folder.
 +

--- a/docs/source/using/index.adoc
+++ b/docs/source/using/index.adoc
@@ -1,12 +1,14 @@
-= Using Minishift
+include::variables.adoc[]
+
+= Using {project}
 :icons:
 
-This section describes how to use the Minishift CLI and manage your Minishift VM. It also helps troubleshooting common issues.
+This section describes how to use the {project} CLI and manage your {project} VM. It also helps troubleshooting common issues.
 
-For details about using Minishift to manage your local OpenShift cluster, see the xref:../openshift/index.adoc#[Interacting with OpenShift] section.
+For details about using {project} to manage your local OpenShift cluster, see the xref:../openshift/index.adoc#[Interacting with OpenShift] section.
 
-- xref:../using/managing-minishift.adoc#[Managing Minishift]
+- xref:../using/managing-minishift.adoc#[Managing {project}]
 - xref:../using/addons.adoc#[Add-ons]
 - xref:../using/host-folders.adoc#[Host Folders]
-- xref:../using/docker-daemon.adoc#[Minishift Docker Daemon]
+- xref:../using/docker-daemon.adoc#[{project} Docker Daemon]
 - xref:../using/profiles.adoc#[Profiles]

--- a/docs/source/using/managing-minishift.adoc
+++ b/docs/source/using/managing-minishift.adoc
@@ -1,6 +1,6 @@
 include::variables.adoc[]
 
-= Managing Minishift
+= Managing {project}
 :icons:
 :toc: macro
 :toc-title:
@@ -11,53 +11,53 @@ toc::[]
 [[managing-minishift-overview]]
 == Overview
 
-When you use Minishift, you interact with two components:
+When you use {project}, you interact with two components:
 
-- a virtual machine (VM) created by Minishift
-- the OpenShift cluster provisioned by Minishift within the VM
+- a virtual machine (VM) created by {project}
+- the OpenShift cluster provisioned by {project} within the VM
 
-The following sections contain information about managing the Minishift VM.
-For details about using Minishift to manage your local OpenShift cluster, see the xref:../openshift/index.adoc#[Interacting with OpenShift] section.
+The following sections contain information about managing the {project} VM.
+For details about using {project} to manage your local OpenShift cluster, see the xref:../openshift/index.adoc#[Interacting with OpenShift] section.
 
 [[minishift-life-cycle]]
-== Minishift Life-cycle
+== {project} Life-cycle
 
 [[minishift-start-overview]]
-=== Minishift start Command
+=== {project} start Command
 
-The xref:../command-ref/minishift_start.adoc#[`minishift start`] command creates and configures the Minishift VM and provisions a local, single-node OpenShift cluster within the Minishift VM.
+The xref:../command-ref/minishift_start.adoc#[`minishift start`] command creates and configures the {project} VM and provisions a local, single-node OpenShift cluster within the {project} VM.
 
 The command also copies the *oc* binary to your host so that you can interact with OpenShift through the `oc` command-line tool or through the Web console, which can be accessed through the URL provided in the output of the `minishift start` command.
 
 [[minishift-stop-overview]]
-=== Minishift stop Command
+=== {project} stop Command
 
-The xref:../command-ref/minishift_stop.adoc#[`minishift stop`] command stops your OpenShift cluster and shuts down the Minishift VM, but preserves the OpenShift cluster state.
+The xref:../command-ref/minishift_stop.adoc#[`minishift stop`] command stops your OpenShift cluster and shuts down the {project} VM, but preserves the OpenShift cluster state.
 
-Starting Minishift again will restore the OpenShift cluster, allowing you to continue working from the last session.
+Starting {project} again will restore the OpenShift cluster, allowing you to continue working from the last session.
 However, you must enter the same parameters that you used in the original start command.
 
 Efforts to further refine this experience are in progress.
 For details, see the GitHub issue link:https://github.com/minishift/minishift/issues/179[#179].
 
 [[minishift-delete-overview]]
-=== Minishift delete Command
+=== {project} delete Command
 
-The xref:../command-ref/minishift_delete.adoc#[`minishift delete`] command deletes the OpenShift cluster, and also shuts down and deletes the Minishift VM.
+The xref:../command-ref/minishift_delete.adoc#[`minishift delete`] command deletes the OpenShift cluster, and also shuts down and deletes the {project} VM.
 No data or state are preserved.
 
 [[choosing-iso-image]]
 == Choosing the ISO Image
 
-When you start Minishift, it downloads a live ISO image that the hypervisor uses to provision the Minishift VM.
+When you start {project}, it downloads a live ISO image that the hypervisor uses to provision the {project} VM.
 
 The following ISO images are available:
 
-- link:https://github.com/minishift/minishift-b2d-iso/releases[Minishift Boot2Docker] (Default).
+- link:https://github.com/minishift/minishift-b2d-iso/releases[{project} Boot2Docker] (Default).
 This ISO image is based on link:https://github.com/boot2docker/boot2docker[Boot2Docker], which is a lightweight Linux distribution customized to run Docker containers.
 The image size is small and optimized for development but not for production.
 
-- link:https://github.com/minishift/minishift-centos-iso/releases[Minishift CentOS].
+- link:https://github.com/minishift/minishift-centos-iso/releases[{project} CentOS].
 This ISO image is based on link:https://www.centos.org/[CentOS], which is an enterprise-ready Linux distribution that more closely resembles a production environment.
 The image size is larger than the Boot2Docker ISO image.
 
@@ -66,10 +66,10 @@ This ISO image is provided by link:https://github.com/kubernetes/minikube/[Minik
 Minikube ISO image also provides alternate container runtime e.g. cri-o and rkt along with docker.
 Please check link:https://github.com/kubernetes/minikube/blob/master/docs/contributors/minikube_iso.md[Minikube documentation] for details.
 
-NOTE: Minikube ISO image use is experimental in Minishift. Work is in progress to make it as stable as CentOS and Boot2Docker ISO images.
+NOTE: Minikube ISO image use is experimental in {project}. Work is in progress to make it as stable as CentOS and Boot2Docker ISO images.
 
-By default, Minishift uses the Minishift Boot2Docker ISO image.
-To choose the Minishift CentOS ISO image instead, you can do one of the following:
+By default, {project} uses the {project} Boot2Docker ISO image.
+To choose the {project} CentOS ISO image instead, you can do one of the following:
 
 - Use the *centos* alias to download and use the latest CentOS ISO:
 +
@@ -77,39 +77,39 @@ To choose the Minishift CentOS ISO image instead, you can do one of the followin
 $ minishift start --iso-url centos
 ----
 
-- Specify explicitly the download URL of the Minishift CentOS ISO image. For example:
+- Specify explicitly the download URL of the {project} CentOS ISO image. For example:
 +
 [subs="attributes"]
 ----
 $ minishift start --iso-url https://github.com/minishift/minishift-centos-iso/releases/download/{centos-iso-version}/minishift-centos7.iso
 ----
 
-- Manually download the Minishift CentSO ISO image from the link:https://github.com/minishift/minishift-centos-iso/releases[releases page] and enter the file URI to the image:
+- Manually download the {project} CentSO ISO image from the link:https://github.com/minishift/minishift-centos-iso/releases[releases page] and enter the file URI to the image:
 +
 ----
 $ minishift start --iso-url file:///<path_to_ISO_image>
 ----
 
-NOTE: You cannot run Minishift with both ISO images concurrently.
-To switch between ISO images, delete the Minishift instance and start a new instance with the ISO image that you want to use.
+NOTE: You cannot run {project} with both ISO images concurrently.
+To switch between ISO images, delete the {project} instance and start a new instance with the ISO image that you want to use.
 
 [[runtime-options]]
 == Runtime Options
 
-The runtime behavior of Minishift can be controlled through flags, environment variables, and persistent configuration options.
+The runtime behavior of {project} can be controlled through flags, environment variables, and persistent configuration options.
 
-The following precedence order is applied to control the behavior of Minishift.
+The following precedence order is applied to control the behavior of {project}.
 Each action in the following list takes precedence over the action below it:
 
 .  Use command-line flags as specified in the xref:flags[Flags] section.
 .  Set environment variables as described in the xref:environment-variables[Environment Variables] section.
 .  Use persistent configuration options as described in the xref:persistent-configuration[Persistent Configuration] section.
-.  Accept the default value as defined by Minishift.
+.  Accept the default value as defined by {project}.
 
 [[flags]]
 === Flags
 
-You can use command line flags with Minishift to specify options and direct its behavior.
+You can use command line flags with {project} to specify options and direct its behavior.
 This has the highest precedence.
 Almost all commands have flags, although different commands might have different flags.
 Some of the commonly-used command line flags of the `minishift start` command are `cpus`, `memory` or `vm-driver`.
@@ -117,7 +117,7 @@ Some of the commonly-used command line flags of the `minishift start` command ar
 [[environment-variables]]
 === Environment Variables
 
-Minishift allows you to specify command-line flags you commonly use through environment variables.
+{project} allows you to specify command-line flags you commonly use through environment variables.
 To do so, apply the following rules to the flag you want to set as an environment variable.
 
 .  Apply `MINISHIFT_` as a prefix to the flag you want to set as an environment variable.
@@ -125,21 +125,21 @@ For example, the `vm-driver` flag of the xref:../command-ref/minishift_start.ado
 .  Use uppercase characters for the flag, so `MINISHIFT_vm-driver` in the above example becomes `MINISHIFT_VM-DRIVER`.
 .  Replace `-` with `_`, so `MINISHIFT_VM-DRIVER` becomes `MINISHIFT_VM_DRIVER`.
 
-Environment variables can be used to replace any option of any Minishift command.
+Environment variables can be used to replace any option of any {project} command.
 A common example is the URL of the ISO to be used.
 Usually, you specify it with the `iso-url` flag of the `minishift start` command.
 Applying the above rules, you can also specify this URL by setting the environment variable as `MINISHIFT_ISO_URL`.
 
-NOTE: You can also use the `MINISHIFT_HOME` environment variable, to choose a different home directory for Minishift.
-By default, Minishift places all runtime state into *_~/.minishift_*.
+NOTE: You can also use the `MINISHIFT_HOME` environment variable, to choose a different home directory for {project}.
+By default, {project} places all runtime state into *_~/.minishift_*.
 This environment variable is currently experimental and semantics might change in future releases.
 
 [[persistent-configuration]]
 === Persistent Configuration
 
-Using persistent configuration allows you to control the Minishift behavior without specifying actual command line flags, similar to the way you use environment variables.
+Using persistent configuration allows you to control the {project} behavior without specifying actual command line flags, similar to the way you use environment variables.
 
-Minishift maintains a configuration file in *_$MINISHIFT_HOME/config/config.json_*.
+{project} maintains a configuration file in *_$MINISHIFT_HOME/config/config.json_*.
 This file can be used to set commonly-used command-line flags persistently.
 
 NOTE: Persistent configuration can only be applied to the set of supported configuration options that are listed in the synopsis of the xref:../command-ref/minishift_config.adoc#[`minishift config`] sub-command.
@@ -210,9 +210,9 @@ $ export XHYVE_EXPERIMENTAL_NFS_SHARE=true
 $ minishift start --vm-driver xhyve
 ----
 
-CAUTION: Driver-specific options might overlap with values specified using Minishift-specific flags and environment variables.
+CAUTION: Driver-specific options might overlap with values specified using {project}-specific flags and environment variables.
 Examples are boot2docker URL, memory size, cpu count, and so on.
-In this case, driver-specific environment variables will override Minishift-specific settings.
+In this case, driver-specific environment variables will override {project}-specific settings.
 
 [[caching-openshift-images]]
 == Caching OpenShift images (experimental)
@@ -225,7 +225,7 @@ $ minishift config set image-caching true
 ----
 
 Once enabled, caching occurs transparently, in a background process, the first time you use the xref:../command-ref/minishift_start#[`minishift start`] command.
-Once the images are cached under _$MINISHIFT_HOME/cache/images_, successive Minishift VM creations will use these cached images.
+Once the images are cached under _$MINISHIFT_HOME/cache/images_, successive {project} VM creations will use these cached images.
 
 Each time an image exporting background process runs, a log file is generated under _$MINISHIFT_HOME/logs_ which can be used to verify the progress of the export.
 
@@ -244,7 +244,7 @@ You can track the progress on this feature on the GitHub issue link:https://gith
 
 As part of the OpenShift cluster provisioning, 100 link:https://docs.openshift.org/latest/dev_guide/persistent_volumes.html[persistent volumes] are created for your OpenShift cluster.
 This allows applications to make link:https://docs.openshift.org/latest/dev_guide/persistent_volumes.html#persistent-volumes-claims-as-volumes-in-pods[persistent volumes claims].
-The location of the persistent data is determined in the `host-pv-dir` flag of the xref:../command-ref/minishift_start.adoc#[`minishift start`] command and defaults to *_/var/lib/minishift/openshift.local.pv_* on the Minishift VM.
+The location of the persistent data is determined in the `host-pv-dir` flag of the xref:../command-ref/minishift_start.adoc#[`minishift start`] command and defaults to *_/var/lib/minishift/openshift.local.pv_* on the {project} VM.
 
 [[http-s-proxies]]
 == HTTP/HTTPS Proxies
@@ -276,22 +276,22 @@ If these variables are set, they are implicitly used during `minishift start` un
 
 - Using the proxy options requires that you run OpenShift version 1.5.0 or later.
 Use the `openshift-version` option to request a specific version of OpenShift.
-You can list all Minishift-compatible OpenShift versions with the xref:../command-ref/minishift_openshift_version_list.adoc#[`minishift openshift version list`] command.
+You can list all {project}-compatible OpenShift versions with the xref:../command-ref/minishift_openshift_version_list.adoc#[`minishift openshift version list`] command.
 ====
 
 [[networking]]
 == Networking
 
-The Minishift VM is exposed to the host system with a host-only IP address that can be obtained with the xref:../command-ref/minishift_ip.adoc#[`minishift ip`] command.
+The {project} VM is exposed to the host system with a host-only IP address that can be obtained with the xref:../command-ref/minishift_ip.adoc#[`minishift ip`] command.
 
 [[connecting-with-ssh]]
-== Connecting to the Minishift VM with SSH
+== Connecting to the {project} VM with SSH
 
-You can use the xref:../command-ref/minishift_ssh.adoc#[`minishift ssh`] command to interact with the Minishift VM.
+You can use the xref:../command-ref/minishift_ssh.adoc#[`minishift ssh`] command to interact with the {project} VM.
 
-You can run `minishift ssh` without a sub-command to open an interactive shell and run commands on the Minishift VM in the same way that you run commands interactively on any remote machine using SSH.
+You can run `minishift ssh` without a sub-command to open an interactive shell and run commands on the {project} VM in the same way that you run commands interactively on any remote machine using SSH.
 
-You can also run `minishift ssh` with a sub-command to send the sub-command directly to the Minishift VM and return the result to your local shell.
+You can also run `minishift ssh` with a sub-command to send the sub-command directly to the {project} VM and return the result to your local shell.
 For example:
 
 ----
@@ -303,7 +303,7 @@ CONTAINER    IMAGE                   COMMAND                CREATED        STATU
 [[experimental-features]]
 == Experimental Features
 
-If you want to get early access to some upcoming features and experiment, you can enable some of those in Minishift.
+If you want to get early access to some upcoming features and experiment, you can enable some of those in {project}.
 
 You do this by setting the environment variable `MINISHIFT_ENABLE_EXPERIMENTAL`, which makes additional flags available:
 
@@ -314,13 +314,13 @@ $ export MINISHIFT_ENABLE_EXPERIMENTAL=y
 [IMPORTANT]
 ====
 Experimental features are not officially supported, and might break or result in unexpected behavior.
-To share your feedback on these features, you are welcome to link:https://github.com/minishift/minishift#community[contact the Minishift community].
+To share your feedback on these features, you are welcome to link:https://github.com/minishift/minishift#community[contact the {project} community].
 ====
 
 [[enabling-experimental-oc-flags]]
 === Enabling experimental `oc cluster up` flags in `minishift start`
 
-By default, Minishift does not expose all link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[`oc cluster up`] flags in the Minishift CLI.
+By default, {project} does not expose all link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[`oc cluster up`] flags in the {project} CLI.
 
 You can set the `MINISHIFT_ENABLE_EXPERIMENTAL` environment variable to enable the following options for the xref:../command-ref/minishift_start.adoc#[`minishift start`] command:
 
@@ -328,7 +328,7 @@ You can set the `MINISHIFT_ENABLE_EXPERIMENTAL` environment variable to enable t
 Enables provisioning the OpenShift link:https://docs.openshift.org/latest/architecture/service_catalog/index.html[service catalog].
 
 `extra-clusterup-flags`::
-Enables passing flags that are not directly exposed in the Minishift CLI directly to `oc cluster up`.
+Enables passing flags that are not directly exposed in the {project} CLI directly to `oc cluster up`.
 
 
 [[hyperv-static-ip]]
@@ -340,7 +340,7 @@ For Hyper-V a functionality is provided to assign an IP address on startup using
 [IMPORTANT]
 ====
 -  While the default image is B2D, this only works with the CentOS/RHEL based image in combination with Hyper-V. The B2D image experiences
-   a problem when the values are being send to the Minishift instance and consumed by the B2D iso. We are looking into the issue and hope
+   a problem when the values are being send to the {project} instance and consumed by the B2D iso. We are looking into the issue and hope
    to provide a solution in the coming future.
 ====
 

--- a/docs/source/using/profiles.adoc
+++ b/docs/source/using/profiles.adoc
@@ -1,4 +1,6 @@
-= Minishift Profiles
+include::variables.adoc[]
+
+= {project} Profiles
 :icons:
 :toc: macro
 :toc-title:
@@ -9,13 +11,13 @@ toc::[]
 [[pofile-overview]]
 == Overview
 
-Minishift allows to create multiple instances of Minishift.
-Each Minishift instance can be created with different configurations and users can switch between different instances.
+{project} allows to create multiple instances of {project}.
+Each {project} instance can be created with different configurations and users can switch between different instances.
 
 [[create-profile]]
 == Create profile
 
-You can create a new instance of Minishift with xref:../command-ref/minishift_start.adoc#[`minishift start --profile`] command.
+You can create a new instance of {project} with xref:../command-ref/minishift_start.adoc#[`minishift start --profile`] command.
 
 NOTE: The default profile is `minishift`. It will be present by-default and user does not need to create it specifically.
 


### PR DESCRIPTION
Add a static `project` attribute to the generated variables.adoc file and refer to Minishift as a project with this attribute -- this allows for easier project naming downstream.

Ensure variables.adoc is added to the troubleshooting section directory.

Add `minikube-iso-version` attribute to variables.adoc.