### PR TITLE
Issue #1579 Remove colons from filename of integration test log

### DIFF
--- a/test/integration/util/integration_logger.go
+++ b/test/integration/util/integration_logger.go
@@ -45,7 +45,7 @@ func init() {
 
 func StartLog(logPath string) error {
 	t := time.Now()
-	logFileName := fmt.Sprintf("integration_%d-%d-%d_%02d:%02d:%02d.log", t.Year(), t.Month(),
+	logFileName := fmt.Sprintf("integration_%d-%d-%d_%02d-%02d-%02d.log", t.Year(), t.Month(),
 		t.Day(), t.Hour(), t.Minute(), t.Second())
 	logPath = path.Join(logPath, logFileName)
 	logFile, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)


### PR DESCRIPTION
Quick fix for #1579 which causes problems on Windows machines.