### PR TITLE
Issue #1535 Add error checks into integration tests

### DIFF
--- a/test/integration/proxy/proxy.go
+++ b/test/integration/proxy/proxy.go
@@ -101,6 +101,7 @@ func getIP() (string, error) {
 }
 
 func SetProxy() error {
+	var err error
 	port := getPort()
 	ip, err := getIP()
 	if err != nil {
@@ -110,17 +111,26 @@ func SetProxy() error {
 	go startProxy(port)
 
 	address := fmt.Sprintf("http://%v:%v", ip, port)
-	os.Setenv("MINISHIFT_HTTP_PROXY", address)
+	err = os.Setenv("MINISHIFT_HTTP_PROXY", address)
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("  INFO: this feature is now using MINISHIFT_HTTP_PROXY=%s\n", os.Getenv("MINISHIFT_HTTP_PROXY"))
 
 	return nil
 }
 
 func UnsetProxy() error {
-	os.Unsetenv("MINISHIFT_HTTP_PROXY")
-	if proxyListener != nil {
-		proxyListener.Close()
+	var err error
+	err = os.Unsetenv("MINISHIFT_HTTP_PROXY")
+	if err != nil {
+		return err
 	}
 
-	return nil
+	if proxyListener != nil {
+		err = proxyListener.Close()
+	}
+
+	return err
 }

--- a/test/integration/util/integration_logger.go
+++ b/test/integration/util/integration_logger.go
@@ -61,8 +61,7 @@ func StartLog(logPath string) error {
 }
 
 func CloseLog() error {
-	err := logFile.Close()
-	return err
+	return logFile.Close()
 }
 
 func LogMessage(messageInfo, message string) error {


### PR DESCRIPTION
Tests will now provide more information when an error happens, which should save some time when issues on machines happens.

One problem is, that logFile.Close() returns an error, no idea why and the error message is not really useful: `invalid argument`.