### PR TITLE
Issue #1604 Correct inconsistencies in documentation

### DIFF
--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -19,8 +19,11 @@ The following sections describe how to build and test {project}.
 - Git
 - A recent Go distribution (>=1.8)
 
-NOTE: You should be able to develop {project} on any operating system, such as GNU/Linux, macOS or Windows.
+[NOTE]
+====
+You should be able to develop {project} on Linux, macOS or Windows.
 The Windows operating system might require additional steps or have some limitations.
+====
 
 [[set-up-dev-env]]
 == Setting Up the Development Environment
@@ -55,7 +58,14 @@ $ export GOPATH=$HOME/work
 $ export PATH=$PATH:$GOPATH/bin
 ----
 
-NOTE: On Windows operating systems, you use the UI or use `setx` to set the environment variables.
+[NOTE]
+====
+On Windows operating systems, you use the UI or a shell-specific approach to set environment variables.
+
+For Command Prompt, see link:https://technet.microsoft.com/en-us/library/cc754250.aspx[`set`] and link:https://technet.microsoft.com/en-us/library/cc755104.aspx[`setx`].
+
+For PowerShell, see link:https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables[About Environment Variables].
+====
 
 [[cloning-repository]]
 === Cloning the Repository
@@ -90,7 +100,7 @@ Before you can use Glide you need to download and install it from GitHub:
 $ go get github.com/Masterminds/glide
 ----
 
-This will install the *glide* binary into *_$GOPATH/bin_*.
+This will install the `glide` binary into *_$GOPATH/bin_*.
 Make sure to use Glide version 0.12.3 or later.
 
 [[bootstrap-dependencies]]
@@ -119,20 +129,23 @@ If your work requires a change to the dependencies, you need to update the Glide
 . Edit *_glide.yaml_* to change the dependencies as needed.
 
 . Delete *_glide.lock_* and re-create the vendor directory by running `make vendor`.
- Glide will recognize that there is no lock file and recalculate the required dependencies.
+Glide will recognize that there is no lock file and recalculate the required dependencies.
 
 . Check-in the updated *_glide.yaml_* and *_glide.lock_* files.
 
 . Test that everything still compiles with the new lock file in place by running `make clean && make`.
 
-TIP: In some cases the Glide cache located under *_~/.glide/cache_* can get corrupted.
-If you seeing Glide errors during `make vendor`, you can clear the Glide cache via `glide cc`.
+[TIP]
+====
+The Glide cache located under *_~/.glide/cache_* can get corrupted in some cases.
+If you see Glide errors during `make vendor`, you can clear the Glide cache via `glide cc`.
+====
 
 [[build-minishift]]
 == Building {project}
 
 [[build-minishift-binary]]
-=== Building the {project} Binary
+=== Building the minishift Binary
 
 Run the following command to create a platform-specific binary and copy it to *_$GOPATH/bin_*.
 
@@ -140,12 +153,15 @@ Run the following command to create a platform-specific binary and copy it to *_
 $ make
 ----
 
-NOTE: Use `make cross` to cross-compile for other platforms.
+[NOTE]
+====
+Use `make cross` to cross-compile for other platforms.
+====
 
 [[run-minishift-binary]]
-=== Running the {project} Binary
+=== Running the minishift Binary
 
-Start the OpenShift cluster with your built minishift binary:
+Start the OpenShift cluster with your built `minishift` binary:
 
 ----
 $ minishift start
@@ -196,32 +212,35 @@ For more information about test options, run the `go test --help` command and re
 [[integration-tests]]
 === Integration Tests
 
-Integration tests utilize link:https://github.com/DATA-DOG/godog[Godog], which uses Gherkin (Cucumber) to define sets of test cases, in Gherkin terminology known as _features_.
-The features are located in *_test/integration/features_* folder.
+Integration tests utilize link:https://github.com/DATA-DOG/godog[Godog], which uses Gherkin (Cucumber) to define sets of test cases.
+These test cases are known as _features_ in Gherkin terminology.
+Features are located in the *_test/integration/features_* directory.
 Features for {project} follow these basic concepts:
 
 User stories::
 Features which follow a happy path of user.
-For example, _basic.feature_ or _coolstore.feature_.
+For example, *basic.feature* or *coolstore.feature*.
 
 Feature and command coverage::
 Features which focuses on specific fields of {project} functionality or individual commands.
-For example, _proxy.feature_ or _cmd-version.feature_.
-
+For example, *proxy.feature* or *cmd-version.feature*.
 
 [[running-integration-tests]]
 ==== Running Integration Tests
 
-By default, the tests are being run against the binary created by `make build`, which is *_$GOPATH/bin/minishift_*.
+By default, tests are run against the binary created by `make build` (*_$GOPATH/bin/minishift_*).
 To run the basic test, use the following command:
 
 ----
 $ make integration
 ----
 
-NOTE: By default `make integration` only runs tests which are tagged as `@basic`.
+[NOTE]
+====
+`make integration` only runs tests which are tagged as `@basic` by default.
+====
 
-To run all tests, use the following command:
+To run all of the tests, use the following command:
 
 ----
 $ make integration_all
@@ -234,37 +253,37 @@ There is also a `make integration_pr` target which is being run as part of pull 
 
 ===== Additional Parameters
 
-To provide more flexibility the default targets `integration` and `integration_all` can be further customized using several parameters.
+The default targets `integration` and `integration_all` can be further customized using several parameters to provide more flexibility.
 
 MINISHIFT_BINARY::
-Parameter `MINISHIFT_BINARY` can be used to run integration tests against {project} binary located in different directory:
+The `MINISHIFT_BINARY` parameter can be used to run integration tests against a `minishift` binary located in a different directory:
 
 ----
 $ make integration MINISHIFT_BINARY=<path-to-custom-binary>
 ----
 
 TIMEOUT::
-Parameter `TIMEOUT` can be used to override the default timeout of `3600s`.
-To run all the tests with timeout `7200s`, use the following command:
+The `TIMEOUT` parameter can be used to override the default timeout of `3600s`.
+To run all the tests with a timeout of `7200s`, use the following command:
 
 ----
 $ make integration_all TIMEOUT=7200s
 ----
 
 RUN_BEFORE_FEATURE::
-Parameter `RUN_BEFORE_FEATURE` specifies {project} commands to be run before each feature.
-This provides ability to run integration tests against {project} which is not in default state.
+The `RUN_BEFORE_FEATURE` parameter specifies {project} commands to be run before each feature.
+This provides the ability to run integration tests against a {project} instance which is not in its default state.
 When multiple commands are specified, they must be delimited by a semicolon.
-For example, tests can be run against stopped {project} with _image caching_ option turned on by running:
+For example, tests can be run against a stopped {project} instance with the image caching option turned on by running the following:
 
 ----
 $ make integration_all RUN_BEFORE_FEATURE="start; stop; config set image-caching true"
 ----
 
 [[godog-options]]
-==== Using GODOG_OPTS Parameter
+==== Using the GODOG_OPTS Parameter
 
-Parameter `GODOG_OPTS` specifies additional arguments for Godog runner.
+The `GODOG_OPTS` parameter specifies additional arguments for the Godog runner.
 The following options are available:
 
 Tags::
@@ -276,16 +295,16 @@ This can be used to run feature files outside of the *_test/integration/features
 
 Format::
 Use `format` to change the format of Godog's output.
-For example, you can set `progress` format instead of the default `pretty`.
+For example, you can set the format to `progress` instead of the default `pretty`.
 
 Stop-on-failure::
-Set `stop-on-failure` to true to stop integration tests on failure.
+Set `stop-on-failure` to `true` to stop integration tests on failure.
 
 No-colors::
-Set `no-colors` to true to disable ansi colors of Godog's output.
+Set `no-colors` to `true` to disable ANSI colorization of Godog's output.
 
 Definitions::
-Set `definitions` to true to print all available step definitions.
+Set `definitions` to `true` to print all available step definitions.
 
 [NOTE]
 ====
@@ -293,21 +312,25 @@ Passing any value via `GODOG_OPTS` overrides the default tag definition on each 
 Thus in this case `--tags` must be specified manually, otherwise all features will be run.
 ====
 
-For example, to run integration tests on two specific feature files using only `@basic` and `@openshift` tags and without ansi colors, the following command can be used:
+For example, to run integration tests on two specific feature files using only `@basic` and `@openshift` tags and without ANSI colors, the following command can be used:
 
 ----
 $ make integration GODOG_OPTS="-paths ~/tests/custom.feature,~/my.feature -tags basic,openshift -no-colors true"
 ----
 
-NOTE: When multiple values are used for options in `GODOG_OPTS`, then they have to be separated by a comma without whitespace.
-While `-tags basic,openshift` will be parsed properly by make, `-tags basic, openshift` will result in only `@basic` being used.
+[NOTE]
+====
+Multiple values for a `GODOG_OPTS` option must be separated by a comma without whitespace.
+For example, `-tags basic,openshift` will be parsed properly by `make`, whereas `-tags basic, openshift` will result in only `@basic` being used.
+====
 
 ==== Viewing Results
 
-Integration test logs its progress directly into a console with accent of providing additional useful information when failures of individual Gherkin steps happen.
-This information is often enough to find and debug the reason of failure.
+The integration test logs its progress directly into a console.
+This information is often enough to find and debug the reason for a failure.
 
-However for cases which needs further investigation the integration test also logs more detailed progress into a log file. This file is located at `$GOPATH/github.com/minishift/minishift/out/test-results/integration_YYYY-MM-DD_HH:MM:SS.log`.
+However, for cases which require further investigation, the integration test also logs more detailed progress into a log file.
+This file is located at *_$GOPATH/github.com/minishift/minishift/out/test-results/integration_YYYY-MM-DD_HH:MM:SS.log_*.
 
 [[format-source-code]]
 === Formatting the Source Code
@@ -334,8 +357,8 @@ $ make vet
 
 Similar to `make fmtcheck`, failures in `make vet` will fail the CI builds.
 
-[[commit-messages]]
-=== Commit messages
+[[commit-message-requirements]]
+=== Commit Message Requirements
 
 Each commit message must meet two requirements:
 
@@ -349,7 +372,7 @@ $ make validate_commits
 ----
 
 [[clean-workspace]]
-=== Cleaning the workspace
+=== Cleaning the Workspace
 
 To remove all generated artifacts and installed dependencies, run the following command:
 
@@ -361,5 +384,5 @@ $ make clean
 == Godoc
 
 When developing {project}, it is encouraged to use link:https://godoc.org/golang.org/x/tools/cmd/godoc[Godoc] to document the source code.
-You can find guidelines on how to use godoc in link:https://blog.golang.org/godoc-documenting-go-code[this blog post].
+You can find guidelines on how to use Godoc in link:https://blog.golang.org/godoc-documenting-go-code[this blog post].
 You can browse the {project} Godoc documentation under link:https://godoc.org/github.com/minishift/minishift[https://godoc.org/github.com/minishift/minishift].

--- a/docs/source/contributing/index.adoc
+++ b/docs/source/contributing/index.adoc
@@ -5,7 +5,7 @@ include::variables.adoc[]
 
 Join the {project} community! Learn about the link:https://github.com/minishift/minishift/blob/master/README.adoc[project] and how to link:https://github.com/minishift/minishift/blob/master/CONTRIBUTING.adoc[contribute].
 
-- link:https://github.com/minishift/minishift/blob/master/CONTRIBUTING.adoc#contribution-guidelines[Contribution guidelines]
+- link:https://github.com/minishift/minishift/blob/master/CONTRIBUTING.adoc#contribution-guidelines[Contribution Guidelines]
 - xref:../contributing/developing.adoc#[Developing {project}]
 - xref:../contributing/ci.adoc#[{project} CI]
 - xref:../contributing/writing-docs.adoc#[Writing Documentation]

--- a/docs/source/contributing/releasing.adoc
+++ b/docs/source/contributing/releasing.adoc
@@ -20,8 +20,8 @@ The following sections describe how to release {project} either via automated jo
   - Move remaining open issues into the next milestone.
   - Review resolved/closed issues and make sure they are classified correctly.
   - Check and update the resolution of the issues.
-  For example, issues with a merged pull requests should be labeled as *resolution/done*.
-. Close milestone.
+  For example, issues with merged pull requests should be labeled as *resolution/done*.
+. Close the milestone.
 
 [[automated-release]]
 == Automated Release
@@ -35,14 +35,14 @@ $ make ci_release API_KEY=<api-key> RELEASE_VERSION=<version>
 where
 
   - `api-key` : {project} CentOS CI API key
-  - `version` : Expected release version. Eg : 1.0.0 (without 'v')
+  - `version` : The expected release version (without 'v'). For example, 1.0.0.
 
 Once triggered you can follow the release process link:https://ci.centos.org/job/minishift-release/[here].
 
 The automated release performs:
 
 - xref:../contributing/releasing.adoc#cut-release[Cutting the Release]
-- xref:../contributing/releasing.adoc#trigger-docs-build[Trigger the documentation build]
+- xref:../contributing/releasing.adoc#trigger-docs-build[Triggering the Documentation Build]
 - xref:../contributing/releasing.adoc#post-release-tasks[Perform Post-Release Tasks]
 
 [[manaul-release]]
@@ -51,8 +51,7 @@ The automated release performs:
 [[release-prereqs]]
 === Prerequisites
 
-- You must have a https://help.github.com/articles/creating-an-access-token-for-command-line-use[GitHub personal access token]
-defined in your environment as _GITHUB_ACCESS_TOKEN_.
+- You must have a https://help.github.com/articles/creating-an-access-token-for-command-line-use[GitHub personal access token] defined in your environment as `GITHUB_ACCESS_TOKEN`.
 
 [[cut-release]]
 === Cutting the Release
@@ -74,7 +73,9 @@ $ make release
 ----
 
 [[trigger-docs-build]]
-=== Trigger the documentation build
+=== Triggering the Documentation Build
+
+Use the following to trigger the documentation build:
 
 ----
 $ export API_KEY=<api-key>
@@ -91,7 +92,7 @@ As part of the release process we also send a release announcement and edit the 
 
 For the latter we usually add a categorized list of closed issues as well as some release highlights (most often taken from the release announcement).
 
-If you have link:https://stedolan.github.io/jq/[jq] installed on your machine, you can use the link:https://github.com/minishift/minishift/blob/master/scripts/release/issue-list.sh[issue-list.sh] script to generate the markdown needed for adding the issue list.
+If you have link:https://stedolan.github.io/jq/[`jq`] installed on your machine, you can use the link:https://github.com/minishift/minishift/blob/master/scripts/release/issue-list.sh[issue-list.sh] script to generate the Markdown needed for adding the issue list.
 For example:
 
 ----

--- a/docs/source/contributing/writing-docs.adoc
+++ b/docs/source/contributing/writing-docs.adoc
@@ -28,7 +28,10 @@ Since {project} is closely related to the OpenShift Origin project, we follow th
 
 The documentation source structure follows a modular format, where each file is called a _topic_ and each topic is stored under a sub-folder based on the relevant category, such as Getting Started, Using {project}, or Command Reference.
 
-TIP: You can check out the link:https://raw.githubusercontent.com/minishift/minishift/master/docs/source/contributing/writing-docs.adoc[raw file] of this topic or other existing {project} topics to see examples of how the information is structured and which tags to use.
+[TIP]
+====
+You can check out the link:https://raw.githubusercontent.com/minishift/minishift/master/docs/source/contributing/writing-docs.adoc[raw file] of this topic or other existing {project} topics to see examples of how the information is structured and which tags to use.
+====
 
 [[common-conventions]]
 === Commonly-Used Conventions
@@ -43,7 +46,8 @@ See the link:https://github.com/openshift/openshift-docs/blob/master/contributin
 The anchor ID text should match the title as much as possible.
 See the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#unique-ids[unique IDs] section of the OpenShift documentation guidelines for more information and examples.
 
-- To make documentation reviews easier on GitHub, we use one line per sentence wherever possible. This practice is in addition to the OpenShift documentation guidlines.
+- To make documentation reviews easier on GitHub, we use one line per sentence wherever possible.
+This practice is in addition to the OpenShift documentation guidelines.
 
 [[adding-new-topic]]
 === Adding a New Topic
@@ -62,7 +66,7 @@ Make sure to add the new topic in the same order in all of the locations.
 == Building the Documentation Locally
 
 By default, the documentation is built in a Docker container.
-This way you do not need to install all the required dependencies on your development machine.
+This way you do not need to install all of the required dependencies on your development machine.
 All you need is a running Docker daemon.
 In case you don't have one, use {project} itself.
 For more information, see xref:../using/docker-daemon.adoc#[reusing the Docker daemon].
@@ -82,9 +86,8 @@ In case you need to make changes to the link:https://github.com/minishift/minish
 $ make build_docs_container
 ----
 
-If changes to the Dockerfile become part of a pull request, make sure to
-deploy a new version of the image to link:https://hub.docker.com/r/minishift/minishift-docs-builder/:[minishift/minishift-docs-builder].
-First increment the version of the image in the _DOCS_BUILDER_IMAGE_ variable of the Makefile. Then run:
+If changes to the Dockerfile become part of a pull request, make sure to deploy a new version of the image to link:https://hub.docker.com/r/minishift/minishift-docs-builder/:[minishift/minishift-docs-builder].
+First increment the version of the image in the `DOCS_BUILDER_IMAGE` variable of the Makefile. Then run:
 
 ----
 $ make push_docs_container
@@ -128,11 +131,11 @@ To view the {project} documentation integrated into the OpenShift documentation,
 
 [NOTE]
 ====
-- Before you start, you need to check out the link:https://github.com/openshift/openshift-docs.git[openshift-docs] GitHub repository.
-You need all the tooling to build openshift-docs.
-See the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/tools_and_setup.adoc[Install and set up the tools and software] section, which is part of the _openshift-docs_ repository.
+Before you start, you need to check out the link:https://github.com/openshift/openshift-docs.git[*openshift-docs*] GitHub repository.
+You need all of the tooling required to build *openshift-docs*.
+See the link:https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/tools_and_setup.adoc[Install and set up the tools and software] section, which is part of the *openshift-docs* repository.
 
-- Make sure that the `rake build` commands succeeds before integrating the {project} documentation.
+Make sure that the `rake build` command succeeds before integrating the {project} documentation.
 ====
 
 . In the local {project} repository, build the {project} documentation tarball.
@@ -143,7 +146,7 @@ $ make gen_adoc_tar
 
 After the build completes there will be a *_minishift-adoc.tar_* file in the *_docs/build_* directory of the local {project} repository.
 
-. In the local openshift-docs repository, run the following commands:
+. In the local *openshift-docs* repository, run the following commands:
 
 ----
 $ mkdir minishift

--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -25,14 +25,20 @@ Depending on your host operating system, you have the choice of the following hy
 macOS::
 - link:https://github.com/mist64/xhyve[xhyve] (default)
 +
-NOTE: xhyve requires specific installation and configuration steps that are described in the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.
+[NOTE]
+====
+xhyve requires specific installation and configuration steps that are described in the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.
+====
 
 - link:https://www.virtualbox.org/wiki/Downloads[VirtualBox]
 
-GNU/Linux::
+Linux::
 - link:https://en.wikipedia.org/wiki/Kernel-based_Virtual_Machine[KVM] (default)
 +
-NOTE: KVM requires specific installation and configuration steps that are described in the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.
+[NOTE]
+====
+KVM requires specific installation and configuration steps that are described in the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.
+====
 
 - link:https://www.virtualbox.org/wiki/Downloads[VirtualBox]
 
@@ -66,7 +72,7 @@ If you encounter issues related to the hypervisor, see the xref:../troubleshooti
 
 [NOTE]
 ====
-- On the Windows operating system, due to issue link:https://github.com/minishift/minishift/issues/236[#236], you need to execute the {project} binary from your local *_C:\_* drive.
+On the Windows operating system, due to issue link:https://github.com/minishift/minishift/issues/236[#236], you need to execute the {project} binary from your local *_C:\_* drive.
 You cannot run {project} from a network drive.
 ====
 

--- a/docs/source/getting-started/quickstart.adoc
+++ b/docs/source/getting-started/quickstart.adoc
@@ -15,17 +15,17 @@ toc::[]
 This section contains a brief demo of {project} and of the provisioned OpenShift cluster.
 For details on the usage of {project}, see the xref:../using/basic-usage.adoc#[Basic Usage] section.
 
-The interaction with OpenShift is with the command-line tool _oc_ which is copied to your host.
+The interaction with OpenShift is with the command line tool `oc` which is copied to your host.
 For more information on how {project} can assist you in interacting with and configuring your local OpenShift instance, see the xref:../openshift/openshift-client-binary.adoc#[OpenShift Client Binary] section.
 
 For more information about the OpenShift cluster architecture, see link:https://docs.openshift.org/latest/architecture/index.html[Architecture Overview] in the OpenShift documentation.
 
-The following steps describe how to get started with {project} on a GNU/Linux operating system with the KVM hypervisor driver.
+The following steps describe how to get started with {project} on a Linux operating system with the KVM hypervisor driver.
 
 [[starting-minishift]]
 == Starting {project}
 
-. Run the `minishift start` command.
+. Run the `minishift start` command:
 +
 ----
 $ minishift start
@@ -49,50 +49,50 @@ $ minishift start
 To check the IP, run the `minishift ip` command.
 - By default, {project} uses the driver most relevant to the host OS.
 To use a different driver, set the `--vm-driver` flag in `minishift start`.
-For example, to use VirtualBox instead of KVM on GNU/Linux operating systems, run `minishift start --vm-driver=virtualbox`.
+For example, to use VirtualBox instead of KVM on Linux operating systems, run `minishift start --vm-driver=virtualbox`.
 - While {project} starts it runs several checks to make sure that the {project} VM and the OpenShift cluster are able to start correctly.
 If any startup checks fail, see the xref:../troubleshooting/troubleshooting-getting-started.adoc#minshift-startup-check-failed[Troubleshooting Getting Started] topic for information about possible causes and solutions.
 
 For more information about `minishift start` options, see the xref:../command-ref/minishift_start.adoc#[`minishift start`] command.
 ====
 
-. Use xref:../command-ref/minishift_oc-env.adoc#[`minishift oc-env`] to display the command you need to type into your shell in order to add the *oc* binary to your `PATH` environment variable.
+. Use xref:../command-ref/minishift_oc-env.adoc#[`minishift oc-env`] to display the command you need to type into your shell in order to add the `oc` binary to your `PATH` environment variable.
 The output of `oc-env` will differ depending on OS and shell type.
 +
 ----
 $ minishift oc-env
-export PATH="/Users/john/.minishift/cache/oc/v1.5.0:$PATH"
+export PATH="/home/john/.minishift/cache/oc/v1.5.0:$PATH"
 # Run this command to configure your shell:
 # eval $(minishift oc-env)
 ----
 
-For more information about interacting with OpenShift with the command-line interface and the Web console, see the xref:../openshift/openshift-client-binary.adoc#[OpenShift Client Binary] section.
+For more information about interacting with OpenShift with the command line interface and the Web console, see the xref:../openshift/openshift-client-binary.adoc#[OpenShift Client Binary] section.
 
 [[deploy-sample-app]]
 == Deploying a Sample Application
 
 OpenShift provides various sample applications, such as templates, builder applications, and quickstarts.
-The following steps describe how to deploy a sample Node.js application from the command-line.
+The following steps describe how to deploy a sample Node.js application from the command line.
 
-.  Create a Node.js example app.
+.  Create a Node.js example app:
 +
 ----
 $ oc new-app https://github.com/openshift/nodejs-ex -l name=myapp
 ----
 
-.  Track the build log until the app is built and deployed.
+.  Track the build log until the app is built and deployed:
 +
 ----
 $ oc logs -f bc/nodejs-ex
 ----
 
-.  Expose a route to the service.
+.  Expose a route to the service:
 +
 ----
 $ oc expose svc/nodejs-ex
 ----
 
-.  Access the application.
+.  Access the application:
 +
 ----
 $ minishift openshift service nodejs-ex --in-browser

--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -44,7 +44,7 @@ For more information, see the GitHub documentation of the link:https://github.co
 $ sudo apt install libvirt-bin qemu-kvm
 ----
 
-.  Add yourself to the **libvirtd** group (this may vary according to the Linux distribution) so that you do not need to use `sudo`:
+.  Add yourself to the *libvirtd* group (this may vary according to the Linux distribution) so that you do not need to use `sudo`:
 +
 ----
 $ sudo usermod -a -G libvirtd <username>
@@ -150,7 +150,7 @@ The following steps explain the installation of the *docker-machine-driver-xhyve
 $ sudo curl -L  https://github.com/zchee/docker-machine-driver-xhyve/releases/download/v0.3.1/docker-machine-driver-xhyve -o /usr/local/bin/docker-machine-driver-xhyve
 ----
 
-. Enable root access for the *docker-machine-driver-xhyve* binary and add it to the default wheel group:
+. Enable root access for the *docker-machine-driver-xhyve* binary and add it to the default *wheel* group:
 +
 ----
 $ sudo chown root:wheel /usr/local/bin/docker-machine-driver-xhyve
@@ -164,8 +164,8 @@ $ sudo chmod u+s,+x /usr/local/bin/docker-machine-driver-xhyve
 
 [NOTE]
 ====
-The downloaded *docker-machine-driver-xhyve* binaries are compiled against a specific version of macOS.
-It is possible that the driver fails to work after an macOS version upgrade.
+The downloaded *docker-machine-driver-xhyve* binary is compiled against a specific version of macOS.
+It is possible that the driver will fail to work after a macOS version upgrade.
 In this case you can try to compile the driver from source:
 
 ----
@@ -190,12 +190,18 @@ To use {project} with Hyper-V:
 
 . Add the user to the local Hyper-V Administrators group.
 +
-NOTE: This is required to allow the user to create and delete virtual machines with the Hyper-V Management API.
-For more information, see xref:../troubleshooting/troubleshooting-driver-plugins.adoc#insufficient-privileges[Hyper-V commands must be run as an Administrator]
+[NOTE]
+====
+This is required to allow the user to create and delete virtual machines with the Hyper-V Management API.
+For more information, see xref:../troubleshooting/troubleshooting-driver-plugins.adoc#insufficient-privileges[Hyper-V commands must be run as an Administrator].
+====
 
 . Add an link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/connect-to-network[External Virtual Switch].
 +
-NOTE: Verify that you pair the virtual switch with a network card (wired or wireless) that is connected to the network.
+[NOTE]
+====
+Verify that you pair the virtual switch with a network card (wired or wireless) that is connected to the network.
+====
 
 . Set the environment variable `HYPERV_VIRTUAL_SWITCH` to the name of the external virtual switch you want to use for {project}.
 For more information, see xref:../using/basic-usage.adoc#driver-specific-environment-variables[driver-specific environment variables].

--- a/docs/source/getting-started/uninstalling.adoc
+++ b/docs/source/getting-started/uninstalling.adoc
@@ -16,16 +16,16 @@ This section describes how you can uninstall {project} and delete associated fil
 [[uninstall-instructions]]
 == Uninstalling {project}
 
-.  Delete the {project} VM and any VM-specific files.
+.  Delete the {project} VM and any VM-specific files:
 +
 ----
 $ minishift delete
 ----
 +
-This command deletes everything in the *_MINISHIFT_HOME/.minishift/machines/minishift_* directory.
+This command deletes everything in the *_$MINISHIFT_HOME/.minishift/machines/minishift_* directory.
 Other cached data and the xref:../using/basic-usage.adoc#persistent-configuration[persistent configuration] are not removed.
 
-.  To completely uninstall {project}, delete everything in the *_MINISHIFT_HOME_* directory (default *_~/.minishift_*) and *_~/.kube_*, run the following commands:
+.  To completely uninstall {project}, delete everything in the `MINISHIFT_HOME` directory (default *_~/.minishift_*) and *_~/.kube_*:
 +
 ----
 $ rm -rf ~/.minishift

--- a/docs/source/getting-started/updating.adoc
+++ b/docs/source/getting-started/updating.adoc
@@ -25,7 +25,7 @@ If so, it prompts user to confirm the update, downloads the new binary and repla
 
 [NOTE]
 ====
-We recommend to run xref:../command-ref/minishift_delete.adoc#[`minishift delete`] before running the update command to avoid backward compatibility issues.
+We recommend running xref:../command-ref/minishift_delete.adoc#[`minishift delete`] before running the update command to avoid backward compatibility issues.
 ====
 
 [NOTE]

--- a/docs/source/openshift/exposing-services.adoc
+++ b/docs/source/openshift/exposing-services.adoc
@@ -12,7 +12,7 @@ toc::[]
 == Overview
 
 There are several ways you can expose your service after you deploy it on OpenShift.
-The following sections describes the various methods and when to use them.
+The following sections describe the various methods and when to use them.
 
 [[application-routes]]
 == Routes

--- a/docs/source/openshift/openshift-client-binary.adoc
+++ b/docs/source/openshift/openshift-client-binary.adoc
@@ -12,16 +12,16 @@ toc::[]
 == Overview
 
 The `minishift start` command creates an OpenShift cluster using the link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[cluster up] approach.
-For this purpose it copies the *oc* binary onto your host.
+For this purpose it copies the `oc` binary onto your host.
 
-The *oc* binary is located in the  *_~/.minishift/cache/oc/{openshift-version}_* directory, assuming that you use {project}'s default version of OpenShift.
+The `oc` binary is located in the  *_~/.minishift/cache/oc/{openshift-version}_* directory, assuming that you use {project}'s default version of OpenShift.
 You can add this binary to your `PATH` using xref:../command-ref/minishift_oc-env.adoc#[`minishift oc-env`], which displays the command you need to type into your shell.
 
 The output of `minishift oc-env` differs depending on the operating system and the shell type.
 
 ----
 $ minishift oc-env
-export PATH="/Users/john/.minishift/cache/oc/v1.5.0:$PATH"
+export PATH="/home/john/.minishift/cache/oc/v1.5.0:$PATH"
 # Run this command to configure your shell:
 # eval $(minishift oc-env)
 ----
@@ -46,7 +46,8 @@ For an introduction to `oc` usage, see the link:https://docs.openshift.org/lates
 By default, `cluster up` uses link:https://docs.openshift.org/latest/install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider[AllowAllPasswordIdentityProvider] to authenticate against the local cluster.
 This means any non-empty user name and password can be used to login to the local cluster.
 
-The recommended user name and password is `developer` and `developer`, respectively. This is because they are already assigned to the default project *myproject* and also can link:https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#authentication-impersonation[impersonate] the administrator.
+The recommended user name and password is `developer` and `developer`, respectively.
+This is because they are already assigned to the default project *myproject* and also can link:https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#authentication-impersonation[impersonate] the administrator.
 This allows you to run administrator commands using the `--as system:admin` parameter.
 
 To login as administrator, use the system account:
@@ -100,7 +101,7 @@ For more information refer also to xref:../openshift/exposing-services.adoc#[Exp
 [[view-openshift-logs]]
 == Viewing OpenShift Logs
 
-To access OpenShift logs, run the `logs` command after starting {project}:
+To access OpenShift logs, run the following command after starting {project}:
 
 ----
 $ minishift logs
@@ -121,7 +122,10 @@ To show the node configuration instead of the master configuration, specify the 
 
 For details about the `view` sub-command, see the xref:../command-ref/minishift_openshift_config_view.adoc#[minishift openshift config view] synopsis.
 
-NOTE: After you update the OpenShift configuration, OpenShift will transparently restart.
+[NOTE]
+====
+After you update the OpenShift configuration, OpenShift will transparently restart.
+====
 
 [[example-config-cors]]
 === Example: Configuring cross-origin resource sharing
@@ -139,7 +143,7 @@ $  minishift openshift config set --patch '{"corsAllowedOrigins": [".*"]}'
 
 [NOTE]
 ====
-If you get the error _The specified patch need to be a valid JSON._ when you run the above command, you need to modify the above command depending on your Operating System, your shell environment and its interpolation behavior.
+If you get the error _The specified patch need to be a valid JSON._ when you run the above command, you need to modify the above command depending on your operating system, your shell environment and its interpolation behavior.
 
 For example, if you use PowerShell on Windows 7 or 10, modify the above command to:
 
@@ -156,7 +160,7 @@ C:\> minishift.exe openshift config set --patch "{\"corsAllowedOrigins\": [\".*\
 ====
 
 [[example-change-openshift-routing-suffix]]
-=== Example: Changing the OpenShift routing suffix
+=== Example: Changing the OpenShift Routing Suffix
 
 In this example, you change the OpenShift routing suffix in the master configuration.
 

--- a/docs/source/openshift/openshift-docker-registry.adoc
+++ b/docs/source/openshift/openshift-docker-registry.adoc
@@ -17,7 +17,7 @@ Images present in the registry can directly be used for applications, speeding u
 [[login-to-registry]]
 == Logging Into the Registry
 
-. Start {project} and add the *oc* binary to the PATH. For a detailed example, see the xref:../getting-started/quickstart.adoc#[{project} Quickstart] section.
+. Start {project} and add the `oc` binary to the `PATH`. For a detailed example, see the xref:../getting-started/quickstart.adoc#[{project} Quickstart] section.
 . Make sure your shell is configured to xref:../using/docker-daemon.adoc#[reuse the {project} docker daemon].
 . Log into the OpenShift Docker registry.
 +
@@ -28,24 +28,24 @@ Images present in the registry can directly be used for applications, speeding u
 [[deploy-applications]]
 == Deploying Applications
 
-The following example shows how to deploy an OpenShift application directly from a locally-built docker image.
+The following example shows how to deploy an OpenShift application directly from a locally-built Docker image.
 This example uses the OpenShift project *myproject*. This project is automatically created by `minishift start`.
 
 . Make sure your shell is configured to xref:../using/docker-daemon.adoc#[reuse the {project} docker daemon].
-. Build the docker image as usual.
-. Tag the image against the OpenShift registry.
+. Build the Docker image as usual.
+. Tag the image against the OpenShift registry:
 +
 ----
  $ docker tag my-app $(minishift openshift registry)/myproject/my-app
 ----
 
-. Push the image to the registry to create an image stream with the same name as the application.
+. Push the image to the registry to create an image stream with the same name as the application:
 +
 ----
  $ docker push $(minishift openshift registry)/myproject/my-app
 ----
 
-. Create an application from the image stream and expose the service.
+. Create an application from the image stream and expose the service:
 +
 ----
  $ oc new-app --image-stream=my-app --name=my-app

--- a/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
+++ b/docs/source/troubleshooting/troubleshooting-driver-plugins.adoc
@@ -20,7 +20,7 @@ This section contains solutions to common problems that you might encounter whil
 [[minishift-delete-fails-undefine-snapshots]]
 === Undefining virsh snapshots fail
 
-If you use `virsh` on KVM/libvirt to create snapshots in your development workflow, and then use `minishift delete` to delete the snapshots along with the VM, you might encounter the following error:
+If you use `virsh` on KVM/libvirt to create snapshots in your development workflow then use `minishift delete` to delete the snapshots along with the VM, you might encounter the following error:
 
 ----
 $ minishift delete
@@ -32,14 +32,14 @@ Cause: The snapshots are stored in *_~/.minishift/machines_*, but the definition
 
 Workaround: To delete the snapshots, you need to perform the following steps.
 
-.  Delete the definitions.
+.  Delete the definitions:
 +
 
 ----
 $ sudo virsh snapshot-delete --metadata minishift <snapshot-name>
 ----
 
-.  Undefine the {project} domain.
+.  Undefine the {project} domain:
 +
 
 ----
@@ -106,7 +106,7 @@ $ systemctl enable virtlogd
 If you try `minishift start` and the this error appears, ensure that you use `minishift delete` to delete the VMs that you created earlier.
 However, if this fails and you want to completely clean up {project} and start fresh, do the following:
 
-. Check if any existing {project} VM are running:
+. Check if any existing {project} VMs are running:
 +
 
 ----
@@ -160,7 +160,10 @@ Reset the {project}-specific IP database, ensure that you remove the `minishift`
 }
 ----
 
-NOTE: You can completely reset the IP database by removing the files manually but this is very risky.
+[NOTE]
+====
+You can completely reset the IP database by removing the files manually, but this is very risky.
+====
 
 [[troubleshooting-driver-virtualbox]]
 == VirtualBox

--- a/docs/source/troubleshooting/troubleshooting-getting-started.adoc
+++ b/docs/source/troubleshooting/troubleshooting-getting-started.adoc
@@ -17,9 +17,11 @@ This section contains solutions to common problems that you might encounter whil
 [[github-api-rate-limit-exceeded]]
 == GitHub API rate limit exceeded
 
-When you run `minishift start` or `minishift update`, it makes requests to the GitHub API to check for new version and potentially download new versions of {project} or the OpenShift client tool `oc`.
+When you run `minishift start` or `minishift update`, it makes requests to the GitHub API to check for and potentially download new versions of {project} or the OpenShift client tool `oc`.
 
-Sometimes, during these requests, you might receive a 403 forbidden status from GitHub if your request exceeds the rate limit for your IP address. In this case, the command will fail and you will receive an error message. For example:
+Sometimes, during these requests, you might receive a 403 forbidden status from GitHub if your request exceeds the rate limit for your IP address.
+In this case, the command will fail and you will receive an error message.
+For example:
 
 ----
 Error starting the cluster: Error attempting to download and cache oc: Cannot get the OpenShift
@@ -29,9 +31,12 @@ requests get a higher rate limit. Check out the documentation for more details.)
 17m2.462768522s
 ----
 
-GitHub has a rate limiting policy, see link:https://developer.github.com/v3/#rate-limiting[Rate Limiting]. You may have reached this limit for various reasons. For example, your package manager may use GitHub API calls or you are behind a corporate network that makes a lot of GitHub unauthenticated API calls.
+GitHub has a rate limiting policy, see link:https://developer.github.com/v3/#rate-limiting[Rate Limiting].
+You may have reached this limit for various reasons.
+For example, your package manager may use GitHub API calls or you are behind a corporate network that makes a lot of GitHub unauthenticated API calls.
 
-Instead of waiting for GitHub to reset the limit for your IP address, you can create a link:https://GitHub.com/blog/1509-personal-api-tokens[Personal API Tokens] from your GitHub account. This gives you a higher rate limit.
+Instead of waiting for GitHub to reset the limit for your IP address, you can create a link:https://GitHub.com/blog/1509-personal-api-tokens[Personal API Tokens] from your GitHub account.
+This gives you a higher rate limit.
 
 After you generate the API token, you need to set the `MINISHIFT_GITHUB_API_TOKEN` environment variable by running:
 
@@ -39,7 +44,8 @@ After you generate the API token, you need to set the `MINISHIFT_GITHUB_API_TOKE
 $ export MINISHIFT_GITHUB_API_TOKEN=<token_ID>
 ----
 
-Replace `<token_ID>` with your token. You can also add this variable in your shell profile so you don't need to manually set the variable every time you run a {project} command.
+Replace `<token_ID>` with your token.
+You can also add this variable in your shell profile so you don't need to manually set the variable every time you run a {project} command.
 
 [[minshift-startup-check-failed]]
 == {project} startup check failed
@@ -95,7 +101,8 @@ After the {project} VM starts, it runs several network checks to verify whether 
 By default, network checks are configured to treat any errors as warnings, because of the diversity of the development environments.
 You can configure the network checks to optimize them for your environment.
 
-For example, one of the network checks pings an external host. You can change the host by running the following command:
+For example, one of the network checks pings an external host.
+You can change the host by running the following command:
 
 ----
 $ minishift config set check-network-ping-host <host-IP-address>
@@ -113,7 +120,7 @@ $ minishift config set check-network-http-host <URL>
 [[minshift-update-failed-due-to-permission-denied]]
 == Permission denied error when updating {project}
 
-When updating {project} using `minishift update`, the update process needs write permissions for the {project} binary as well as the directory in which it is located.
+When updating {project} using `minishift update`, the update process needs write permissions for the `minishift` binary as well as the directory in which it is located.
 Without these permisions `minishift update` will fail.
 For example, this issue might occur when installing {project} as root.
 

--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -11,9 +11,7 @@ toc::[]
 [[add-ons-overview]]
 == Overview
 
-NOTE: This feature is still considered experimental and might change in future releases.
-
-{project} allows to extend the vanilla OpenShift setup provided by *cluster up* with an add-on mechanism.
+{project} allows you to extend the vanilla OpenShift setup provided by *cluster up* with an add-on mechanism.
 
 Add-ons are directories that contain a text file with the *_.addon_* extension.
 The directory can also contain other resource files such as JSON template files.
@@ -38,7 +36,10 @@ oc adm policy add-scc-to-group anyuid system:authenticated                      
 <4> (Optional) OpenShift version required to run a specific add-on. See xref:../using/addons.adoc#addon-openshift-version-semantics[OpenShift Version Semantic]
 <5> Actual add-on command. In this case, the command executes the *oc* binary.
 
-NOTE: Comment lines, starting with the '#' character, can be inserted at anywhere in the file.
+[NOTE]
+====
+Comment lines, starting with the '#' character, can be inserted anywhere in the file.
+====
 
 Enabled add-ons are applied during xref:../command-ref/minishift_start.adoc#[`minishift start`], immediately after the initial cluster provisioning is successfully completed.
 
@@ -46,7 +47,8 @@ Enabled add-ons are applied during xref:../command-ref/minishift_start.adoc#[`mi
 == OpenShift-Version Semantics
 
 As part of the add-on metadata you can specify the OpenShift version which needs to be running in order to apply the add-on.
-To do so you can specify the optional _OpenShift-Version_ metadata field. The semantics are as follow:
+To do so, you can specify the optional *OpenShift-Version* metadata field.
+The semantics are as follows:
 
 [cols="1,3"]
 |===
@@ -57,26 +59,35 @@ To do so you can specify the optional _OpenShift-Version_ metadata field. The se
 | >=3.5.0, <=3.8.0 | OpenShift version should higher or equal to 3.5.0 but lower or equal to 3.8.0.
 |===
 
-NOTE: If the metadata field _OpenShift-Version_ is not specified in the add-on header, the add-on is applied against any version of OpenShift.
+[NOTE]
+====
+If the metadata field *OpenShift-Version* is not specified in the add-on header, the add-on can be applied against any version of OpenShift.
+====
 
-NOTE: OpenShift-Version supports only versions in the form of <major>.<minor>.<patch>.
+[NOTE]
+====
+*OpenShift-Version* only supports versions in the form of <major>.<minor>.<patch>.
+====
 
 [[addon-commands]]
 == Add-on Commands
 
 This section describes the commands that an add-on file can contain.
-They are forming a mini-DSL for {project} add-ons:
+They form a small domain-specific language for {project} add-ons:
 
 ssh::
 If the add-on command starts with `ssh`, you can run any command within the {project}-managed VM.
 This is similar to running xref:../command-ref/minishift_ssh.adoc#[`minishift ssh`] and then executing any command on the VM.
-For more information about the `minishift ssh` command usage, see xref:../using/basic-usage.adoc#connecting-with-ssh[Connecting to the {project} VM with SSH].
+For more information about `minishift ssh` command usage, see xref:../using/basic-usage.adoc#connecting-with-ssh[Connecting to the {project} VM with SSH].
 
 oc::
-If the add-on command starts with `oc`, it uses the *oc* binary that is cached on your host to execute the specified `oc` command.
-This is similar to running `oc --as system:admin ...` from the command-line.
+If the add-on command starts with `oc`, it uses the `oc` binary that is cached on your host to execute the specified `oc` command.
+This is similar to running `oc --as system:admin ...` from the command line.
 +
-NOTE: The `oc` command is executed as *system:admin*.
+[NOTE]
+====
+The `oc` command is executed as *system:admin*.
+====
 
 openshift::
 If the add-on command starts with `openshift`, you can run the *openshift* binary within the container that runs OpenShift.
@@ -96,7 +107,10 @@ sleep::
 If the add-on command starts with `sleep`, it waits for the specified number of seconds.
 This can be useful in cases where you know that a command such as `oc` might take a few seconds before a certain resource can be queried.
 
-NOTE: Trying to use an undefined command will cause an error when the add-on gets parsed.
+[NOTE]
+====
+Trying to use an undefined command will cause an error when the add-on gets parsed.
+====
 
 [[addon-variable-interpolation]]
 == Variable Interpolation
@@ -159,9 +173,13 @@ $ minishift config set addon-env PROJECT_USER=john
 $ minishift addons apply acme
 ----
 
-TIP: Multiple variables need to be comma separated when the xref:../command-ref/minishift_config_set.adoc#[`minishift config set`] is used.
+[TIP]
+====
+Multiple variables need to be comma separated when the xref:../command-ref/minishift_config_set.adoc#[`minishift config set`] command is used.
+====
 
-There is also the possibility to dynamically interpolate a variable with the value of an environment variable at the time the add-on gets applied. For this the variable value needs to be prefixed with _env_.
+There is also the possibility to dynamically interpolate a variable with the value of an environment variable at the time the add-on gets applied.
+For this the variable value needs to be prefixed with _env_.
 
 ----
 $ minishift config set addon-env PROJECT_USER=env.USER        // <1>
@@ -191,9 +209,15 @@ Multiple default key/value pairs need to be comma separated.
 # Var-Defaults: PROJECT_USER=john
 ----
 
-NOTE: `=` and `,` are metacharacters and cannot be used as part of keys or values.
+[NOTE]
+====
+`=` and `,` are metacharacters and cannot be used as part of keys or values.
+====
 
-NOTE: Variable values specified via the command line using the `--addon-env` or set via `minishift config set addon-env` have precedence over _Var-Defaults_.
+[NOTE]
+====
+Variable values specified via the command line using the `--addon-env` or set via `minishift config set addon-env` have precedence over _Var-Defaults_.
+====
 
 [[default-addons]]
 == Default Add-ons
@@ -212,7 +236,8 @@ To view the list of installed add-ons, you can then run:
 $ minishift addons list --verbose=true
 ----
 
-This command prints a list of installed add-ons. You should at least see the *anyuid* add-on listed.
+This command prints a list of installed add-ons.
+You should at least see the *anyuid* add-on listed.
 This is an important add-on that allows you to run images that do not use a pre-allocated UID.
 By default, this is not allowed in OpenShift.
 
@@ -253,7 +278,8 @@ $ minishift addons enable registry --priority=5
 ----
 
 The add-on priority attribute determines the order in which add-ons are applied.
-By default, an add-on has the priority 0. Add-ons with a lower priority value are applied first.
+By default, an add-on has the priority 0.
+Add-ons with a lower priority value are applied first.
 
 In the following example, the *anyuid*, *registry*, and *eap* add-ons are enabled with the respective priorities of 0, 5 and 10.
 This means that *anyuid* is applied first, followed by *registry*, and lastly the *eap* add-on.
@@ -268,7 +294,10 @@ $ minishift addons list
 - eap            : enabled    P(10)
 ----
 
-NOTE: If two add-ons have the same priority the order in which they are getting applied is not determined.
+[NOTE]
+====
+If two add-ons have the same priority the order in which they are getting applied is not determined.
+====
 
 [[apply-addons]]
 == Applying Add-ons
@@ -297,7 +326,7 @@ To remove multiple add-ons with a single command, specify the add-on names separ
 The following example shows how to explicitly remove the *admin-user* add-on.
 
 [[example-remove-admin-user]]
-.Example: Removing admin-user add-ons
+.Example: Removing admin-user add-on
 
 ----
 $ minishift addons remove admin-user
@@ -349,7 +378,7 @@ $ minishift addons install <ADDON_DIR_PATH>
 
 [TIP]
 ====
-You can also write metadata in multiple line.
+You can also write metadata with multiple lines.
 
 [[example-multiline-metadata]]
 .Example: Add-on definition which contain multiline description
@@ -364,9 +393,12 @@ You can also write metadata in multiple line.
 ----
 ====
 
-NOTE: You can also edit your add-on directly in the {project} add-on install directory *_$MINISHIFT_HOME/addons_*.
+[NOTE]
+====
+You can also edit your add-on directly in the {project} add-on install directory *_$MINISHIFT_HOME/addons_*.
 Be aware that if there is an error in the add-on, it will not show when you run any `addons` commands, and it will not be applied during the `minishift start` process.
+====
 
 To provide add-on remove instructions, you can create text file with the extension *_.addon.remove_*, for example *_admin-user.addon.remove_*.
 Similar to the *_.addon_* file, it needs the *Name* and *Description* metadata fields.
-If a *_.addon.remove_* file exist, it can be applied via the xref:../using/addons.adoc#remove-addons[`remove`] command.
+If a *_.addon.remove_* file exists, it can be applied via the xref:../using/addons.adoc#remove-addons[`remove`] command.

--- a/docs/source/using/basic-usage.adoc
+++ b/docs/source/using/basic-usage.adoc
@@ -77,7 +77,7 @@ For more details about using {project} to manage your local OpenShift cluster, s
 
 The xref:../command-ref/minishift_start.adoc#[`minishift start`] command creates and configures the {project} VM and provisions a local, single-node OpenShift cluster within the {project} VM.
 
-The command also copies the *oc* binary to your host so that you can interact with OpenShift through the `oc` command-line tool or through the Web console, which can be accessed through the URL provided in the output of the `minishift start` command.
+The command also copies the *oc* binary to your host so that you can interact with OpenShift through the `oc` command line tool or through the Web console, which can be accessed through the URL provided in the output of the `minishift start` command.
 
 [[minishift-stop-overview]]
 === {project} stop Command
@@ -116,7 +116,10 @@ This ISO image is provided by link:https://github.com/kubernetes/minikube/[Minik
 Minikube ISO image also provides alternate container runtime e.g. cri-o and rkt along with docker.
 Please check link:https://github.com/kubernetes/minikube/blob/master/docs/contributors/minikube_iso.md[Minikube documentation] for details.
 
-NOTE: Minikube ISO image use is experimental in {project}. Work is in progress to make it as stable as CentOS and Boot2Docker ISO images.
+[NOTE]
+====
+Minikube ISO image use is experimental in {project}. Work is in progress to make it as stable as CentOS and Boot2Docker ISO images.
+====
 
 By default, {project} uses the {project} Boot2Docker ISO image.
 To choose the {project} CentOS ISO image instead, you can do one of the following:
@@ -140,20 +143,25 @@ $ minishift start --iso-url https://github.com/minishift/minishift-centos-iso/re
 ====
 The path given for a file URI must be an absolute path.
 ====
-- On GNU/Linux or macOS, the path must begin with *_/_*. For example:
+- On Linux or macOS, the path must begin with *_/_*.
+For example:
 +
 ----
 $ minishift start --iso-url file:///path/to/image.iso
 ----
 
-- On Windows, the path must begin with a drive letter (*_C:_*, *_D:_*). For example:
+- On Windows, the path must begin with a drive letter (*_C:_*, *_D:_*).
+For example:
 +
 ----
 C:\> minishift.exe start --iso-url file://c:/path/to/image.iso
 ----
 
-NOTE: You cannot run {project} with both ISO images concurrently.
+[NOTE]
+====
+You cannot run {project} with both ISO images concurrently.
 To switch between ISO images, delete the {project} instance and start a new instance with the ISO image that you want to use.
+====
 
 [[runtime-options]]
 == Runtime Options
@@ -163,7 +171,7 @@ The runtime behavior of {project} can be controlled through flags, environment v
 The following precedence order is applied to control the behavior of {project}.
 Each action in the following list takes precedence over the action below it:
 
-.  Use command-line flags as specified in the xref:flags[Flags] section.
+.  Use command line flags as specified in the xref:flags[Flags] section.
 .  Set environment variables as described in the xref:environment-variables[Environment Variables] section.
 .  Use persistent configuration options as described in the xref:persistent-configuration[Persistent Configuration] section.
 .  Accept the default value as defined by {project}.
@@ -179,7 +187,7 @@ Some of the commonly-used command line flags of the `minishift start` command ar
 [[environment-variables]]
 === Environment Variables
 
-{project} allows you to specify command-line flags you commonly use through environment variables.
+{project} allows you to specify command line flags you commonly use through environment variables.
 To do so, apply the following rules to the flag you want to set as an environment variable.
 
 .  Apply `MINISHIFT_` as a prefix to the flag you want to set as an environment variable.
@@ -192,20 +200,26 @@ A common example is the URL of the ISO to be used.
 Usually, you specify it with the `iso-url` flag of the `minishift start` command.
 Applying the above rules, you can also specify this URL by setting the environment variable as `MINISHIFT_ISO_URL`.
 
-NOTE: You can also use the `MINISHIFT_HOME` environment variable, to choose a different home directory for {project}.
+[NOTE]
+====
+You can also use the `MINISHIFT_HOME` environment variable, to choose a different home directory for {project}.
 By default, {project} places all runtime state into *_~/.minishift_*.
 This environment variable is currently experimental and semantics might change in future releases.
+====
 
 [[persistent-configuration]]
 === Persistent Configuration
 
-Using persistent configuration allows you to control the {project} behavior without specifying actual command line flags, similar to the way you use environment variables.
+Using persistent configuration allows you to control {project} behavior without specifying actual command line flags, similar to the way you use environment variables.
 
 {project} maintains a configuration file in *_$MINISHIFT_HOME/config/config.json_*.
-This file can be used to set commonly-used command-line flags persistently.
+This file can be used to set commonly-used command line flags persistently.
 
-NOTE: Persistent configuration can only be applied to the set of supported configuration options that are listed in the synopsis of the xref:../command-ref/minishift_config.adoc#[`minishift config`] sub-command.
+[NOTE]
+====
+Persistent configuration can only be applied to the set of supported configuration options that are listed in the synopsis of the xref:../command-ref/minishift_config.adoc#[`minishift config`] sub-command.
 This is different from environment variables, which can be used to replace any option of any command.
+====
 
 [[setting-persistent-configuration-values]]
 ==== Setting Persistent Configuration Values
@@ -259,8 +273,8 @@ $ minishift config unset memory
 === Driver-Specific Environment Variables
 
 You can also set driver-specific environment variables.
-Each docker-machine driver supports its own set of options and variables.
-A good starting point is the official docker-machine link:https://docs.docker.com/machine/drivers/[driver documentation].
+Each Docker Machine driver supports its own set of options and variables.
+A good starting point is the official Docker Machine link:https://docs.docker.com/machine/drivers/[driver documentation].
 
 xhyve and KVM documentation is available under their respective GitHub repository link:https://github.com/zchee/docker-machine-driver-xhyve[docker-machine-driver-xhyve] and https://github.com/dhiltgen/docker-machine-kvm[docker-machine-kvm].
 
@@ -272,9 +286,12 @@ $ export XHYVE_EXPERIMENTAL_NFS_SHARE=true
 $ minishift start --vm-driver xhyve
 ----
 
-CAUTION: Driver-specific options might overlap with values specified using {project}-specific flags and environment variables.
+[CAUTION]
+====
+Driver-specific options might overlap with values specified using {project}-specific flags and environment variables.
 Examples are boot2docker URL, memory size, cpu count, and so on.
 In this case, driver-specific environment variables will override {project}-specific settings.
+====
 
 [[persistent-volumes]]
 == Persistent Volumes

--- a/docs/source/using/docker-daemon.adoc
+++ b/docs/source/using/docker-daemon.adoc
@@ -12,7 +12,7 @@ toc::[]
 == Overview
 
 When running OpenShift in a single VM, you can reuse the Docker daemon managed by {project} for other Docker use-cases as well.
-By using the same docker daemon as {project}, you can speed up your local development.
+By using the same Docker daemon as {project}, you can speed up your local development.
 
 [[docker-daemon-configuration]]
 == Console configuration

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -24,7 +24,7 @@ To share your feedback on these features, you are welcome to link:https://github
 ====
 
 [[enabling-experimental-oc-flags]]
-== Enabling experimental `oc cluster up` flags
+== Enabling Experimental `oc cluster up` Flags
 
 By default, {project} does not expose all link:https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[`oc cluster up`] flags in the {project} CLI.
 
@@ -37,23 +37,24 @@ Enables provisioning the OpenShift link:https://docs.openshift.org/latest/archit
 Enables passing flags that are not directly exposed in the {project} CLI directly to `oc cluster up`.
 
 [[hyperv-static-ip]]
-== Assign IP address to Hyper-V
+== Assign IP Address to Hyper-V
 
 Since the Internal Virtual Switch for Hyper-V does not provide a DHCP offer option, an IP address needs to be provided in a different way.
 For Hyper-V a functionality is provided to assign an IP address on startup using the Data Exchange Service.
 
 [IMPORTANT]
 ====
--  While the default image is B2D, this only works with the CentOS/RHEL based image in combination with Hyper-V. The B2D image experiences
-   a problem when the values are being send to the {project} instance and consumed by the B2D iso. We are looking into the issue and hope
-   to provide a solution in the coming future.
+While the default image is B2D, this only works with the CentOS/RHEL based image in combination with Hyper-V.
+The B2D image experiences a problem when the values are being sent to the {project} instance and consumed by the B2D iso.
+We are looking into the issue and hope to provide a solution in the future.
 ====
 
-To make this work you need to create a link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[Virtual Switch using NAT]
+To make this work you need to create a link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[Virtual Switch using NAT].
 
 [NOTE]
 ====
-WinNAT is limited to one NAT network per host. For more details about capabilities, and limitations, please see the link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[WinNAT capabilities and limitations blog]
+WinNAT is limited to one NAT network per host.
+For more details about capabilities, and limitations, please see the link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[WinNAT capabilities and limitations blog].
 ====
 
 The following command will attempt to assign an IP address for use on the Internal Virtual Switch 'MyInternal':
@@ -68,7 +69,7 @@ PS> minishift.exe start `
   --network-nameserver 8.8.8.8
 ----
 
-If you want to use the 'DockerNAT' network, the following commands are needed to setup the correct NAT networking and assigning an IP in the range expected:
+If you want to use the 'DockerNAT' network, the following commands are needed to setup the correct NAT networking and assign an IP in the range expected:
 
 ----
 PS> New-NetNat -Name SharedNAT -InternalIPInterfaceAddressPrefix 10.0.75.1/24
@@ -83,5 +84,6 @@ PS> minishift.exe start `
 
 [NOTE]
 ====
-- Be sure to specify a valid gateway and nameserver. Failing to do so will result in connectivity issues
+Be sure to specify a valid gateway and nameserver.
+Failing to do so will result in connectivity issues.
 ====

--- a/docs/source/using/host-folders.adoc
+++ b/docs/source/using/host-folders.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 Host folders are directories on the host which are shared between the host and the {project} VM.
 They allow for a two way file synchronization between host and VM.
-The following sections discuss the various types of host folders, driver provided host folders, as well as the `minishift hostfolder` command.
+The following sections discuss the various types of host folders, driver-provided host folders, as well as the `minishift hostfolder` command.
 
 [[driver-host-folders]]
 == Driver-Provided Host Folders
@@ -25,28 +25,28 @@ These folders are currently not configurable and differ for each driver and OS.
 .Driver-provided host folders
 
 |===
-|Driver |OS |HostFolder |VM
+|Driver |OS |Host Folder |VM
 
-|Virtualbox |Linux |/home |/hosthome
+|VirtualBox |Linux |/home |/hosthome
 
-|Virtualbox |OSX |/Users |/Users
+|VirtualBox |macOS |/Users |/Users
 
-|Virtualbox |Windows |C://Users |/c/Users
+|VirtualBox |Windows |C:\Users |/c/Users
 
-|Xhyve |OSX |/Users |/Users
+|xhyve |macOS |/Users |/Users
 |===
 
 [NOTE]
 ====
-- Host folder sharing is not implemented in the KVM and Hyper-V drivers.
+Host folder sharing is not implemented in the KVM and Hyper-V drivers.
 If you use one of these drivers, you need to use the `minishift hostfolder` command to set up and configure host folders.
 
-- The VirtualBox default host folders are available only with the default Boot2Docker ISO.
+The VirtualBox default host folders are available only with the default Boot2Docker ISO.
 It requires VirtualBox link:https://www.virtualbox.org/manual/ch04.html[Guest Additions], which is currently unavailable in the CentOS ISO.
 ====
 
 [[minishift-hostfolder-command]]
-== {project} hostfolder Command
+== The minishift hostfolder Command
 
 {project} provides the xref:../command-ref/minishift_hostfolder.adoc#[`minishift hostfolder`] command to list, add, mount, unmount and remove host folders.
 In contrast to the driver-provided host folders, you can use the `hostfolder` command to mount multiple shared folders onto custom specified mount points.
@@ -63,7 +63,7 @@ If you want to manually set up SSHFS, see xref:sshfs-folder-mount[SSHFS Host Fol
 
 To use the `minishift hostfolder` command, you need to be able to share directories using CIFS.
 On Windows, CIFS is the default technology for sharing directories.
-For example, on Windows 10 the *_C:\Users_* folder is shared by default and can be accessed by locally-authenticated users.
+For example, on Windows 10 the *_C:\Users_* directory is shared by default and can be accessed by locally-authenticated users.
 
 It is also possible to use CIFS on macOS and Linux.
 On macOS, you can enable CIFS-based shares under *System Preferences > Sharing*.
@@ -87,15 +87,18 @@ myshare     /mnt/sda1/myshare     //192.168.1.82/MYSHARE   N
 In this example, there is a host folder with the name *_myshare_* which mounts *_//192.168.1.82/MYSHARE_* onto *_/mnt/sda1/myshare_* in the {project} VM.
 The share is currently not mounted.
 
-NOTE: The remote path must be reachable from within the VM.
-In the example above, *192.168.1.82* is the IP of host within the LAN, which is one option you can use.
+[NOTE]
+====
+The remote path must be reachable from within the VM.
+In the example above, *192.168.1.82* is the IP of the host within the LAN, which is one option you can use.
 You can use `ifconfig` (or `Get-NetIPAddress | Format-Table` on Windows) to determine a routable IP address.
+====
 
 [[adding-host-folders]]
 === Adding Host Folders
 
 The xref:../command-ref/minishift_hostfolder_add.adoc#[`minishift hostfolder add`] command allows you to define a new host folder.
-This in an interactive process that queries the relevant details for a host folder based on CIFS.
+This is an interactive process that queries the relevant details for a host folder based on CIFS.
 
 [[adding-cifs-hostfolder]]
 .Adding a CIFS based hostfolder
@@ -108,17 +111,23 @@ Password: [HIDDEN]                 // <5>
 Domain:                            // <6>
 Added: myshare
 ----
-<1> (Required) Actual `minishift hostfolder add` command that specifie a host folder with a name of *_myshare_*.
+<1> (Required) Actual `minishift hostfolder add` command that specifies a host folder with the name of *_myshare_*.
 <2> (Required) The UNC path for the share.
 <3> The mount point within the VM. The default is *_/mnt/sda1/<host folder name>_*.
 <4> (Required) The user name for the CIFS share.
 <5> (Required) The password for the CIFS share.
 <6> The domain of the share. Often this can be left blank, but for example on Windows, when your account is linked to a Microsoft account, you must use the Microsoft account email address as user name as well as your machine name as displayed by `$env:COMPUTERNAME` as a domain.
 
-TIP: On Windows hosts, the `minishift hostfolder add` command also provides a `users-share` option.
+[TIP]
+====
+On Windows hosts, the `minishift hostfolder add` command also provides a `users-share` option.
 When this option is specified, no UNC path needs to be specified and the *_C:\Users_* is assumed.
+====
 
-WARNING: When you use the Boot2Docker ISO with the VirtualBox driver, VirtualBox guest additions are automatically enabled and occupy the *_/Users_* mount point.
+[WARNING]
+====
+When you use the Boot2Docker ISO with the VirtualBox driver, VirtualBox guest additions are automatically enabled and occupy the *_/Users_* mount point.
+====
 
 [[instance-host-folders]]
 ==== Instance-Specific Host Folders
@@ -128,7 +137,7 @@ This means that these host folder definitions will survive the deletion and subs
 
 In some cases you might want to define a host folder just for a specific {project} instance.
 To do so, you can use the `instance-only` flag of the xref:../command-ref/minishift_hostfolder_add.adoc#[`minishift hostfolder add`] command.
-Host folder definition that are created with the `instance-only` flag will be removed together with any other instance-specific state during xref:../command-ref/minishift_delete.adoc#[`minishift delete`].
+Host folder definitions that are created with the `instance-only` flag will be removed together with any other instance-specific state during xref:../command-ref/minishift_delete.adoc#[`minishift delete`].
 
 [[mounting-host-folders]]
 === Mounting Host Folders
@@ -200,12 +209,16 @@ No host folders defined
 [[sshfs-folder-mount]]
 === SSHFS Host Folders
 
-NOTE: This host folder type is not supported by the `minishift hostfolder` command and requires manual configuration.
+[NOTE]
+====
+This host folder type is not supported by the `minishift hostfolder` command and requires manual configuration.
+====
 
 You can use SSHFS-based host folders if you have an SSH daemon running on your host.
 Normally, this prerequisite is met by default on Linux and macOS.
 
-Most Linux distributions have an SSH daemon installed. If not, follow the instructions for your specific distribution to install an SSH daemon.
+Most Linux distributions have an SSH daemon installed.
+If not, follow the instructions for your specific distribution to install an SSH daemon.
 
 macOS also has a built-in SSH server.
 To use it, make sure that *Remote Login* is enabled in *System Preferences > Sharing*.

--- a/docs/source/using/image-caching.adoc
+++ b/docs/source/using/image-caching.adoc
@@ -24,9 +24,9 @@ $ minishift config set image-caching true
 ----
 
 Once enabled, caching occurs transparently, in a background process, the first time you use the xref:../command-ref/minishift_start#[`minishift start`] command.
-Once the images are cached under _$MINISHIFT_HOME/cache/images_, successive {project} VM creations will use these cached images.
+Once the images are cached under *_$MINISHIFT_HOME/cache/images_*, successive {project} VM creations will use these cached images.
 
-Each time an image exporting background process runs, a log file is generated under _$MINISHIFT_HOME/logs_ which can be used to verify the progress of the export.
+Each time an image exporting background process runs, a log file is generated under *_$MINISHIFT_HOME/logs_* which can be used to verify the progress of the export.
 
 You can disable the caching of the OpenShift images by setting `image-caching` to `false` or removing the setting altogether using xref:../command-ref/minishift_config_unset#[`minishift config unset`]:
 
@@ -34,6 +34,9 @@ You can disable the caching of the OpenShift images by setting `image-caching` t
 $ minishift config unset image-caching
 ----
 
-NOTE: Image caching is considered experimental and its semantics and API is subject to change.
+[NOTE]
+====
+Image caching is considered experimental and its semantics and API are subject to change.
 The aim is to allow caching of arbitrary images, as well as using a better format for storing the images on the host.
-You can track the progress on this feature on the GitHub issue link:https://github.com/minishift/minishift/issues/952[#952].
+You can track the progress on this feature on GitHub issue link:https://github.com/minishift/minishift/issues/952[#952].
+====

--- a/docs/source/using/profiles.adoc
+++ b/docs/source/using/profiles.adoc
@@ -19,7 +19,7 @@ Refer to the use of xref:../using/basic-usage.adoc#environment-variables[environ
 
 The _active_ profile is the profile against which all commands are executed, unless the global `--profile` flag is used.
 You can determine the active profile by using the xref:../command-ref/minishift_profile_list.adoc#[`minishift profile list`] command.
-You can execute single commands against a non-active profile by using the `--profile` flag, for example `minishift --profile profile-demo console` to open the OpenShift console for the specified _profile-demo_ profile.
+You can execute single commands against a non-active profile by using the `--profile` flag, for example `minishift --profile profile-demo console` to open the OpenShift console for the specified *profile-demo* profile.
 
 On top of the `--profile` flag, there are xref:../command-ref/minishift_profile.adoc#[commands] for xref:../command-ref/minishift_profile_list.adoc#[listing], xref:../command-ref/minishift_profile_delete.adoc#[deleting] and xref:../command-ref/minishift_profile_set.adoc#[setting] the active profile.
 These commands are described in the following sections.
@@ -29,7 +29,7 @@ These commands are described in the following sections.
 
 There are two ways to create a new profile.
 
-=== Using The `--profile` Flag
+=== Using the `--profile` Flag
 
 When you run any {project} command with the `--profile` flag the profile gets created if it does not exist, for example:
 
@@ -48,11 +48,11 @@ $ minishift --profile profile-demo start
 ...
 ----
 
-See also xref:../using/profiles.adoc#example-workflows-profiles[workflow for profile configuration].
+See also xref:../using/profiles.adoc#example-workflow-profile-config[workflow for profile configuration].
 
 [NOTE]
 ====
- A profile automatically becomes the active profile when a {project} instance is started successfully via `minishift start`.
+A profile automatically becomes the active profile when a {project} instance is started successfully via `minishift start`.
 ====
 
 === Using the `profile set` Command
@@ -93,7 +93,10 @@ $ minishift profile set profile-demo
 Profile 'profile-demo' set as active profile
 ----
 
-NOTE: Only one profile can be active at any time.
+[NOTE]
+====
+Only one profile can be active at any time.
+====
 
 [[deleting-profiles]]
 == Deleting Profiles
@@ -108,9 +111,12 @@ Profile 'profile-demo' deleted successfully
 Switching to default profile 'minishift' as the active profile.
 ----
 
-NOTE: The default profile *minishift* cannot be deleted.
+[NOTE]
+====
+The default profile *minishift* cannot be deleted.
+====
 
-[[example-workflows-profiles]]
+[[example-workflow-profile-config]]
 == Example Workflow for Profile Configuration
 
 You have two options to create a new profile and configure its xref:../using/basic-usage.adoc#persistent-configuration[persistent configuration].


### PR DESCRIPTION
Applied:
- Title casing
- Styling of file paths, environment variables, etc.
- Block-style admonitions
- One sentence per line
- Wording consistency ("command line" versus "command-line")
- Minimal rewriting