### PR TITLE
Issue #1600 Restructuring the usage topic

### DIFF
--- a/docs/source/_topic_map.yml
+++ b/docs/source/_topic_map.yml
@@ -25,8 +25,10 @@ Topics:
     Topics:
       - Name: Overview
         File: index
-      - Name: Managing Minishift
-        File: managing-minishift
+      - Name: Basic Usage
+        File: basic-usage
+      - Name: Image Caching
+        File: image-caching
       - Name: Add-ons
         File: addons
       - Name: Host Folders
@@ -35,6 +37,8 @@ Topics:
         File: docker-daemon
       - Name: Profiles
         File: profiles
+      - Name: Experimental Features
+        File: experimental-features
   - Name: Interacting with OpenShift
     Dir: openshift
     Topics:

--- a/docs/source/contributing/writing-docs.adoc
+++ b/docs/source/contributing/writing-docs.adoc
@@ -65,7 +65,7 @@ By default, the documentation is built in a Docker container.
 This way you do not need to install all the required dependencies on your development machine.
 All you need is a running Docker daemon.
 In case you don't have one, use {project} itself.
-For more information, see xref:../using/docker-daemon.adoc#reusing-docker-daemon[reusing the Docker daemon].
+For more information, see xref:../using/docker-daemon.adoc#[reusing the Docker daemon].
 
 To generate the documentation into the *_docs/build_* directory, run:
 

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -13,7 +13,7 @@ toc::[]
 == Overview
 
 This section contains a brief demo of {project} and of the provisioned OpenShift cluster.
-For details on the usage of {project}, see the xref:../using/managing-minishift.adoc#[Managing {project}] section.
+For details on the usage of {project}, see the xref:../using/basic-usage.adoc#[Basic Usage] section.
 
 The interaction with OpenShift is with the command-line tool _oc_ which is copied to your host.
 For more information on how {project} can assist you in interacting with and configuring your local OpenShift instance, see the xref:../openshift/openshift-client-binary.adoc#[OpenShift Client Binary] section.

--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -163,7 +163,7 @@ To use {project} with Hyper-V:
 
 . Add the user to the local Hyper-V Administrators group.
 +
-NOTE: This is required to allow the user to create and delete virtual machines with the Hyper-V Management API. 
+NOTE: This is required to allow the user to create and delete virtual machines with the Hyper-V Management API.
 For more information, see xref:../troubleshooting/troubleshooting-driver-plugins.adoc#insufficient-privileges[Hyper-V commands must be run as an Administrator]
 
 . Add an link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/connect-to-network[External Virtual Switch].
@@ -171,7 +171,7 @@ For more information, see xref:../troubleshooting/troubleshooting-driver-plugins
 NOTE: Verify that you pair the virtual switch with a network card (wired or wireless) that is connected to the network.
 
 . Set the environment variable `HYPERV_VIRTUAL_SWITCH` to the name of the external virtual switch you want to use for {project}.
-For more information, see xref:../using/managing-minishift.adoc#driver-specific-environment-variables[driver-specific environment variables].
+For more information, see xref:../using/basic-usage.adoc#driver-specific-environment-variables[driver-specific environment variables].
 +
 For example, on Command Prompt use:
 +

--- a/docs/source/getting-started/uninstalling.adoc
+++ b/docs/source/getting-started/uninstalling.adoc
@@ -23,7 +23,7 @@ $ minishift delete
 ----
 +
 This command deletes everything in the *_MINISHIFT_HOME/.minishift/machines/minishift_* directory.
-Other cached data and the xref:../using/managing-minishift.adoc#persistent-configuration[persistent configuration] are not removed.
+Other cached data and the xref:../using/basic-usage.adoc#persistent-configuration[persistent configuration] are not removed.
 
 .  To completely uninstall {project}, delete everything in the *_MINISHIFT_HOME_* directory (default *_~/.minishift_*) and *_~/.kube_*, run the following commands:
 +

--- a/docs/source/openshift/index.adoc
+++ b/docs/source/openshift/index.adoc
@@ -6,8 +6,8 @@ include::variables.adoc[]
 {project} creates a virtual machine and provisions a local, single-node OpenShift cluster in this VM.
 The following sections describe how {project} can assist you in interacting and configuring your local OpenShift cluster.
 
-For details about managing the {project} VM, see the xref:../using/managing-minishift.adoc#[Managing {project}] section.
-
 - xref:../openshift/openshift-client-binary.adoc#[Using the OpenShift Client Binary]
 - xref:../openshift/exposing-services.adoc#[Exposing Services]
 - xref:../openshift/openshift-docker-registry.adoc#[Accessing the OpenShift Docker Registry]
+
+For details about the basic commands to interact with the {project} VM, see the xref:../using/basic-usage.adoc#[Basic Usage] section.

--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -51,10 +51,10 @@ To do so you can specify the optional _OpenShift-Version_ metadata field. The se
 [cols="1,3"]
 |===
 | >3.6.0           | OpenShift version higher than 3.6.0 needs to be running in order to apply the add-on.
-| >=3.6.0          | OpenShift version 3.6.0 or higher needs to be running in order to apply the add-on. 
-| 3.6.0            | OpenShift version 3.6.0 needs to be running in order to apply the add-on. 
-| >=3.5.0, <3.8.0  | OpenShift version should higher or equal to 3.5.0 but lower than 3.8.0. 
-| >=3.5.0, <=3.8.0 | OpenShift version should higher or equal to 3.5.0 but lower or equal to 3.8.0. 
+| >=3.6.0          | OpenShift version 3.6.0 or higher needs to be running in order to apply the add-on.
+| 3.6.0            | OpenShift version 3.6.0 needs to be running in order to apply the add-on.
+| >=3.5.0, <3.8.0  | OpenShift version should higher or equal to 3.5.0 but lower than 3.8.0.
+| >=3.5.0, <=3.8.0 | OpenShift version should higher or equal to 3.5.0 but lower or equal to 3.8.0.
 |===
 
 NOTE: If the metadata field _OpenShift-Version_ is not specified in the add-on header, the add-on is applied against any version of OpenShift.
@@ -70,7 +70,7 @@ They are forming a mini-DSL for {project} add-ons:
 ssh::
 If the add-on command starts with `ssh`, you can run any command within the {project}-managed VM.
 This is similar to running xref:../command-ref/minishift_ssh.adoc#[`minishift ssh`] and then executing any command on the VM.
-For more information about the `minishift ssh` command usage, see xref:../using/managing-minishift.adoc#connecting-with-ssh[Connecting to the {project} VM with SSH].
+For more information about the `minishift ssh` command usage, see xref:../using/basic-usage.adoc#connecting-with-ssh[Connecting to the {project} VM with SSH].
 
 oc::
 If the add-on command starts with `oc`, it uses the *oc* binary that is cached on your host to execute the specified `oc` command.
@@ -152,7 +152,7 @@ $ minishift addons apply --addon-env PROJECT_USER=john acme
 
 The `--addon-env` flag can be specified multiple times to define more than one variables for interpolation.
 
-Specifying dynamic variables also works in conjunction with xref:../using/managing-minishift.adoc#setting-persistent-configuration-values[setting persistent configuration values].
+Specifying dynamic variables also works in conjunction with xref:../using/basic-usage.adoc#setting-persistent-configuration-values[setting persistent configuration values].
 
 ----
 $ minishift config set addon-env PROJECT_USER=john

--- a/docs/source/using/basic-usage.adoc
+++ b/docs/source/using/basic-usage.adoc
@@ -1,6 +1,6 @@
 include::variables.adoc[]
 
-= Managing {project}
+= Basic Usage
 :icons:
 :toc: macro
 :toc-title:
@@ -8,7 +8,7 @@ include::variables.adoc[]
 
 toc::[]
 
-[[managing-minishift-overview]]
+[[basic-usage-overview]]
 == Overview
 
 When you use {project}, you interact with two components:
@@ -226,31 +226,6 @@ CAUTION: Driver-specific options might overlap with values specified using {proj
 Examples are boot2docker URL, memory size, cpu count, and so on.
 In this case, driver-specific environment variables will override {project}-specific settings.
 
-[[caching-openshift-images]]
-== Caching OpenShift images (experimental)
-
-To speed up provisioning of the OpenShift cluster and to minimize network traffic, the core OpenShift images can be cached on the host.
-This feature is considered experimental and needs to be explicitly enabled using the xref:../command-ref/minishift_config_set#[`minishift config set`] command:
-
-----
-$ minishift config set image-caching true
-----
-
-Once enabled, caching occurs transparently, in a background process, the first time you use the xref:../command-ref/minishift_start#[`minishift start`] command.
-Once the images are cached under _$MINISHIFT_HOME/cache/images_, successive {project} VM creations will use these cached images.
-
-Each time an image exporting background process runs, a log file is generated under _$MINISHIFT_HOME/logs_ which can be used to verify the progress of the export.
-
-You can disable the caching of the OpenShift images by setting `image-caching` to `false` or removing the setting altogether using xref:../command-ref/minishift_config_unset#[`minishift config unset`]:
-
-----
-$ minishift config unset image-caching
-----
-
-NOTE: Image caching is considered experimental and its semantics and API is subject to change.
-The aim is to allow caching of arbitrary images, as well as using a better format for storing the images on the host.
-You can track the progress on this feature on the GitHub issue link:https://github.com/minishift/minishift/issues/952[#952].
-
 [[persistent-volumes]]
 == Persistent Volumes
 
@@ -311,89 +286,3 @@ $ minishift ssh -- docker ps
 CONTAINER    IMAGE                   COMMAND                CREATED        STATUS        NAMES
 71fe8ff16548 openshift/origin:v1.5.1 "/usr/bin/openshift s" 4 minutes ago  Up 4 minutes  origin
 ----
-
-[[experimental-features]]
-== Experimental Features
-
-If you want to get early access to some upcoming features and experiment, you can enable some of those in {project}.
-
-You do this by setting the environment variable `MINISHIFT_ENABLE_EXPERIMENTAL`, which makes additional flags available:
-
-----
-$ export MINISHIFT_ENABLE_EXPERIMENTAL=y
-----
-
-[IMPORTANT]
-====
-Experimental features are not officially supported, and might break or result in unexpected behavior.
-To share your feedback on these features, you are welcome to link:https://github.com/minishift/minishift#community[contact the {project} community].
-====
-
-[[enabling-experimental-oc-flags]]
-=== Enabling experimental `oc cluster up` flags in `minishift start`
-
-By default, {project} does not expose all link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[`oc cluster up`] flags in the {project} CLI.
-
-You can set the `MINISHIFT_ENABLE_EXPERIMENTAL` environment variable to enable the following options for the xref:../command-ref/minishift_start.adoc#[`minishift start`] command:
-
-`service-catalog`::
-Enables provisioning the OpenShift link:https://docs.openshift.org/latest/architecture/service_catalog/index.html[service catalog].
-
-`extra-clusterup-flags`::
-Enables passing flags that are not directly exposed in the {project} CLI directly to `oc cluster up`.
-
-
-[[hyperv-static-ip]]
-=== Assign IP address to Hyper-V (experimental)
-
-Since the Internal Virtual Switch for Hyper-V does not provide a DHCP offer option, an IP address needs to be provided in a different way.
-For Hyper-V a functionality is provided to assign an IP address on startup using the Data Exchange Service.
-
-[IMPORTANT]
-====
--  While the default image is B2D, this only works with the CentOS/RHEL based image in combination with Hyper-V. The B2D image experiences
-   a problem when the values are being send to the {project} instance and consumed by the B2D iso. We are looking into the issue and hope
-   to provide a solution in the coming future.
-====
-
-To make this work you need to create a Virtual Switch using NAT
-
-- link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[Set up a NAT network]
-
-
-[NOTE]
-====
-WinNAT is limited to one NAT network per host. For more details about capabilities, and limitations, please see the link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[WinNAT capabilities and limitations blog]
-====
-
-The following command will attempt to assign an IP address for use on the Internal Virtual Switch 'MyInternal'.
-
-----
-PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
-PS> $env:HYPERV_VIRTUAL_SWITCH="MyInternal"
-PS> minishift.exe start `
-  --iso-url centos `
-  --network-ipaddress 192.168.1.10 `
-  --network-gateway 192.168.1.1 `
-  --network-nameserver 8.8.8.8
-----
-
-
-If you want to use the 'DockerNAT' network, the following commands are needed to setup the correct NAT networking and assigning an IP in the range expected.
-
-----
-PS> New-NetNat -Name SharedNAT -InternalIPInterfaceAddressPrefix 10.0.75.1/24
-PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
-PS> $env:HYPERV_VIRTUAL_SWITCH="DockerNAT"
-PS> minishift.exe start `
-  --iso-url centos `
-  --network-ipaddress 10.0.75.128 `
-  --network-gateway 10.0.75.1 `
-  --network-nameserver 8.8.8.8
-----
-
-[NOTE]
-====
-- Be sure to specify a valid gateway and nameserver. Failing to do so will result in connectivity issuesi
-====
-

--- a/docs/source/using/docker-daemon.adoc
+++ b/docs/source/using/docker-daemon.adoc
@@ -8,13 +8,16 @@ include::variables.adoc[]
 
 toc::[]
 
-[[reusing-docker-daemon]]
-== Reusing the Docker Daemon
+[[docker-daemon-overview]]
+== Overview
 
 When running OpenShift in a single VM, you can reuse the Docker daemon managed by {project} for other Docker use-cases as well.
 By using the same docker daemon as {project}, you can speed up your local development.
 
-In order to configure your console to reuse the {project} Docker dameon, follow these steps:
+[[docker-daemon-configuration]]
+== Console configuration
+
+In order to configure your console to reuse the {project} Docker daemon, follow these steps:
 
 . Make sure that you have the Docker client binary installed on your machine.
 For information about specific binary installations for your operating system, see the link:https://docs.docker.com/engine/installation/[Docker installation] site.

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -1,0 +1,87 @@
+include::variables.adoc[]
+
+= Experimental Features
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 2
+
+toc::[]
+
+[[experimental-features-overview]]
+== Overview
+
+If you want to get early access to some upcoming features and experiment, you can set the environment variable `MINISHIFT_ENABLE_EXPERIMENTAL`, which makes additional features flags available:
+
+----
+$ export MINISHIFT_ENABLE_EXPERIMENTAL=y
+----
+
+[IMPORTANT]
+====
+Experimental features are not officially supported, and might break or result in unexpected behavior.
+To share your feedback on these features, you are welcome to link:https://github.com/minishift/minishift#community[contact the {project} community].
+====
+
+[[enabling-experimental-oc-flags]]
+== Enabling experimental `oc cluster up` flags
+
+By default, {project} does not expose all link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[`oc cluster up`] flags in the {project} CLI.
+
+You can set the `MINISHIFT_ENABLE_EXPERIMENTAL` environment variable to enable the following options for the xref:../command-ref/minishift_start.adoc#[`minishift start`] command:
+
+`service-catalog`::
+Enables provisioning the OpenShift link:https://docs.openshift.org/latest/architecture/service_catalog/index.html[service catalog].
+
+`extra-clusterup-flags`::
+Enables passing flags that are not directly exposed in the {project} CLI directly to `oc cluster up`.
+
+[[hyperv-static-ip]]
+== Assign IP address to Hyper-V
+
+Since the Internal Virtual Switch for Hyper-V does not provide a DHCP offer option, an IP address needs to be provided in a different way.
+For Hyper-V a functionality is provided to assign an IP address on startup using the Data Exchange Service.
+
+[IMPORTANT]
+====
+-  While the default image is B2D, this only works with the CentOS/RHEL based image in combination with Hyper-V. The B2D image experiences
+   a problem when the values are being send to the {project} instance and consumed by the B2D iso. We are looking into the issue and hope
+   to provide a solution in the coming future.
+====
+
+To make this work you need to create a link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[Virtual Switch using NAT]
+
+[NOTE]
+====
+WinNAT is limited to one NAT network per host. For more details about capabilities, and limitations, please see the link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[WinNAT capabilities and limitations blog]
+====
+
+The following command will attempt to assign an IP address for use on the Internal Virtual Switch 'MyInternal':
+
+----
+PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
+PS> $env:HYPERV_VIRTUAL_SWITCH="MyInternal"
+PS> minishift.exe start `
+  --iso-url centos `
+  --network-ipaddress 192.168.1.10 `
+  --network-gateway 192.168.1.1 `
+  --network-nameserver 8.8.8.8
+----
+
+If you want to use the 'DockerNAT' network, the following commands are needed to setup the correct NAT networking and assigning an IP in the range expected:
+
+----
+PS> New-NetNat -Name SharedNAT -InternalIPInterfaceAddressPrefix 10.0.75.1/24
+PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
+PS> $env:HYPERV_VIRTUAL_SWITCH="DockerNAT"
+PS> minishift.exe start `
+  --iso-url centos `
+  --network-ipaddress 10.0.75.128 `
+  --network-gateway 10.0.75.1 `
+  --network-nameserver 8.8.8.8
+----
+
+[NOTE]
+====
+- Be sure to specify a valid gateway and nameserver. Failing to do so will result in connectivity issues
+====

--- a/docs/source/using/host-folders.adoc
+++ b/docs/source/using/host-folders.adoc
@@ -125,7 +125,7 @@ WARNING: When you use the Boot2Docker ISO with the VirtualBox driver, VirtualBox
 [[instance-host-folders]]
 ==== Instance-Specific Host Folders
 
-By default, host folder definitions are persistent, similar to other xref:../using/managing-minishift.adoc#persistent-configuration[persistent configuration] options.
+By default, host folder definitions are persistent, similar to other xref:../using/basic-usage.adoc#persistent-configuration[persistent configuration] options.
 This means that these host folder definitions will survive the deletion and subsequent re-creation of a {project} VM.
 
 In some cases you might want to define a host folder just for a specific {project} instance.

--- a/docs/source/using/image-caching.adoc
+++ b/docs/source/using/image-caching.adoc
@@ -1,0 +1,39 @@
+include::variables.adoc[]
+
+= Image Caching
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+
+toc::[]
+
+[[image-caching-overview]]
+== Overview
+
+To speed up provisioning of the OpenShift cluster and to minimize network traffic, the core OpenShift images can be cached on the host.
+This feature is considered experimental and needs to be explicitly enabled.
+
+[[image-chaching-configuration]]
+== Image Caching Configuration
+
+To enable image caching you use the xref:../command-ref/minishift_config_set#[`minishift config set`] command:
+
+----
+$ minishift config set image-caching true
+----
+
+Once enabled, caching occurs transparently, in a background process, the first time you use the xref:../command-ref/minishift_start#[`minishift start`] command.
+Once the images are cached under _$MINISHIFT_HOME/cache/images_, successive {project} VM creations will use these cached images.
+
+Each time an image exporting background process runs, a log file is generated under _$MINISHIFT_HOME/logs_ which can be used to verify the progress of the export.
+
+You can disable the caching of the OpenShift images by setting `image-caching` to `false` or removing the setting altogether using xref:../command-ref/minishift_config_unset#[`minishift config unset`]:
+
+----
+$ minishift config unset image-caching
+----
+
+NOTE: Image caching is considered experimental and its semantics and API is subject to change.
+The aim is to allow caching of arbitrary images, as well as using a better format for storing the images on the host.
+You can track the progress on this feature on the GitHub issue link:https://github.com/minishift/minishift/issues/952[#952].

--- a/docs/source/using/index.adoc
+++ b/docs/source/using/index.adoc
@@ -3,12 +3,15 @@ include::variables.adoc[]
 = Using {project}
 :icons:
 
-This section describes how to use the {project} CLI and manage your {project} VM. It also helps troubleshooting common issues.
+This section describes how to use the {project} CLI.
+It covers the basic commands as well as advanced features like image caching, add-ons, host folders and profiles.
 
-For details about using {project} to manage your local OpenShift cluster, see the xref:../openshift/index.adoc#[Interacting with OpenShift] section.
-
-- xref:../using/managing-minishift.adoc#[Managing {project}]
+- xref:../using/basic-usage.adoc#[Basic Usage]
+- xref:../using/image-caching.adoc#[Image Caching]
 - xref:../using/addons.adoc#[Add-ons]
 - xref:../using/host-folders.adoc#[Host Folders]
-- xref:../using/docker-daemon.adoc#[{project} Docker Daemon]
 - xref:../using/profiles.adoc#[Profiles]
+- xref:../using/docker-daemon.adoc#[{project} Docker Daemon]
+- xref:../using/experimental-features.adoc#[Experimental Features]
+
+For details about using {project} to manage your local OpenShift cluster, see the xref:../openshift/index.adoc#[Interacting with OpenShift] section.

--- a/docs/source/using/profiles.adoc
+++ b/docs/source/using/profiles.adoc
@@ -14,8 +14,8 @@ toc::[]
 {project} allows to create multiple instances of {project}.
 Each {project} instance can be created with different configurations and users can switch between different instances.
 
-[[create-profile]]
-== Create profile
+[[creating-profile]]
+== Creating Profiles
 
 You can create a new instance of {project} with xref:../command-ref/minishift_start.adoc#[`minishift start --profile`] command.
 
@@ -27,8 +27,8 @@ To create a new profile, run:
 $ minishift --profile PROFILE_NAME start
 ----
 
-[[List-profiles]]
-== List profiles
+[[listing-profiles]]
+== Listing Profiles
 
 You can list all existing profiles with xref:../command-ref/minishift_profile_list.adoc#[`minishift profile list`] command.
 You can also see the active profile in the output.
@@ -40,8 +40,8 @@ $ minishift profile list
 ----
 
 
-[[set-active-profiles]]
-== Switch between profiles
+[[switching-profiles]]
+== Switching Profiles
 
 With the help of xref:../command-ref/minishift_profile_set.adoc#[`minishift profile set`] you can switch between profiles or set a profile as active.
 When a profile is active, it is not required to pass `--profile` flag to run minishift commands against that profile.
@@ -54,8 +54,8 @@ $ minishift profile set PROFILE_NAME
 
 When you have multiple profiles you can use `--profile` flag with any minishift command to run the command against a specific profile.
 
-[[delete-profiles]]
-== Delete a profile
+[[deleting-profiles]]
+== Deleting Profiles
 
 To delete a profile, run:
 


### PR DESCRIPTION
- Rename "Managing Minishift" to "Basic Commands". Naming is ambiguous
- Extract image caching and experimental features in their own topics
- Adjust cross-links
- Align header styles, eg headers should use present continuous