### PR TITLE
Issue #1729 Making sure generated images gets removed in clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ push_docs_container: build_docs_container
 	cd docs && docker push $(DOCS_BUILDER_IMAGE)
 
 .PHONY: gen_adoc_tar
-gen_adoc_tar: synopsis_docs
-	cd docs && docker run -u $(DOCS_UID) $(DOC_VARIABLES) -tiv $(LOCAL_DOCS_DIR):$(CONTAINER_DOCS_DIR):Z $(DOCS_BUILDER_IMAGE) clean adoc_tar
+gen_adoc_tar: clean_docs synopsis_docs
+	cd docs && docker run -u $(DOCS_UID) $(DOC_VARIABLES) -tiv $(LOCAL_DOCS_DIR):$(CONTAINER_DOCS_DIR):Z $(DOCS_BUILDER_IMAGE) adoc_tar
 
 .PHONY: gen_docs
 gen_docs: synopsis_docs

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -266,7 +266,7 @@ function perform_release() {
   MINISHIFT_VM_DRIVER=kvm make integration_all
   exit_on_failure "$?" "Integration tests failed."
 
-  make link_check_docs IMAGE_UID=$(id -u) # Test docs builds and all links are valid
+  make link_check_docs # Test docs builds and all links are valid
   exit_on_failure "$?" "Documentation build failed."
 
   create_release_commit
@@ -279,7 +279,7 @@ function perform_release() {
   add_release_notes;
   exit_on_failure "$?" "Failed to update release notes of Minishift v$RELEASE_VERSION. Try to manually update the release notes here - https://github.com/${REPO_OWNER}/minishift/releases/tag/v$RELEASE_VERSION."
 
-  make gen_adoc_tar IMAGE_UID=$(id -u)
+  make gen_adoc_tar
   exit_on_failure "$?" "Documentation tarball build failed."
 
   docs_tar_upload $1
@@ -318,7 +318,7 @@ else
 
   if [[ "$JOB_NAME" = "minishift-docs" ]]; then
     cd gopath/src/github.com/minishift/minishift
-    make gen_adoc_tar IMAGE_UID=$(id -u)
+    make gen_adoc_tar
     docs_tar_upload $RSYNC_PASSWORD;
   elif [[ "$JOB_NAME" = "minishift-release" ]]; then
     perform_release $RSYNC_PASSWORD;

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -31,6 +31,14 @@ task :clean do
   rm_f Rake::FileList.new("#{GENERATED_ADOC_DIR}/*.adoc")
   rm_rf BUILD_DIR
   rm_f ADOC_VARIABLES
+  # find ditaa images based on the fact that they have a cache file
+  DITAA_IMAGES = Rake::FileList.new do |list|
+    Rake::FileList.new("source/**/images/*.png.cache").each do |f|
+      list.add(f)
+      list.add(f.gsub(/\.cache/, ''))
+    end
+  end
+  rm_f DITAA_IMAGES
 end
 
 file TOPIC_MAP => [:init, 'source/_topic_map.yml'] do


### PR DESCRIPTION
Addresses #1729 

This pull request tries to dynamically deal with cleaning up generated ditaa images (without having to explicitly list them). It also makes sure that generating the tarball for openshift.org gets build from a clean source directory. 

Whether the existence of the image in the tarball is really the reason for failure we are seeing I am not sure off, but this change makes sense regardless. 