### PR TITLE
Adjust ocale to fix the string based network check

### DIFF
--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -283,6 +283,9 @@ func checkLibvirtInstalled() bool {
 //checkLibvirtDefaultNetwork returns true if the "default" network is present and active
 func checkLibvirtDefaultNetwork() bool {
 	cmd := exec.Command("virsh", "--connect", "qemu:///system", "net-list")
+	cmd.Env = append(os.Environ(),
+		"LC_ALL=C",
+	)
 	stdOutStdError, err := cmd.CombinedOutput()
 	if err != nil {
 		return false


### PR DESCRIPTION
Previously we were checking for the (in other languages localized)
string 'active' in order to determine if the default network is active.
This failed whenever the language of the terminal had a translation which
was not the string 'active'.
This patch explicitly sets the language in order to fix this check.

Fixes #1583