### PR TITLE
Issue #1613 use consistent Windows drive letters and prompts

### DIFF
--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -67,7 +67,7 @@ If you encounter issues related to the hypervisor, see the xref:../troubleshooti
 
 [NOTE]
 ====
-- On Windows operating system, due to issue link:https://github.com/minishift/minishift/issues/236[#236], you need to execute the {project} binary from your local C:/ drive.
+- On the Windows operating system, due to issue link:https://github.com/minishift/minishift/issues/236[#236], you need to execute the {project} binary from your local *_C:\_* drive.
 You cannot run {project} from a network drive.
 ====
 

--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -189,5 +189,5 @@ Error creating the VM. Error with pre-create check: "vswitch \"\\\"External (Wir
 However, on PowerShell you need to use the quotes:
 +
 ----
-PS C:\> $env:HYPERV_VIRTUAL_SWITCH="External (Wireless)"
+PS> $env:HYPERV_VIRTUAL_SWITCH="External (Wireless)"
 ----

--- a/docs/source/openshift/openshift-client-binary.adoc
+++ b/docs/source/openshift/openshift-client-binary.adoc
@@ -144,13 +144,13 @@ If you get the error _The specified patch need to be a valid JSON._ when you run
 For example, if you use PowerShell on Windows 7 or 10, modify the above command to:
 
 ----
-$ minishift openshift config set --patch '{\"corsAllowedOrigins\": [\".*\"]}'
+PS> minishift.exe openshift config set --patch '{\"corsAllowedOrigins\": [\".*\"]}'
 ----
 
-If you use Command Prompt you might need to use:
+If you use Command Prompt, you might need to use the following:
 
 ----
-$ minishift openshift config set --patch "{\"corsAllowedOrigins\": [\".*\"]}"
+C:\> minishift.exe openshift config set --patch "{\"corsAllowedOrigins\": [\".*\"]}"
 ----
 
 ====

--- a/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
+++ b/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
@@ -192,7 +192,7 @@ If you are using PowerShell, you can add yourself to the Hyper-V Administrators 
 . As an administrator, run the following command:
 +
 ----
-([adsi]”WinNT://./Hyper-V Administrators,group”).Add(“WinNT://$env:UserDomain/$env:Username,user”)
+PS> ([adsi]”WinNT://./Hyper-V Administrators,group”).Add(“WinNT://$env:UserDomain/$env:Username,user”)
 ----
 
 . Log out and log back in for the change to take effect.

--- a/docs/source/troubleshooting/troubleshooting-getting-started.adoc
+++ b/docs/source/troubleshooting/troubleshooting-getting-started.adoc
@@ -72,7 +72,7 @@ $ minishift config set warn-check-xhyve-driver true
 - For Hyper-V on Windows, run the following command:
 +
 ----
-$ minishift config set warn-check-hyperv-driver true
+C:\> minishift.exe config set warn-check-hyperv-driver true
 ----
 
 [[persistent-storage-check]]

--- a/docs/source/using/basic-usage.adoc
+++ b/docs/source/using/basic-usage.adoc
@@ -148,7 +148,7 @@ $ minishift start --iso-url file:///path/to/image.iso
 - On Windows, the path must begin with a drive letter (*_C:_*, *_D:_*). For example:
 +
 ----
-$ minishift start --iso-url file://c:/path/to/image.iso
+C:\> minishift.exe start --iso-url file://c:/path/to/image.iso
 ----
 
 NOTE: You cannot run {project} with both ISO images concurrently.


### PR DESCRIPTION
* Use `PS>` consistently for PowerShell
* Use `C:\>` consistently for Command Prompt
* Replace slashes in Windows-specific paths with backslashes
* Refer to the Minishift binary in Windows-specific contexts as `minishift.exe`