### PR TITLE
Issue #944 Docs build image which does not require UID at image build time

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -296,8 +296,6 @@ function perform_release() {
 function build_and_test() {
   setup_kvm_docker_machine_driver;
   cd $GOPATH/src/github.com/minishift/minishift
-  # Pull minishift/docs image to avoid building it
-  docker pull minishift/docs
   make prerelease synopsis_docs link_check_docs
   # Run integration test with 'kvm' driver
   MINISHIFT_VM_DRIVER=kvm make integration_all

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -21,26 +21,17 @@ ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
 
-ARG uid
-ENV UID=${uid:-1000}
-
-RUN groupadd -r docs && useradd -g docs -u $UID docs
-RUN mkdir -p /home/docs
-RUN chown docs:docs /home/docs
-
-# From here we run everything as dev user
-USER docs
-
-RUN echo locale
-
 ADD Gemfile .
 ADD Gemfile.lock .
 RUN /bin/bash -l -c "bundle install;"
 
-WORKDIR /home/docs
+ENV     DOCS_CONTENT /minishift-docs
+RUN     mkdir $DOCS_CONTENT
+VOLUME  $DOCS_CONTENT
 
 EXPOSE 35729:35729
 EXPOSE 4567:4567
 
-ENTRYPOINT ["rake"]
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["-T"]

--- a/docs/docker-entrypoint.sh
+++ b/docs/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [[ "$*" == "id" ]]; then
+	# Have a way to determine the uid under which volume mounts get mounted
+    stat -c "%u" /minishift-docs
+elif [ "$(id -u)" = '0' ]; then
+	echo "Image cannot be run as root. Use -u option of 'docker run' to specify a uid."
+	exit -1
+else
+	BUNDLER_HOME="/tmp/bundler/home"
+	mkdir -p $BUNDLER_HOME
+    cd $DOCS_CONTENT && HOME="$BUNDLER_HOME" /usr/local/bin/rake "$@"
+fi

--- a/docs/source/contributing/writing-docs.adoc
+++ b/docs/source/contributing/writing-docs.adoc
@@ -75,25 +75,19 @@ $ make gen_docs
 
 [NOTE]
 ====
-Your local checkout of the sources are going to be mounted into the container in order to built the docs.
-Depending on your UID on the host, you might see file permissions problems when trying to run `make gen_docs`.
-This is caused by the fact, that the *docs* user used within the container has a UID of 1000 by default.
-This might conflict with the user id of the mounted docs sources.
-
-Your output might look like:
+The image to build the documentation is downloaded from link:https://hub.docker.com/r/minishift/minishift-docs-builder/:[minishift/minishift-docs-builder].
+In case you need to make changes to the link:https://github.com/minishift/minishift/blob/master/docs/Dockerfile[Dockerfile] and want to build a local version of the image run:
 
 ----
-$ make gen_docs
-mkdir -p build
-rake aborted!
-Errno::EACCES: Permission denied @ dir_s_mkdir - build
+$ make build_docs_container
 ----
 
-In this case you need to build the container with a different user ID.
-This will ensure that the *docs* user in the container will be able to create files and directories.
+If changes to the Dockerfile become part of a pull request, make sure to
+deploy a new version of the image to link:https://hub.docker.com/r/minishift/minishift-docs-builder/:[minishift/minishift-docs-builder].
+First increment the version of the image in the _DOCS_BUILDER_IMAGE_ variable of the Makefile. Then run:
 
 ----
-$ make build_docs_container IMAGE_UID=$(id -u)
+$ make push_docs_container
 ----
 
 ====

--- a/docs/source/using/profiles.adoc
+++ b/docs/source/using/profiles.adoc
@@ -29,7 +29,7 @@ These commands are described in the following sections.
 
 There are two ways to create a new profile.
 
-==== Using The `--profile` Flag
+=== Using The `--profile` Flag
 
 When you run any {project} command with the `--profile` flag the profile gets created if it does not exist, for example:
 


### PR DESCRIPTION
- Update CentOS CI setup to not explcitly pull docs builder image
- Enable docs build on Appveyor

Addresses issue #944