### PR TITLE
Issue #1503 Use vmdriver variable instead of reading from config

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -348,7 +348,7 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 
 		// Configure networking on startup only works on Hyper-V
 		if networkSettings.IPAddress != "" {
-			minishiftNetwork.ConfigureNetworking(constants.MachineName, networkSettings)
+			minishiftNetwork.ConfigureNetworking(constants.MachineName, machineConfig.VMDriver, networkSettings)
 		}
 	}
 

--- a/pkg/minishift/network/settings_darwin.go
+++ b/pkg/minishift/network/settings_darwin.go
@@ -20,6 +20,6 @@ import (
 	"fmt"
 )
 
-func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
+func ConfigureNetworking(machineName string, vmDriver string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }

--- a/pkg/minishift/network/settings_linux.go
+++ b/pkg/minishift/network/settings_linux.go
@@ -20,6 +20,6 @@ import (
 	"fmt"
 )
 
-func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
+func ConfigureNetworking(machineName string, vmDriver string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }

--- a/pkg/minishift/network/settings_windows.go
+++ b/pkg/minishift/network/settings_windows.go
@@ -25,7 +25,6 @@ import (
 	hvkvp "github.com/gbraad/go-hvkvp"
 	"github.com/golang/glog"
 	"github.com/minishift/minishift/pkg/minishift/shell/powershell"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -34,9 +33,9 @@ const (
 	networkingMessageName = "PROVISION_NETWORKING"
 )
 
-func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
+func ConfigureNetworking(machineName string, vmDriver string, networkSettings NetworkSettings) {
 	// Instruct the user that this does not work for other Hypervisors on Windows
-	if viper.GetString("vm-driver") != "hyperv" {
+	if vmDriver != "hyperv" {
 		fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 		return
 	}


### PR DESCRIPTION
startHost is already reading the VM driver from the config.  We can pass this value in directly rather than reading it out of the config a second time. 