### PR TITLE
Issue #1570 Nightly job integration in centos_ci.sh script

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -308,6 +308,14 @@ function prepare_for_proxy() {
   firewall-cmd --zone=public --add-port=$INTEGRATION_PROXY_CUSTOM_PORT/tcp;
 }
 
+function perform_nightly() {
+  setup_kvm_docker_machine_driver;
+  cd $GOPATH/src/github.com/minishift/minishift
+  make prerelease synopsis_docs link_check_docs
+  MINISHIFT_VM_DRIVER=kvm make integration_all GODOG_OPTS=""
+  echo "CICO: Tests ran successfully"
+}
+
 if [[ "$UID" = 0 ]]; then
   setup_build_environment;
 else
@@ -322,6 +330,8 @@ else
     docs_tar_upload $RSYNC_PASSWORD;
   elif [[ "$JOB_NAME" = "minishift-release" ]]; then
     perform_release $RSYNC_PASSWORD;
+  elif [[ "$JOB_NAME" = "minishift-nightly" ]]; then
+    perform_nightly;
   else
     build_and_test $RSYNC_PASSWORD;
   fi

--- a/docs/source/contributing/ci.adoc
+++ b/docs/source/contributing/ci.adoc
@@ -1,3 +1,5 @@
+include::variables.adoc[]
+
 = Minishift CI
 :data-uri:
 :imagesdir: images
@@ -39,9 +41,11 @@ The artifacts of a successful pull request build can be found at link:http://art
 
 On top of building the master branch and pull requests, CentOS CI is also used to build the tar bundle used for xref:../contributing/writing-docs.adoc#integration-with-docs-openshift-org[integration with docs.openshift.org], as well as to build xref:../contributing/releasing.adoc#automated-release[releases].
 
+The link:https://ci.centos.org/job/minishift-nightly[nightly job] runs daily at midnight.
+It executes all integration tests against the _master_ branch of the {project} GitHub repository.
 
 |link:https://ci.centos.org/job/minishift/[master], link:https://ci.centos.org/job/minishift-pr/[pull requests], link:https://ci.centos.org/job/minishift-docs/[docs],
-link:https://ci.centos.org/job/minishift-release/[release]
+link:https://ci.centos.org/job/minishift-release/[release], link:https://ci.centos.org/job/minishift-nightly[nightly]
 
 |link:https://github.com/minishift/minishift/blob/master/centos_ci.sh[centos_ci.sh]
 


### PR DESCRIPTION
Fix #1570

Job is ready in CentOS CI, last successfully performed here https://ci.centos.org/job/minishift-nightly/10/console with same checks as PR build.

This PR add necessary changes for nightly build.
