### PR TITLE
Issue #1705 Add -f to delete commands

### DIFF
--- a/cmd/minishift/cmd/delete.go
+++ b/cmd/minishift/cmd/delete.go
@@ -107,7 +107,7 @@ func removeInstanceConfigs() {
 }
 
 func init() {
-	deleteCmd.Flags().BoolVar(&forceMachineDeletion, "force", false, "Forces the deletion of the VM specific files in MINISHIFT_HOME.")
+	deleteCmd.Flags().BoolVarP(&forceMachineDeletion, "force", "f", false, "Forces the deletion of the VM specific files in MINISHIFT_HOME.")
 	deleteCmd.Flags().BoolVar(&clearCache, "clear-cache", false, "Deletes all cached artifacts as part of the VM deletion.")
 	RootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/minishift/cmd/profile/profile_delete.go
+++ b/cmd/minishift/cmd/profile/profile_delete.go
@@ -107,6 +107,6 @@ func runProfileDelete(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	profileDeleteCmd.Flags().BoolVar(&forceProfileDeletion, "force", false, "Forces the deletion of profile and related files in MINISHIFT_HOME.")
+	profileDeleteCmd.Flags().BoolVarP(&forceProfileDeletion, "force", "f", false, "Forces the deletion of profile and related files in MINISHIFT_HOME.")
 	ProfileCmd.AddCommand(profileDeleteCmd)
 }


### PR DESCRIPTION
Fixes #1705

Added `-f` shorthand to the `delete` and `profile delete` commands.
Please let me know if I have missed any command.