### PR TITLE
Issue #1567 Make CONTRIBUTING.adoc more discoverable

### DIFF
--- a/docs/source/contributing/index.adoc
+++ b/docs/source/contributing/index.adoc
@@ -5,6 +5,7 @@ include::variables.adoc[]
 
 Join the {project} community! Learn about the link:https://github.com/minishift/minishift/blob/master/README.adoc[project] and how to link:https://github.com/minishift/minishift/blob/master/CONTRIBUTING.adoc[contribute].
 
+- link:https://github.com/minishift/minishift/blob/master/CONTRIBUTING.adoc#contribution-guidelines[Contribution guidelines]
 - xref:../contributing/developing.adoc#[Developing {project}]
 - xref:../contributing/ci.adoc#[{project} CI]
 - xref:../contributing/writing-docs.adoc#[Writing Documentation]


### PR DESCRIPTION
Let me know if this isn't what was desired or if any changes need to take place.

Notes:

Linked as "Contribution guidelines" in order to be consistent with the header casing in **_CONTRIBUTING.adoc_**. Linked directly to the `#contributing-guidelines` anchor in order to make the guidelines immediately visible and clear when the link is visited.