### PR TITLE
Issue #250 Use testify unit testing framework for unit tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -61,6 +61,12 @@
   version = "v1.0.7"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/docker/distribution"
   packages = [".","digestset","reference","registry/api/errcode","registry/api/v2","registry/client","registry/client/auth/challenge","registry/client/transport","registry/storage/cache","registry/storage/cache/memory"]
   revision = "5f6282db7d65e6d72ad7c2cc66310724a57be716"
@@ -296,6 +302,12 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/pquerna/ffjson"
   packages = ["fflib/v1","fflib/v1/internal"]
@@ -351,6 +363,12 @@
   name = "github.com/spf13/viper"
   packages = ["."]
   revision = "382f87b929b84ce13e9c8a375a4b217f224e6c65"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/tchap/go-patricia"
@@ -417,6 +435,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0aef932b275def0df646c10b2df61d5070a5678ec76e6ae33f019283dab85361"
+  inputs-digest = "8f23b05e678847832ee58b983e8164ece758740889f248423fba5fae50d0f924"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -170,3 +170,7 @@ ignored = ["github.com/Sirupsen/logrus"]
 [[constraint]]
   name = "github.com/opencontainers/go-digest"
   revision = "aa2ec055abd10d26d539eb630a92241b781ce4bc"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "=v1.2.0"

--- a/cmd/minishift/cmd/addon/addon_uninstall_test.go
+++ b/cmd/minishift/cmd/addon/addon_uninstall_test.go
@@ -19,13 +19,15 @@ package addon
 import (
 	"testing"
 
-	"fmt"
-	"github.com/minishift/minishift/cmd/testing/cli"
-	"github.com/minishift/minishift/pkg/minikube/constants"
-	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/minishift/minishift/cmd/testing/cli"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var adminUser string = `# Name: admin-user
@@ -57,25 +59,22 @@ func Test_uninstall_with_enable_flag_works(t *testing.T) {
 	defer cli.TearDown(tmpMinishiftHomeDir, tee)
 
 	addOnManager := GetAddOnManager()
-	if len(addOnManager.List()) != 0 {
-		t.Fatal(fmt.Sprintf("There should be no add-ons installed. Got : %v", addOnManager.List()))
-	}
+
+	assert.Empty(t, addOnManager.List())
 
 	// create a dummy addon named as admin-user
 	testAddOnDir := filepath.Join(tmpMinishiftHomeDir, "admin-user")
 	os.Mkdir(testAddOnDir, 0777)
 	err := ioutil.WriteFile(filepath.Join(testAddOnDir, "admin-user.addon"), []byte(adminUser), 0644)
-	if err != nil {
-		t.Fatal(fmt.Sprintf("Unexpected error writing to file: %v", err))
-	}
+
+	assert.NoError(t, err, "Unexpected error writing to file")
 
 	enable = true
 	runInstallAddon(nil, []string{testAddOnDir})
 
 	runUnInstallAddon(nil, []string{"admin-user"})
 	addOnManager = GetAddOnManager()
-	if len(addOnManager.List()) != 0 {
-		t.Fatal(fmt.Sprintf("There shouldn't be any add-on installed. Got : %v", addOnManager.List()))
-	}
+
+	assert.Empty(t, addOnManager.List())
 
 }

--- a/cmd/minishift/cmd/config/config_test.go
+++ b/cmd/minishift/cmd/config/config_test.go
@@ -18,8 +18,9 @@ package config
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type configTestCase struct {
@@ -96,9 +97,8 @@ func TestReadConfig(t *testing.T) {
 	for _, tt := range configTestCases {
 		r := bytes.NewBufferString(tt.data)
 		config, err := decode(r)
-		if reflect.DeepEqual(config, tt.config) || err != nil {
-			t.Errorf("Cannot decode config. \n\n expected %+v, \n\n received %+v \n\n err %+v", tt.config, config, err)
-		}
+		assert.NoError(t, err, "Error Decoding config")
+		assert.ObjectsAreEqualValues(tt.data, config)
 	}
 }
 
@@ -106,12 +106,8 @@ func TestWriteConfig(t *testing.T) {
 	var b bytes.Buffer
 	for _, tt := range configTestCases {
 		err := encode(&b, tt.config)
-		if err != nil {
-			t.Errorf("Error encoding: %s", err)
-		}
-		if b.String() != tt.data {
-			t.Errorf("Cannot encode config. \n\n expected \n %+v, \n\n received \n %+v \n\n err %+v", tt.data, b.String(), err)
-		}
+		assert.NoError(t, err, "Error Encoding config")
+		assert.Equal(t, b.String(), tt.data)
 		b.Reset()
 	}
 }

--- a/cmd/minishift/cmd/config/set_test.go
+++ b/cmd/minishift/cmd/config/set_test.go
@@ -17,26 +17,24 @@ limitations under the License.
 package config
 
 import (
-	"github.com/minishift/minishift/cmd/minishift/state"
-	"github.com/minishift/minishift/pkg/minikube/constants"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/minishift/minishift/cmd/minishift/state"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNotFound(t *testing.T) {
 	err := set("nonexistant", "10")
-	if err == nil {
-		t.Fatal("Set did not return error for unknown property")
-	}
+	assert.Error(t, err, "Set did not return error for unknown property")
 }
 
 func TestModifyData(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-config-")
-	if err != nil {
-		t.Error()
-	}
+	assert.NoError(t, err, "Error creating temp directory")
 	state.InstanceDirs = state.NewMinishiftDirs(testDir)
 
 	constants.ConfigFile = filepath.Join(testDir, "config.json")
@@ -54,27 +52,17 @@ func TestModifyData(t *testing.T) {
 
 func verifyStoredValue(t *testing.T, key string, expectedValue string) {
 	actualValue, err := get(key)
-	if err != nil {
-		t.Fatalf("Error getting value %s", err)
-	}
-	if actualValue != expectedValue {
-		t.Fatalf("Unexpexted value in confif. Expected '%s'. Got '%s'.", expectedValue, actualValue)
-	}
+	assert.NoError(t, err, "Unexpexted value in config")
+	assert.Equal(t, expectedValue, actualValue)
 }
 
 func verifyValueUnset(t *testing.T, key string) {
 	actualValue, err := get(key)
-	if err != nil {
-		t.Fatalf("Error getting value %s", err)
-	}
-	if actualValue != "<nil>" {
-		t.Fatalf("Expexted '<nil>' value. Got '%s'.", actualValue)
-	}
+	assert.NoError(t, err, "Error getting value")
+	assert.Equal(t, "<nil>", actualValue)
 }
 
 func persistValue(t *testing.T, key string, value string) {
 	err := set(key, value)
-	if err != nil {
-		t.Fatalf("Error setting value %s", err)
-	}
+	assert.NoError(t, err, "Error setting value")
 }

--- a/cmd/minishift/cmd/config/util_test.go
+++ b/cmd/minishift/cmd/config/util_test.go
@@ -16,9 +16,12 @@ limitations under the License.
 
 package config
 
-import "testing"
-import "reflect"
-import "strings"
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 var minikubeConfig = MinishiftConfig{
 	"vm-driver":            "kvm",
@@ -27,68 +30,50 @@ var minikubeConfig = MinishiftConfig{
 }
 
 func TestFindSettingNotFound(t *testing.T) {
-	s, err := findSetting("nonexistant")
-	if err == nil {
-		t.Fatalf("Unexpected setting found. [%+v]", s)
-	}
+	_, err := findSetting("nonexistant")
+	assert.Error(t, err)
 }
 
 func TestFindSetting(t *testing.T) {
 	s, err := findSetting("vm-driver")
-	if err != nil {
-		t.Fatalf("Cannot find the setting of the vm-driver: %s", err)
-	}
-	if s.Name != "vm-driver" {
-		t.Fatalf("Incorrect setting, expected vm-driver, received %s", s.Name)
-	}
+	assert.NoError(t, err, "Cannot find the setting of the vm-driver")
+	assert.Equal(t, "vm-driver", s.Name, "Setting of the vm-driver not found")
 }
 
 func TestSetString(t *testing.T) {
 	err := SetString(minikubeConfig, "vm-driver", "virtualbox")
-	if err != nil {
-		t.Fatalf("Cannot set the string: %s", err)
-	}
+	assert.NoError(t, err, "Error setting config")
 }
 
 func TestSetInt(t *testing.T) {
 	err := SetInt(minikubeConfig, "cpus", "22")
-	if err != nil {
-		t.Fatalf("Cannot set integer value in config: %s", err)
-	}
+
+	assert.NoError(t, err, "Error setting int value")
+
 	val, ok := minikubeConfig["cpus"].(int)
-	if !ok {
-		t.Fatal("Type is not set to int")
-	}
-	if val != 22 {
-		t.Fatal("SetInt set value is incorrect")
-	}
+
+	assert.True(t, ok, "Type is not set to int")
+	assert.Equal(t, 22, val, "SetInt set value is incorrect")
+	assert.IsType(t, *new(int), minikubeConfig["cpus"])
 }
 
 func TestSetBool(t *testing.T) {
 	err := SetBool(minikubeConfig, "show-libmachine-logs", "true")
-	if err != nil {
-		t.Fatalf("Cannot set boolean value in config: %s", err)
-	}
+
+	assert.NoError(t, err, "Error setting boolean value in config")
+
 	val, ok := minikubeConfig["show-libmachine-logs"].(bool)
-	if !ok {
-		t.Fatal("Type is not set to bool")
-	}
-	if !val {
-		t.Fatal("SetBool set value is incorrect")
-	}
+
+	assert.True(t, ok, "Type is not set to bool")
+	assert.True(t, val, "SetBool set value is incorrect")
+	assert.IsType(t, *new(bool), minikubeConfig["show-libmachine-logs"])
 }
 
 func TestSetSlice(t *testing.T) {
 	expectedSlice := []string{"172.0.0.1/16", "mycustom.registry.com/3030"}
 	err := SetSlice(minikubeConfig, "insecure-registry", strings.Join(expectedSlice, ","))
-	if err != nil {
-		t.Fatalf("Cannot set Slice value in config: %s", err)
-	}
-	val, ok := minikubeConfig["insecure-registry"].([]string)
-	if !ok {
-		t.Fatal("Type is not set to slice")
-	}
-	if !reflect.DeepEqual(expectedSlice, val) {
-		t.Fatalf("Expected: %+v, Got: %+v", expectedSlice, val)
-	}
+	assert.NoError(t, err, "Error setting slice")
+	val, _ := minikubeConfig["insecure-registry"].([]string)
+	assert.IsType(t, *new([]string), minikubeConfig["insecure-registry"])
+	assert.Equal(t, expectedSlice, val)
 }

--- a/cmd/minishift/cmd/config/view_test.go
+++ b/cmd/minishift/cmd/config/view_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/minishift/minishift/cmd/testing/cli"
+	"github.com/stretchr/testify/assert"
 )
 
 type templateExpectedOutputTest struct {
@@ -73,8 +74,6 @@ func TestConfigView(t *testing.T) {
 
 		template := determineTemplate(tt.template)
 		configView(configTest, template, tee.StdoutBuffer)
-		if tee.StdoutBuffer.String() != tt.expectedString {
-			t.Fatalf("Expected '%s'. Got '%s'.", tt.expectedString, tee.StdoutBuffer.String())
-		}
+		assert.Equal(t, tt.expectedString, tee.StdoutBuffer.String())
 	}
 }

--- a/cmd/minishift/cmd/console_test.go
+++ b/cmd/minishift/cmd/console_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/minishift/minishift/cmd/testing/cli"
-	"strings"
 	"testing"
+
+	"github.com/minishift/minishift/cmd/testing/cli"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDisplayConsoleInMachineReadable(t *testing.T) {
@@ -27,13 +29,12 @@ func TestDisplayConsoleInMachineReadable(t *testing.T) {
 
 	expectedStdout := `HOST=192.168.1.1
 PORT=8443
-CONSOLE_URL=https://192.168.99.103:8443`
+CONSOLE_URL=https://192.168.99.103:8443
+`
 
 	displayConsoleInMachineReadable("192.168.1.1", "https://192.168.99.103:8443")
 	tee.Close()
 
 	actualStdout := tee.StdoutBuffer.String()
-	if strings.TrimSpace(actualStdout) != expectedStdout {
-		t.Fatalf("Expected:\n '%s' \nGot\n '%s'", expectedStdout, actualStdout)
-	}
+	assert.Equal(t, expectedStdout, actualStdout)
 }

--- a/cmd/minishift/cmd/delete_test.go
+++ b/cmd/minishift/cmd/delete_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/minishift/minishift/cmd/testing/cli"
 	pgkTesting "github.com/minishift/minishift/pkg/testing"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/pkg/util/filehelper"
@@ -67,9 +68,7 @@ func Test_clear_cache_forced(t *testing.T) {
 	forceFlag = true
 	clearCache()
 
-	if filehelper.Exists(state.InstanceDirs.Cache) {
-		t.Fatalf("Expected cache dir '%s' to be deleted", state.InstanceDirs.Cache)
-	}
+	assert.False(t, filehelper.Exists(state.InstanceDirs.Cache), "Expected cache dir '%s' to be deleted", state.InstanceDirs.Cache)
 }
 
 func Test_delete_succeeds_for_non_existing_vm(t *testing.T) {

--- a/cmd/minishift/cmd/image/util_test.go
+++ b/cmd/minishift/cmd/image/util_test.go
@@ -17,13 +17,15 @@ limitations under the License.
 package image
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testData struct {
 	image           string
 	normalizedImage string
-	err             error
 }
 
 var tests = []testData{
@@ -34,11 +36,8 @@ var tests = []testData{
 func Test_normalize_image_names(t *testing.T) {
 	for _, test := range tests {
 		normalizedImage, err := normalizeImageName(test.image)
-		if err != test.err {
-			t.Errorf("Expected error '%v' , got '%v'", test.err, err)
-		}
-		if normalizedImage != test.normalizedImage {
-			t.Errorf("Normalinzing '%s' should have returned '%s', got '%s'", test.image, normalizedImage, test.normalizedImage)
-		}
+
+		assert.NoError(t, err)
+		assert.Equal(t, normalizedImage, test.normalizedImage, fmt.Sprintf("Normalizing '%s' should have returned '%s', got '%s'", test.image, normalizedImage, test.normalizedImage))
 	}
 }

--- a/cmd/minishift/cmd/oc_env_test.go
+++ b/cmd/minishift/cmd/oc_env_test.go
@@ -20,15 +20,13 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_unix_oc_path(t *testing.T) {
 	shellConfig, err := getOcShellConfig("/Users/john/.minishift/cache/oc/v1.5.0/oc", "bash")
-	if err != nil {
-		t.Fatalf("Unexepcted error: %s", err)
-	}
-
-	if shellConfig.OcDirPath != "/Users/john/.minishift/cache/oc/v1.5.0" {
-		t.Fatalf("Unexepcted oc path: %s", shellConfig.OcDirPath)
-	}
+	assert.NoError(t, err)
+	expectedOcDirPath := "/Users/john/.minishift/cache/oc/v1.5.0"
+	assert.Equal(t, shellConfig.OcDirPath, expectedOcDirPath)
 }

--- a/cmd/minishift/cmd/oc_env_test_windows.go
+++ b/cmd/minishift/cmd/oc_env_test_windows.go
@@ -18,15 +18,13 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_windows_oc_path(t *testing.T) {
 	shellConfig, err := getOcShellConfig("C:\\Users\\john\\.minishift\\cache\\oc\\v1.5.0\\oc.exe", "")
-	if err != nil {
-		t.Fatalf("Unexepcted error: %s", err)
-	}
-
-	if shellConfig.OcDirPath != "C:\\Users\\john\\.minishift\\cache\\oc\\v1.5.0" {
-		t.Fatalf("Unexepcted oc path: %s", shellConfig.OcDirPath)
-	}
+	assert.NoError(t, err)
+	expectedOcDirPath := "C:\\Users\\john\\.minishift\\cache\\oc\\v1.5.0"
+	assert.Equal(t, shellConfig.OcDirPath, expectedOcDirPath)
 }

--- a/cmd/minishift/cmd/root_test.go
+++ b/cmd/minishift/cmd/root_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 
 	"io/ioutil"
 	"path/filepath"
@@ -91,9 +92,7 @@ func TestPreRunDirectories(t *testing.T) {
 	allInstanceConfigPath := filepath.Join(testDir, "config", "allinstances.json")
 	minishiftConfig.AllInstancesConfig, err = minishiftConfig.NewAllInstancesConfig(allInstanceConfigPath)
 
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
 	constants.Minipath = testDir
@@ -103,18 +102,16 @@ func TestPreRunDirectories(t *testing.T) {
 	for i := 0; i < dirPaths.NumField(); i++ {
 		dir := dirPaths.Field(i).Interface().(string)
 		_, err := os.Stat(dir)
-		if os.IsNotExist(err) {
-			t.Fatalf("Directory %s does not exist.", dir)
-		}
+		assert.NoError(t, err, "Directory %s does not exist.", dir)
 	}
 }
 
 func TestViperConfig(t *testing.T) {
 	defer viper.Reset()
 	err := cli.InitTestConfig(`{ "v": "999" }`)
-	if viper.GetString("v") != "999" || err != nil {
-		t.Fatalf("Viper cannot read the test config file: %v", err)
-	}
+
+	assert.NoError(t, err, "Failed to initialize the test config file")
+	assert.Equal(t, viper.GetString("v"), "999", "Viper cannot read the test config file")
 }
 
 func TestViperAndFlags(t *testing.T) {
@@ -124,13 +121,9 @@ func TestViperAndFlags(t *testing.T) {
 		cli.SetOptionValue(t, testOption)
 		setupViper()
 		f := pflag.Lookup(testOption.Name)
-		if f == nil {
-			t.Fatalf("Cannot find the flag for %s", testOption.Name)
-		}
+		assert.NotNil(t, f)
 		actual := f.Value.String()
-		if actual != testOption.ExpectedValue {
-			t.Errorf("pflag.Value(%s) => %s, wanted %s [%+v]", testOption.Name, actual, testOption.ExpectedValue, testOption)
-		}
+		assert.Equal(t, testOption.ExpectedValue, actual)
 		cli.UnsetValues(testOption)
 	}
 }
@@ -153,8 +146,6 @@ func TestInitializeProfile(t *testing.T) {
 	for _, testInput := range Testdata {
 		os.Args = testInput.Args
 		got := initializeProfile()
-		if got != testInput.Result {
-			t.Errorf("Got %s, Expected %s as profile Name", got, testInput.Result)
-		}
+		assert.Equal(t, testInput.Result, got)
 	}
 }

--- a/cmd/minishift/cmd/start_preflight_notwin_test.go
+++ b/cmd/minishift/cmd/start_preflight_notwin_test.go
@@ -25,14 +25,13 @@ import (
 
 	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsoUrl(t *testing.T) {
 	defer viper.Reset()
 	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	assert.NoError(t, err, "Error getting working directory")
 	dummyIsoFile := filepath.Join(currentDir, "..", "..", "..", "test", "testdata", "dummy.iso")
 
 	var isoURLCheck = sharedIsoURLChecks
@@ -40,9 +39,7 @@ func TestIsoUrl(t *testing.T) {
 
 	for _, urlTest := range isoURLCheck {
 		viper.Set(configCmd.ISOUrl.Name, urlTest.in)
-		ret := checkIsoURL()
-		if ret != urlTest.out {
-			t.Errorf("Expected '%t' for given url '%s'. Got '%t'.", urlTest.out, urlTest.in, ret)
-		}
+		actual := checkIsoURL()
+		assert.Equal(t, urlTest.out, actual)
 	}
 }

--- a/cmd/minishift/cmd/start_preflight_windows_test.go
+++ b/cmd/minishift/cmd/start_preflight_windows_test.go
@@ -25,14 +25,13 @@ import (
 
 	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsoUrlOnWindows(t *testing.T) {
 	defer viper.Reset()
 	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	assert.NoError(t, err, "Error getting working directory")
 
 	dummyIsoFile := filepath.Join(currentDir, "..", "..", "..", "test", "testdata", "dummy.iso")
 	dummyIsoFileWithForwardSlash := strings.Replace(dummyIsoFile, "\\", "/", -1)
@@ -45,9 +44,7 @@ func TestIsoUrlOnWindows(t *testing.T) {
 
 	for _, urlTest := range isoURLCheck {
 		viper.Set(configCmd.ISOUrl.Name, urlTest.in)
-		ret := checkIsoURL()
-		if ret != urlTest.out {
-			t.Errorf("Expected '%t' for given url '%s'. Got '%t'.", urlTest.out, urlTest.in, ret)
-		}
+		actual := checkIsoURL()
+		assert.Equal(t, urlTest.out, actual)
 	}
 }

--- a/cmd/minishift/cmd/start_test.go
+++ b/cmd/minishift/cmd/start_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/machine/libmachine/provision"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/minishift/minishift/cmd/minishift/cmd/config"
 
@@ -149,9 +150,7 @@ func TestStartClusterUpNoFlags(t *testing.T) {
 	clusterUpParams := determineClusterUpParameters(testConfig)
 	clusterup.ClusterUp(testConfig, clusterUpParams, testRunner)
 
-	if testRunner.Cmd != testConfig.OcPath {
-		t.Errorf("Expected command '%s'. Received '%s'", testConfig.OcPath, testRunner.Cmd)
-	}
+	assert.Equal(t, testConfig.OcPath, testRunner.Cmd)
 
 	expectedArguments := []string{
 		"cluster",
@@ -336,9 +335,7 @@ func TestNoExplicitRouteSuffixDefaultsToNip(t *testing.T) {
 	expectedRoutingSuffix := testConfig.Ip + ".nip.io"
 	actualRoutingSuffix := getDefaultRoutingPrefix(testConfig.Ip)
 
-	if actualRoutingSuffix != expectedRoutingSuffix {
-		t.Fatalf("Expected argument '%s'. Received '%s'", expectedRoutingSuffix, viper.Get(config.RoutingSuffix.Name))
-	}
+	assert.Equal(t, expectedRoutingSuffix, actualRoutingSuffix)
 }
 
 func TestExplicitRouteSuffixGetApplied(t *testing.T) {
@@ -352,9 +349,7 @@ func TestExplicitRouteSuffixGetApplied(t *testing.T) {
 
 	actualRoutingSuffix := getDefaultRoutingPrefix(testConfig.Ip)
 
-	if actualRoutingSuffix != explicitRoutingSuffix {
-		t.Fatalf("Expected argument '%s'. Received '%s'", explicitRoutingSuffix, viper.Get(config.RoutingSuffix.Name))
-	}
+	assert.Equal(t, explicitRoutingSuffix, actualRoutingSuffix)
 }
 
 func TestCheckMemorySize(t *testing.T) {
@@ -370,9 +365,8 @@ func TestCheckMemorySize(t *testing.T) {
 
 	for _, sizeTest := range sizeTests {
 		size := calculateMemorySize(sizeTest.in)
-		if size != sizeTest.out {
-			t.Errorf("Expected '%d' for memory size given input '%s'. Got '%d'.", sizeTest.out, sizeTest.in, size)
-		}
+
+		assert.Equal(t, sizeTest.out, size)
 	}
 }
 
@@ -389,9 +383,8 @@ func TestCheckDiskSize(t *testing.T) {
 
 	for _, sizeTest := range sizeTests {
 		size := calculateDiskSize(sizeTest.in)
-		if size != sizeTest.out {
-			t.Errorf("Expected '%d' for disk size given input '%s'. Got '%d'.", sizeTest.out, sizeTest.in, size)
-		}
+
+		assert.Equal(t, sizeTest.out, size)
 	}
 }
 
@@ -414,9 +407,7 @@ func TestDetermineIsoUrl(t *testing.T) {
 
 	for _, isoTest := range isoTests {
 		isoUrl := determineIsoUrl(isoTest.in)
-		if isoUrl != isoTest.out {
-			t.Errorf("Expected '%s' as ISO URL for input '%s'. Got '%s'.", isoTest.out, isoTest.in, isoUrl)
-		}
+		assert.Equal(t, isoTest.out, isoUrl)
 	}
 }
 
@@ -443,14 +434,10 @@ func Test_getslice_withConfig(t *testing.T) {
 	viper.ReadConfig(bytes.NewBuffer(confFile))
 
 	expectedSlice := []string{"hello", "world"}
-	if len(expectedSlice) != len(getSlice("bar")) {
-		t.Errorf("expected %+v, Got %+v", len(expectedSlice), len(getSlice("bar")))
-	}
+	assert.Len(t, expectedSlice, len(getSlice("bar")))
 
 	for i, v := range getSlice("bar") {
-		if expectedSlice[i] != v {
-			t.Errorf("expected %+v. Got %+v", expectedSlice[i], v)
-		}
+		assert.Equal(t, expectedSlice[i], v)
 	}
 }
 
@@ -459,50 +446,34 @@ func Test_getslice_withCommandLine(t *testing.T) {
 	defer viper.Reset()
 
 	expectedSlice := []string{"hello", "world"}
-	if len(expectedSlice) != len(getSlice("foo")) {
-		t.Errorf("expected %+v, Got %+v", len(expectedSlice), len(getSlice("foo")))
-	}
+	assert.Len(t, expectedSlice, len(getSlice("foo")))
 
 	for i, v := range getSlice("foo") {
-		if expectedSlice[i] != v {
-			t.Errorf("expected %+v. Got %+v", expectedSlice[i], v)
-		}
+		assert.Equal(t, expectedSlice[i], v)
 	}
 }
 
 func assertCommandLineArguments(expectedArguments []string, t *testing.T) {
-	if len(expectedArguments) > len(testRunner.Args) {
-		t.Errorf("Expected more arguments than received. Expected: '%s'. Got: '%s'", expectedArguments, testRunner.Args)
-	}
-
-	if len(expectedArguments) < len(testRunner.Args) {
-		t.Errorf("Received more arguments than expected. Expected: '%s'. Got '%s'", expectedArguments, testRunner.Args)
-	}
+	assert.Len(t, expectedArguments, len(testRunner.Args))
 
 	sort.Strings(testRunner.Args)
 	sort.Strings(expectedArguments)
 
 	for i, v := range testRunner.Args {
-		if v != expectedArguments[i] {
-			t.Errorf("Expected argument '%s'. Received '%s'", expectedArguments[i], v)
-		}
+		assert.Equal(t, expectedArguments[i], v)
 	}
 }
 
 func setUp(t *testing.T) {
 	var err error
 	testDir, err = ioutil.TempDir("", "minishift-test-start-cmd-")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "Error creating temporary directory")
 
 	machinesDirPath := filepath.Join(testDir, "machines")
 	os.Mkdir(machinesDirPath, 0755)
 	instanceState.InstanceConfig, err = instanceState.NewInstanceConfig(filepath.Join(machinesDirPath, "fake-machines.json"))
-	if err != nil {
-		t.Error(err)
-	}
 
+	assert.NoError(t, err, "Error getting new instance config")
 	constants.Minipath = testDir
 
 	testRunner = &RecordingRunner{}

--- a/cmd/minishift/cmd/update_test.go
+++ b/cmd/minishift/cmd/update_test.go
@@ -21,15 +21,15 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateUpdateMarker(t *testing.T) {
 	testFile, err := ioutil.TempFile(os.TempDir(), "testFile")
 	testFileName := testFile.Name()
 	defer os.Remove(testFileName)
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err, "Error creating temporary file")
 
 	expectedInstallAddon, expectedPreviousVersion := true, "1.0.0"
 	createUpdateMarker(testFileName, UpdateMarker{expectedInstallAddon, expectedPreviousVersion})
@@ -38,15 +38,8 @@ func TestCreateUpdateMarker(t *testing.T) {
 	var markerData UpdateMarker
 
 	file, err := ioutil.ReadFile(testFileName)
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
-
+	assert.NoError(t, err, "Error reading temporary file")
 	json.Unmarshal(file, &markerData)
-	if markerData.InstallAddon != expectedInstallAddon {
-		t.Fatalf("Expected allow installation of addon to be %t but got %t.", expectedInstallAddon, markerData.InstallAddon)
-	}
-	if markerData.PreviousVersion != expectedPreviousVersion {
-		t.Fatalf("Expected previous version to be %s but got %s.", expectedPreviousVersion, markerData.PreviousVersion)
-	}
+	assert.Equal(t, expectedInstallAddon, markerData.InstallAddon)
+	assert.Equal(t, expectedPreviousVersion, markerData.PreviousVersion)
 }

--- a/cmd/minishift/cmd/util/env_test.go
+++ b/cmd/minishift/cmd/util/env_test.go
@@ -20,6 +20,8 @@ package util
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReplaceEnv(t *testing.T) {
@@ -27,11 +29,8 @@ func TestReplaceEnv(t *testing.T) {
 		"LC_ALL=de_DE.UTF8", "MINISHIFTHOME=/home/user/.minishift"}
 	replaced := ReplaceEnv(env, "LC_ALL", "C")
 
-	if env[2] == "LC_ALL=de_DE.UTF8" && replaced[2] != "LC_ALL=C" {
-		t.Fatalf("Environment variable did not get replaced: '%s', '%s'", env[2], replaced[2])
-	}
+	assert.Equal(t, env[2], "LC_ALL=de_DE.UTF8")
+	assert.Equal(t, replaced[2], "LC_ALL=C")
 
-	if len(env) != len(replaced) {
-		t.Fatalf("Environment variables do not match length: '%d', '%d'", len(env), len(replaced))
-	}
+	assert.Len(t, env, len(replaced))
 }

--- a/cmd/minishift/cmd/util/util_test.go
+++ b/cmd/minishift/cmd/util/util_test.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsValidProfileName(t *testing.T) {
@@ -43,8 +45,6 @@ func TestIsValidProfileName(t *testing.T) {
 		{"foo-123", true}}
 	for _, v := range testData {
 		got := IsValidProfileName(v.profileName)
-		if got != v.expected {
-			t.Errorf("Expected *%s* profileName to be %t, Got %t", v.profileName, v.expected, got)
-		}
+		assert.Equal(t, v.expected, got)
 	}
 }

--- a/cmd/minishift/cmd/version_test.go
+++ b/cmd/minishift/cmd/version_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package cmd
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/minishift/minishift/cmd/testing/cli"
-	"regexp"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_version_output_has_correct_format(t *testing.T) {
@@ -32,12 +33,5 @@ func Test_version_output_has_correct_format(t *testing.T) {
 	versionString := tee.StdoutBuffer.String()
 
 	versionRegExp := "minishift v[0-9]+\\.[0-9]+\\.[0-9]+\\+[a-z0-9]{7,8}\n"
-	match, err := regexp.Match(versionRegExp, []byte(versionString))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	if !match {
-		t.Fatalf("Expected version string to match '%s' but '%s' does not.", versionRegExp, versionString)
-	}
+	assert.Regexp(t, regexp.MustCompile(versionRegExp), versionString)
 }

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -20,19 +20,19 @@ import (
 	"path/filepath"
 	"testing"
 
+	"io/ioutil"
+	"os"
+
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minikube/tests"
-	"io/ioutil"
-	"os"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoteBoot2DockerURL(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-tmp-test-dir-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "Error creating temp directory")
 	defer os.RemoveAll(testDir)
 
 	var machineConfig = MachineConfig{
@@ -44,9 +44,7 @@ func TestRemoteBoot2DockerURL(t *testing.T) {
 	expectedURL := "file://" + filepath.ToSlash(isoPath)
 	url := machineConfig.GetISOFileURI()
 
-	if url != expectedURL {
-		t.Fatalf("Expected URL : %s, Got : %s", expectedURL, url)
-	}
+	assert.Equal(t, expectedURL, url)
 }
 
 func TestLocalBoot2DockerURL(t *testing.T) {
@@ -59,9 +57,7 @@ func TestLocalBoot2DockerURL(t *testing.T) {
 
 	url := machineConfig.GetISOFileURI()
 
-	if url != localISOUrl {
-		t.Fatalf("Expected URL : %s", localISOUrl)
-	}
+	assert.Equal(t, localISOUrl, url)
 }
 
 func TestFollowLogsFlag(t *testing.T) {
@@ -69,9 +65,7 @@ func TestFollowLogsFlag(t *testing.T) {
 
 	s, _ := tests.NewSSHServer()
 	port, err := s.Start()
-	if err != nil {
-		t.Fatalf("Error starting ssh server: %s", err)
-	}
+	assert.NoError(t, err, "Error starting ssh server")
 
 	d := &tests.MockDriver{
 		Port: port,
@@ -98,12 +92,10 @@ func TestFollowLogsFlag(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.expectedCommand, func(t *testing.T) {
-			if _, err = GetHostLogs(api, test.follow); err != nil {
-				t.Errorf("Error getting logs of the running OpenShift cluster: %s", err)
-			}
-			if _, ok := s.Commands[test.expectedCommand]; !ok {
-				t.Errorf("Expected command %s to run but did not.", test.expectedCommand)
-			}
+			_, err := GetHostLogs(api, test.follow)
+			assert.NoError(t, err, "Error gettinglogsof the running OpenShift cluster")
+			_, ok := s.Commands[test.expectedCommand]
+			assert.True(t, ok, "Expected command to run but did not")
 		})
 	}
 }

--- a/pkg/minikube/cluster/driver_options_test.go
+++ b/pkg/minikube/cluster/driver_options_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package cluster
 
 import (
-	"github.com/docker/machine/libmachine/drivers"
-	"github.com/minishift/minishift/pkg/minikube/tests"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/minishift/minishift/pkg/minikube/tests"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_driver_options_from_config(t *testing.T) {
@@ -35,17 +37,12 @@ func Test_driver_options_from_config(t *testing.T) {
 	explicitConfig["test-boot2docker-url"] = expectedURL
 
 	driverOptions, err := prepareDriverOptions(supportedFlags, explicitConfig)
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err, "Error preparing driver options ")
 
-	if err := d.SetConfigFromFlags(driverOptions); err != nil {
-		t.Fatal("Unexpected error:" + err.Error())
-	}
+	err = d.SetConfigFromFlags(driverOptions)
+	assert.NoError(t, err, "Error setting configs from flags")
 
-	if d.Boot2DockerURL != expectedURL {
-		t.Fatalf("Expected %s but got %s", expectedURL, d.Boot2DockerURL)
-	}
+	assert.Equal(t, expectedURL, d.Boot2DockerURL)
 }
 
 func Test_driver_options_from_environment(t *testing.T) {
@@ -59,17 +56,12 @@ func Test_driver_options_from_environment(t *testing.T) {
 	defer os.Unsetenv("TEST_BOOT2DOCKER_URL")
 
 	driverOptions, err := prepareDriverOptions(supportedFlags, make(map[string]interface{}))
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err, "Error preparing driver options ")
 
-	if err := d.SetConfigFromFlags(driverOptions); err != nil {
-		t.Fatal("Unexpected error:" + err.Error())
-	}
+	err = d.SetConfigFromFlags(driverOptions)
+	assert.NoError(t, err, "Error setting configs from flags")
 
-	if d.Boot2DockerURL != expectedURL {
-		t.Fatalf("Expected %s but got %s", expectedURL, d.Boot2DockerURL)
-	}
+	assert.Equal(t, expectedURL, d.Boot2DockerURL)
 }
 
 func Test_driver_options_from_environment_int_type(t *testing.T) {
@@ -83,14 +75,10 @@ func Test_driver_options_from_environment_int_type(t *testing.T) {
 	defer os.Unsetenv("TEST_CPU_COUNT")
 
 	driverOptions, err := prepareDriverOptions(supportedFlags, make(map[string]interface{}))
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err, "Error preparing driver options ")
 
 	actualCount := driverOptions.Int("test-cpu-count")
-	if actualCount != expectedCpuCount {
-		t.Fatalf("Expected %d but got %d", expectedCpuCount, actualCount)
-	}
+	assert.Equal(t, expectedCpuCount, actualCount)
 }
 
 func Test_driver_options_from_environment_win(t *testing.T) {
@@ -106,17 +94,12 @@ func Test_driver_options_from_environment_win(t *testing.T) {
 	explicitConfig["test-boot2docker-url"] = "/snafu/boot2docker.iso"
 
 	driverOptions, err := prepareDriverOptions(supportedFlags, explicitConfig)
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err, "Error preparing dirver options")
 
-	if err := d.SetConfigFromFlags(driverOptions); err != nil {
-		t.Fatal("Unexpected error:" + err.Error())
-	}
+	err = d.SetConfigFromFlags(driverOptions)
+	assert.NoError(t, err, "Error setting configs from flags")
 
-	if d.Boot2DockerURL != expectedURL {
-		t.Fatalf("Expected %s but got %s", expectedURL, d.Boot2DockerURL)
-	}
+	assert.Equal(t, expectedURL, d.Boot2DockerURL)
 }
 
 func Test_wrong_driver_option_does_not_affect_driver_config(t *testing.T) {
@@ -130,17 +113,12 @@ func Test_wrong_driver_option_does_not_affect_driver_config(t *testing.T) {
 	defer os.Unsetenv("WRONG_BOOT2DOCKER_URL")
 
 	driverOptions, err := prepareDriverOptions(supportedFlags, make(map[string]interface{}))
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err, "Error preparing driver options")
 
-	if err := d.SetConfigFromFlags(driverOptions); err != nil {
-		t.Fatalf("Unexpected error:" + err.Error())
-	}
+	err = d.SetConfigFromFlags(driverOptions)
+	assert.NoError(t, err, "Error setting configs from flags")
 
-	if d.Boot2DockerURL != "" {
-		t.Fatalf("Expected empty url, but got %s", d.Boot2DockerURL)
-	}
+	assert.Empty(t, d.Boot2DockerURL)
 }
 
 func Test_unused_explicit_driver_options_returns_error(t *testing.T) {
@@ -153,12 +131,8 @@ func Test_unused_explicit_driver_options_returns_error(t *testing.T) {
 	explicitConfig["foo"] = "bar"
 
 	_, err := prepareDriverOptions(supportedFlags, explicitConfig)
-	if err == nil {
-		t.Fatal("Expexted and error, but got none")
-	}
+	assert.Error(t, err, "preparingDriverOptions should return error")
 
 	expectedError := "Unused explicit driver options: map[foo:bar]"
-	if err.Error() != expectedError {
-		t.Fatalf("Expected error message '%s', got '%s'", expectedError, err.Error())
-	}
+	assert.EqualError(t, err, expectedError)
 }

--- a/pkg/minikube/constants/constants_test.go
+++ b/pkg/minikube/constants/constants_test.go
@@ -22,15 +22,14 @@ import (
 	"testing"
 
 	"github.com/minishift/minishift/pkg/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultMinishiftHome(t *testing.T) {
 	os.Unsetenv("MINISHIFT_HOME")
 	expectedMiniPath := filepath.Join(util.HomeDir(), ".minishift")
 	actualMiniPath := GetMinishiftHomeDir()
-	if actualMiniPath != expectedMiniPath {
-		t.Fatalf("Expected Minishift home directory : '%s' Got: '%s'", expectedMiniPath, actualMiniPath)
-	}
+	assert.Equal(t, expectedMiniPath, actualMiniPath)
 }
 
 func TestMinishiftHomeViaEnvironment(t *testing.T) {
@@ -39,7 +38,5 @@ func TestMinishiftHomeViaEnvironment(t *testing.T) {
 	defer os.Unsetenv("MINISHIFT_HOME")
 
 	actualMiniPath := GetMinishiftHomeDir()
-	if actualMiniPath != expectedMiniPath {
-		t.Fatalf("Expected Minishift home directory : '%s' Got: '%s'", expectedMiniPath, actualMiniPath)
-	}
+	assert.Equal(t, expectedMiniPath, actualMiniPath)
 }

--- a/pkg/minikube/kubeconfig/config_test.go
+++ b/pkg/minikube/kubeconfig/config_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
 
@@ -47,14 +47,14 @@ func TestCacheSystemAdminEntries(t *testing.T) {
 	yaml.Unmarshal([]byte(data), &testSystemConfig)
 
 	// verify entries
-	strings.Contains(kubeData, testSystemConfig.Users[0].Name)
-	strings.Contains(kubeData, testSystemConfig.Users[0].User["client-certificate-data"])
-	strings.Contains(kubeData, testSystemConfig.Clusters[0].Name)
-	strings.Contains(kubeData, testSystemConfig.Clusters[0].Cluster["certificate-authority-data"])
-	strings.Contains(kubeData, testSystemConfig.Clusters[0].Cluster["server"])
-	strings.Contains(kubeData, testSystemConfig.Contexts[0].Name)
-	strings.Contains(kubeData, testSystemConfig.Contexts[0].Context["cluster"])
-	strings.Contains(kubeData, testSystemConfig.Contexts[0].Context["user"])
+	assert.Contains(t, kubeData, testSystemConfig.Users[0].Name)
+	assert.Contains(t, kubeData, testSystemConfig.Users[0].User["client-certificate-data"])
+	assert.Contains(t, kubeData, testSystemConfig.Clusters[0].Name)
+	assert.Contains(t, kubeData, testSystemConfig.Clusters[0].Cluster["certificate-authority-data"])
+	assert.Contains(t, kubeData, testSystemConfig.Clusters[0].Cluster["server"])
+	assert.Contains(t, kubeData, testSystemConfig.Contexts[0].Name)
+	assert.Contains(t, kubeData, testSystemConfig.Contexts[0].Context["cluster"])
+	assert.Contains(t, kubeData, testSystemConfig.Contexts[0].Context["user"])
 }
 
 func setUp() {

--- a/pkg/minikube/machine/client_test.go
+++ b/pkg/minikube/machine/client_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
 	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/stretchr/testify/assert"
 )
 
 func makeTempDir() string {
@@ -41,9 +42,7 @@ func TestRunNotDriver(t *testing.T) {
 	tempDir := makeTempDir()
 	defer os.RemoveAll(tempDir)
 	StartDriver()
-	if !localbinary.CurrentBinaryIsDockerMachine {
-		t.Fatal("CurrentBinaryIsDockerMachine is not set. This will prevent driver initialization.")
-	}
+	assert.True(t, localbinary.CurrentBinaryIsDockerMachine, "CurrentBinaryIsDockerMachine Not set This will prevent driver initialization")
 }
 
 func TestRunDriver(t *testing.T) {
@@ -69,13 +68,10 @@ func TestRunDriver(t *testing.T) {
 	// The command will write out what port it's listening on over stdout.
 	reader := bufio.NewReader(r)
 	addr, _, err := reader.ReadLine()
-	if err != nil {
-		t.Fatal("Cannot read address in the standard output.")
-	}
+	assert.NoError(t, err, "Cannot read address in the standard output")
 	os.Stdout = old
 
 	// Now that we got the port, make sure we can connect.
-	if _, err := net.Dial("tcp", string(addr)); err != nil {
-		t.Fatal("Driver is not listening.")
-	}
+	_, err = net.Dial("tcp", string(addr))
+	assert.NoError(t, err, "Driver is not listening")
 }

--- a/pkg/minishift/addon/addon.go
+++ b/pkg/minishift/addon/addon.go
@@ -31,14 +31,14 @@ type AddOn interface {
 	// Commands returns a Command slice of the commands this addon consists of.
 	Commands() []command.Command
 
-	// RemoveCommands returns a Command slice of the commands which use for remove this addon.
+	// RemoveCommands returns a slice of the commands which are used to remove this addon.
 	RemoveCommands() []command.Command
 
 	// InstallPath returns the path under which the addon is installed.
 	InstallPath() string
 
 	// IsEnabled returns true, if this addon is currently enabled and getting applied as part of OpenShift
-	// provisioning. Returns false, is this addon is not enabled.
+	// provisioning. Returns false, if this addon is not enabled.
 	IsEnabled() bool
 
 	// SetEnabled sets this addon as en- or disabled.

--- a/pkg/minishift/addon/addon_meta_test.go
+++ b/pkg/minishift/addon/addon_meta_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package addon
 
 import (
-	"fmt"
 	"testing"
 
-	minishiftTesting "github.com/minishift/minishift/pkg/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Metadata_creation_succeeds(t *testing.T) {
@@ -33,11 +32,8 @@ func Test_Metadata_creation_succeeds(t *testing.T) {
 
 	addOnMeta := getAddOnMeta(testMap, t)
 
-	if addOnMeta.Name() != testName {
-		t.Fatal(fmt.Sprintf("Expected addon name '%s', but got '%s'", testName, addOnMeta.Name()))
-	}
-
-	minishiftTesting.AssertEqualSlice(addOnMeta.Description(), testDescription, t)
+	assert.Equal(t, testName, addOnMeta.Name())
+	assert.Equal(t, testDescription, addOnMeta.Description())
 }
 
 func Test_missing_name_returns_error(t *testing.T) {
@@ -48,14 +44,9 @@ func Test_missing_name_returns_error(t *testing.T) {
 
 	_, err := NewAddOnMeta(testMap)
 
-	if err == nil {
-		t.Fatal("Expected an error, got none")
-	}
-
+	assert.Error(t, err)
 	expectedError := "Metadata does not contain a mandatory entry for 'Name'"
-	if err.Error() != expectedError {
-		t.Fatal(fmt.Sprintf("Expected error '%s', but got '%s'", expectedError, err.Error()))
-	}
+	assert.EqualError(t, err, expectedError)
 }
 
 func Test_missing_description_returns_error(t *testing.T) {
@@ -66,14 +57,11 @@ func Test_missing_description_returns_error(t *testing.T) {
 
 	_, err := NewAddOnMeta(testMap)
 
-	if err == nil {
-		t.Fatal("Expected an error, got none")
-	}
+	assert.Error(t, err)
 
 	expectedError := "Metadata does not contain a mandatory entry for 'Description'"
-	if err.Error() != expectedError {
-		t.Fatal(fmt.Sprintf("Expected error '%s', but got '%s'", expectedError, err.Error()))
-	}
+
+	assert.EqualError(t, err, expectedError)
 }
 
 func Test_optional_metadata_is_retained(t *testing.T) {
@@ -88,9 +76,7 @@ func Test_optional_metadata_is_retained(t *testing.T) {
 
 	addOnMeta := getAddOnMeta(testMap, t)
 
-	if addOnMeta.GetValue("Url") != testUrl {
-		t.Fatal(fmt.Sprintf("Expected addon value '%s', but got '%s'", testName, addOnMeta.GetValue("Url")))
-	}
+	assert.Equal(t, testUrl, addOnMeta.GetValue("Url"))
 }
 
 func Test_required_vars_meta_is_extracted(t *testing.T) {
@@ -101,7 +87,7 @@ func Test_required_vars_meta_is_extracted(t *testing.T) {
 
 	addOnMeta := getAddOnMeta(testMap, t)
 	requiredVars, _ := addOnMeta.RequiredVars()
-	minishiftTesting.AssertEqualSlice(requiredVars, []string{"USER", "access_token"}, t)
+	assert.Equal(t, []string{"USER", "access_token"}, requiredVars)
 }
 
 func Test_required_vars_empty_if_not_specified(t *testing.T) {
@@ -111,7 +97,8 @@ func Test_required_vars_empty_if_not_specified(t *testing.T) {
 
 	addOnMeta := getAddOnMeta(testMap, t)
 	requiredVars, _ := addOnMeta.RequiredVars()
-	minishiftTesting.AssertEqualSlice(requiredVars, []string{}, t)
+
+	assert.Equal(t, []string{}, requiredVars)
 }
 
 func Test_var_defaults_empty_if_not_specified(t *testing.T) {
@@ -121,9 +108,8 @@ func Test_var_defaults_empty_if_not_specified(t *testing.T) {
 
 	addOnMeta := getAddOnMeta(testMap, t)
 	varDefaults, _ := addOnMeta.VarDefaults()
-	if len(varDefaults) != 0 {
-		t.Fatal(fmt.Sprintf("Expected empty var default, but got: '%d'", len(varDefaults)))
-	}
+
+	assert.Len(t, varDefaults, 0)
 }
 
 func Test_var_defaults_meta_is_extracted(t *testing.T) {
@@ -135,9 +121,8 @@ func Test_var_defaults_meta_is_extracted(t *testing.T) {
 
 	addOnMeta := getAddOnMeta(testMap, t)
 	varDefaults, _ := addOnMeta.VarDefaults()
-	if len(varDefaults) != 1 {
-		t.Fatal(fmt.Sprintf("Expected one var default, but got: '%d'", len(varDefaults)))
-	}
+
+	assert.Len(t, varDefaults, 1)
 }
 
 type varDefaultTestCase struct {
@@ -172,22 +157,16 @@ func Test_invalid_var_defaults_meta(t *testing.T) {
 	for _, testCase := range testCases {
 		testMap["Var-Defaults"] = testCase.expectedVarDefault
 		_, err := NewAddOnMeta(testMap)
-		if err == nil {
-			t.Fatalf("Expected an error, got none for var default \"%s\"", testCase.expectedVarDefault)
-		}
 
-		if err.Error() != testCase.expectedError {
-			t.Fatalf("Expected error \"%s\", but got \"%s\"", testCase.expectedError, err.Error())
-		}
+		assert.Error(t, err)
+
+		assert.Equal(t, testCase.expectedError, err.Error())
 	}
 }
 
 func getAddOnMeta(testMap map[string]interface{}, t *testing.T) AddOnMeta {
 	addOnMeta, err := NewAddOnMeta(testMap)
-
-	if err != nil {
-		t.Fatal(fmt.Sprintf("No error expected, but got: \"%s\"", err.Error()))
-	}
+	assert.NoError(t, err, "Error getting new addon meta")
 
 	return addOnMeta
 }
@@ -213,8 +192,6 @@ func Test_check_openshift_version_sematic(t *testing.T) {
 	}
 
 	for _, versionTest := range versionTestData {
-		if checkVersionSemantic(versionTest.OpenshiftVersion) != versionTest.expectedResult {
-			t.Errorf("Expected: '%t', Got 'true' for version: %s", versionTest.expectedResult, versionTest.OpenshiftVersion)
-		}
+		assert.Equal(t, versionTest.expectedResult, checkVersionSemantic(versionTest.OpenshiftVersion))
 	}
 }

--- a/pkg/minishift/addon/addon_test.go
+++ b/pkg/minishift/addon/addon_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type DummyAddOn struct {
@@ -67,9 +69,8 @@ func Test_sorting_addons_by_priority(t *testing.T) {
 	sort.Sort(ByPriority(addOns))
 
 	expectedSortOrder := "[c d e b a]"
-	if fmt.Sprint(addOns) != expectedSortOrder {
-		t.Fatal(fmt.Sprintf("Expected sort order '%s', but got '%s'", expectedSortOrder, fmt.Sprint(addOns)))
-	}
+
+	assert.Equal(t, expectedSortOrder, fmt.Sprint(addOns))
 }
 
 func Test_sorting_addons_by_state_and_name(t *testing.T) {
@@ -77,9 +78,8 @@ func Test_sorting_addons_by_state_and_name(t *testing.T) {
 	sort.Sort(ByStatusThenName(addOns))
 
 	expectedSortOrder := "[b d e a c]"
-	if fmt.Sprint(addOns) != expectedSortOrder {
-		t.Fatal(fmt.Sprintf("Expected sort order '%s', but got '%s'", expectedSortOrder, fmt.Sprint(addOns)))
-	}
+
+	assert.Equal(t, expectedSortOrder, fmt.Sprint(addOns))
 }
 
 func Test_sorting_addons_by_state_priority_and_name(t *testing.T) {
@@ -87,7 +87,6 @@ func Test_sorting_addons_by_state_priority_and_name(t *testing.T) {
 	sort.Sort(ByStatusThenPriorityThenName(addOns))
 
 	expectedSortOrder := "[d e b c a]"
-	if fmt.Sprint(addOns) != expectedSortOrder {
-		t.Fatal(fmt.Sprintf("Expected sort order '%s', but got '%s'", expectedSortOrder, fmt.Sprint(addOns)))
-	}
+
+	assert.Equal(t, expectedSortOrder, fmt.Sprint(addOns))
 }

--- a/pkg/minishift/addon/command/echo_command_test.go
+++ b/pkg/minishift/addon/command/echo_command_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package command
 
 import (
-	"fmt"
 	"testing"
 
 	pkgTesting "github.com/minishift/minishift/pkg/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_echo_command(t *testing.T) {
@@ -53,19 +53,14 @@ func Test_echo_command(t *testing.T) {
 	for _, test := range testCases {
 		tee, err := pkgTesting.NewTee(true)
 		defer tee.Close()
-
-		if err != nil {
-			t.Fatal("Unexpected error: " + err.Error())
-		}
+		assert.NoError(t, err, "Error getting instance of Tee")
 
 		echo := NewEchoCommand(test.echoCommand)
 		context := &FakeInterpolationContext{}
 		echo.Execute(&ExecutionContext{interpolationContext: context})
 		tee.Close()
 
-		if tee.StdoutBuffer.String() != test.expectedOutput {
-			t.Fatal(fmt.Sprintf("Unexpected output to stdout. Expected '%s', but got '%s'", test.expectedOutput, tee.StdoutBuffer.String()))
-		}
+		assert.Equal(t, tee.StdoutBuffer.String(), test.expectedOutput)
 	}
 }
 

--- a/pkg/minishift/addon/command/interpolation_context_test.go
+++ b/pkg/minishift/addon/command/interpolation_context_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package command
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_interpolate_cmd(t *testing.T) {
@@ -30,9 +31,7 @@ func Test_interpolate_cmd(t *testing.T) {
 	expectedCmd := "ssh sudo mkdir -p /etc/docker/certs.d/docker-registry-default.10.0.0.42.xip.io && sudo ls /etc/docker/certs.d"
 	actualCmd := context.Interpolate(cmd)
 
-	if expectedCmd != actualCmd {
-		t.Fatal(fmt.Sprintf("Expected command: %s. Got: %s.", expectedCmd, actualCmd))
-	}
+	assert.Equal(t, expectedCmd, actualCmd)
 }
 
 func Test_adding_multiple_interpolation_variables(t *testing.T) {
@@ -45,9 +44,7 @@ func Test_adding_multiple_interpolation_variables(t *testing.T) {
 	expectedCmd := "bar foobar"
 	actualCmd := context.Interpolate(cmd)
 
-	if expectedCmd != actualCmd {
-		t.Fatal(fmt.Sprintf("Expected command: %s. Got: %s.", expectedCmd, actualCmd))
-	}
+	assert.Equal(t, expectedCmd, actualCmd)
 }
 
 func Test_dollar_sign_in_replacement_value_prints_literally(t *testing.T) {
@@ -59,9 +56,7 @@ func Test_dollar_sign_in_replacement_value_prints_literally(t *testing.T) {
 	expectedCmd := "$bar"
 	actualCmd := context.Interpolate(cmd)
 
-	if expectedCmd != actualCmd {
-		t.Fatal(fmt.Sprintf("Expected command: %s. Got: %s.", expectedCmd, actualCmd))
-	}
+	assert.Equal(t, expectedCmd, actualCmd)
 }
 
 func Test_adding_and_removing_context_variables(t *testing.T) {
@@ -72,15 +67,11 @@ func Test_adding_and_removing_context_variables(t *testing.T) {
 	expected := "bar"
 	actual := context.Interpolate("#{foo}")
 
-	if expected != actual {
-		t.Fatal(fmt.Sprintf("Expected: %s. Got: %s.", expected, actual))
-	}
+	assert.Equal(t, expected, actual)
 
 	context.RemoveFromContext("foo")
 
 	expected = "#{foo}"
 	actual = context.Interpolate("#{foo}")
-	if expected != actual {
-		t.Fatal(fmt.Sprintf("Expected: %s. Got: %s.", expected, actual))
-	}
+	assert.Equal(t, expected, actual)
 }

--- a/pkg/minishift/addon/command/sleep_command_test.go
+++ b/pkg/minishift/addon/command/sleep_command_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_parsing_sleep_time_is_successful(t *testing.T) {
@@ -27,13 +29,9 @@ func Test_parsing_sleep_time_is_successful(t *testing.T) {
 
 	duration, err := sleep.getSleepTime()
 
-	if err != nil {
-		t.Fatal(fmt.Sprintf("Unexpected error '%s'", err.Error()))
-	}
+	assert.NoError(t, err, "Error getting sleep time")
 
-	if duration != time.Duration(100)*time.Second {
-		t.Fatal(fmt.Sprintf("Unexpected duration: %s", duration))
-	}
+	assert.Equal(t, time.Duration(100)*time.Second, duration)
 }
 
 func Test_parsing_sleep_time_ignores_text_after_durationb(t *testing.T) {
@@ -42,13 +40,9 @@ func Test_parsing_sleep_time_ignores_text_after_durationb(t *testing.T) {
 
 	duration, err := sleep.getSleepTime()
 
-	if err != nil {
-		t.Fatal(fmt.Sprintf("Unexpected error '%s'", err.Error()))
-	}
+	assert.NoError(t, err, "Error getting sleep time")
 
-	if duration != time.Duration(5)*time.Second {
-		t.Fatal(fmt.Sprintf("Unexpected duration: %s", duration))
-	}
+	assert.Equal(t, time.Duration(5)*time.Second, duration)
 }
 
 func Test_parsing_sleep_time_fails(t *testing.T) {
@@ -56,12 +50,8 @@ func Test_parsing_sleep_time_fails(t *testing.T) {
 	sleep := NewSleepCommand(cmd)
 
 	_, err := sleep.getSleepTime()
-	if err == nil {
-		t.Fatal("An error should have been returned")
-	}
+	assert.Error(t, err, "Error getting sleep time")
 
 	expectedError := fmt.Sprintf(invalidSleepTimeError, cmd)
-	if err.Error() != expectedError {
-		t.Fatal(fmt.Sprintf("Unexpected error message. Got '%s'. Expected '%s'", err.Error(), expectedError))
-	}
+	assert.EqualError(t, err, expectedError)
 }

--- a/pkg/minishift/cache/oc_caching_test.go
+++ b/pkg/minishift/cache/oc_caching_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	minitesting "github.com/minishift/minishift/pkg/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -40,19 +41,14 @@ func TestIsCached(t *testing.T) {
 	ocDir := filepath.Join(testDir, "cache", "oc", "v1.3.1", runtime.GOOS)
 	os.MkdirAll(ocDir, os.ModePerm)
 
-	if testOc.isCached() != false {
-		t.Error("Expected oc to be uncached")
-	}
+	assert.False(t, testOc.isCached())
 
 	content := []byte("foo")
 
-	if err := ioutil.WriteFile(filepath.Join(ocDir, constants.OC_BINARY_NAME), content, os.ModePerm); err != nil {
-		t.Error()
-	}
+	err := ioutil.WriteFile(filepath.Join(ocDir, constants.OC_BINARY_NAME), content, os.ModePerm)
+	assert.NoError(t, err, "Error writing to file")
 
-	if testOc.isCached() != true {
-		t.Error("Expected oc to be cached")
-	}
+	assert.True(t, testOc.isCached())
 }
 
 func TestCacheOc(t *testing.T) {
@@ -71,9 +67,7 @@ func TestCacheOc(t *testing.T) {
 	os.MkdirAll(ocDir, os.ModePerm)
 
 	err := testOc.cacheOc()
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "Error caching oc")
 }
 
 func setUp(t *testing.T) {

--- a/pkg/minishift/clusterup/clusterup_test.go
+++ b/pkg/minishift/clusterup/clusterup_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package clusterup
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
 	utilStrings "github.com/minishift/minishift/pkg/util/strings"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_DetermineOcVersion(t *testing.T) {
@@ -35,22 +35,14 @@ func Test_DetermineOcVersion(t *testing.T) {
 	}
 	for _, version := range versionTests {
 		actualOcVersion := DetermineOcVersion(version.inputVersion)
-		if actualOcVersion != version.outVersion {
-			t.Fatalf("Expected '%s' Got '%s'", version.outVersion, actualOcVersion)
-		}
+		assert.Equal(t, version.outVersion, actualOcVersion)
 	}
 }
 
 func Test_invalid_addon_variable_leads_to_error_in_context_creation(t *testing.T) {
 	context, err := GetExecutionContext("127.0.0.1", "foo.bar", []string{"FOOBAR"}, nil, nil)
-
-	if err == nil {
-		t.Fatal("There should have been an error due to invalide addon env variable.")
-	}
-
-	if context != nil {
-		t.Fatal("There should be no InterpolationContext returned.")
-	}
+	assert.Error(t, err, "There should have been an error due to incorrect addon env variable.")
+	assert.Nil(t, context, "There should be no InterpolationContext returned.")
 }
 
 func Test_addon_variable_can_be_interpolated(t *testing.T) {
@@ -60,9 +52,7 @@ func Test_addon_variable_can_be_interpolated(t *testing.T) {
 func Test_nil_can_be_passed_to_create_context(t *testing.T) {
 	_, err := GetExecutionContext("127.0.0.1", "foo.bar", nil, nil, nil)
 
-	if err != nil {
-		t.Fatal(fmt.Sprintf("There should have been no error, but got '%s'.", err.Error()))
-	}
+	assert.NoError(t, err, "Error in getting execution context")
 }
 
 func Test_addon_variable_can_be_interpolated_from_environment(t *testing.T) {
@@ -81,14 +71,10 @@ func Test_addon_variable_can_be_interpolated_from_environment(t *testing.T) {
 
 func assertInterpolation(variables []string, testString string, expectedResult string, t *testing.T) {
 	context, err := GetExecutionContext("127.0.0.1", "foo.bar", variables, nil, nil)
-	if err != nil {
-		t.Fatal(fmt.Sprintf("There should have been no error, but got '%s'.", err.Error()))
-	}
+	assert.NoError(t, err)
 
 	result := context.Interpolate(testString)
-	if result != expectedResult {
-		t.Fatal(fmt.Sprintf("Unexpected interpolation result. Expected '%s', got '%s'.", expectedResult, result))
-	}
+	assert.Equal(t, expectedResult, result)
 }
 
 func resetEnv(env []string) {

--- a/pkg/minishift/config/config_test.go
+++ b/pkg/minishift/config/config_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var testDir string
@@ -32,14 +34,10 @@ func TestNewInstanceConfig(t *testing.T) {
 
 	expectedFilePath := filepath.Join(testDir, "fake-machine.json")
 	cfg, _ := NewInstanceConfig(expectedFilePath)
+	assert.Equal(t, expectedFilePath, cfg.FilePath)
 
-	if cfg.FilePath != expectedFilePath {
-		t.Errorf("Expected path '%s'. Received '%s'", expectedFilePath, cfg.FilePath)
-	}
-
-	if _, err := os.Stat(cfg.FilePath); os.IsNotExist(err) {
-		t.Errorf("File %s should exists", cfg.FilePath)
-	}
+	_, err := os.Stat(cfg.FilePath)
+	assert.NoError(t, err, "File %s should exists", cfg.FilePath)
 }
 
 func TestConfigOnFileExists(t *testing.T) {
@@ -58,9 +56,7 @@ func TestConfigOnFileExists(t *testing.T) {
 	ioutil.WriteFile(cfg.FilePath, jsonData, 0644)
 
 	newCfg, _ := NewInstanceConfig(filePath)
-	if newCfg.OcPath != expectedOcPath {
-		t.Errorf("Expected oc path '%s'. Received '%s'", expectedOcPath, cfg.OcPath)
-	}
+	assert.Equal(t, expectedOcPath, newCfg.OcPath)
 }
 
 func TestWrite(t *testing.T) {
@@ -77,14 +73,10 @@ func TestWrite(t *testing.T) {
 	// read config file and verify content
 	var testCfg *InstanceConfigType
 	raw, err := ioutil.ReadFile(path)
-	if err != nil {
-		t.Errorf("Error reading config file %s", path)
-	}
+	assert.NoError(t, err, "Error in reading config file %s", path)
 
 	json.Unmarshal(raw, &testCfg)
-	if testCfg.OcPath != cfg.OcPath {
-		t.Errorf("Expected oc path '%s'. Received '%s'", expectedOcPath, cfg.OcPath)
-	}
+	assert.Equal(t, testCfg.OcPath, cfg.OcPath)
 }
 
 func TestDelete(t *testing.T) {
@@ -96,18 +88,15 @@ func TestDelete(t *testing.T) {
 
 	cfg.Delete()
 
-	if _, err := os.Stat(cfg.FilePath); err == nil {
-		t.Errorf("Expected file '%s' to be deleted", path)
-	}
+	_, err := os.Stat(cfg.FilePath)
+	assert.Error(t, err)
 }
 
 func setup(t *testing.T) {
 	var err error
 	testDir, err = ioutil.TempDir("", "minishift-test-config-")
 
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "Error creating temp directory")
 }
 
 // teardown remove the temp directory

--- a/pkg/minishift/config/hostfolder_test.go
+++ b/pkg/minishift/config/hostfolder_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHostfolderConfig(t *testing.T) {
@@ -40,19 +41,13 @@ func TestHostfolderConfig(t *testing.T) {
 	}
 
 	hostfolderExpectedMountpoint := fmt.Sprintf("%s/%s", HostfoldersDefaultPath, "Users")
-	assertFields(t, hostfolderExpectedMountpoint, hostfolderActual.Mountpoint())
+	assert.Equal(t, hostfolderExpectedMountpoint, hostfolderActual.Mountpoint())
 
 	viper.Set(HostfoldersMountPathKey, "/mnt/data")
 	hostfolderExpectedMountpoint = "/mnt/data/Users"
-	assertFields(t, hostfolderExpectedMountpoint, hostfolderActual.Mountpoint())
+	assert.Equal(t, hostfolderExpectedMountpoint, hostfolderActual.Mountpoint())
 
 	hostfolderActual.Options["mountpoint"] = "/c/Users"
 	hostfolderExpectedMountpoint = "/c/Users"
-	assertFields(t, hostfolderExpectedMountpoint, hostfolderActual.Mountpoint())
-}
-
-func assertFields(t *testing.T, expected string, actual string) {
-	if expected != actual {
-		t.Errorf("Hostfolder expected: '%s'. Actual '%s'", expected, actual)
-	}
+	assert.Equal(t, hostfolderExpectedMountpoint, hostfolderActual.Mountpoint())
 }

--- a/pkg/minishift/config/validations_test.go
+++ b/pkg/minishift/config/validations_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package config
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 type validationTest struct {
 	value     string
@@ -26,11 +31,11 @@ type validationTest struct {
 func runValidations(t *testing.T, tests []validationTest, name string, f func(string, string) error) {
 	for _, tt := range tests {
 		err := f(name, tt.value)
-		if err != nil && !tt.shouldErr {
-			t.Errorf("%s: %v", tt.value, err)
+		if !tt.shouldErr {
+			assert.NoError(t, err, fmt.Sprintf("Error for testcase %v", tt))
 		}
-		if err == nil && tt.shouldErr {
-			t.Errorf("%s: %v", tt.value, err)
+		if tt.shouldErr {
+			assert.Error(t, err, fmt.Sprintf("Error for testcase %v", tt))
 		}
 	}
 }
@@ -49,7 +54,6 @@ func TestDriver(t *testing.T) {
 	}
 
 	runValidations(t, tests, "vm-driver", IsValidDriver)
-
 }
 
 func TestValidCIDR(t *testing.T) {

--- a/pkg/minishift/docker/image/oci_image_handler_test.go
+++ b/pkg/minishift/docker/image/oci_image_handler_test.go
@@ -19,15 +19,14 @@ package image
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Are_Images_Cached(t *testing.T) {
 	currDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal("Unable to determine working directory.")
-	}
+	assert.NoError(t, err, "Unable to determine working directory")
 
 	cacheConfig := &ImageCacheConfig{
 		HostCacheDir:      filepath.Join(currDir, "testdata"),
@@ -38,9 +37,7 @@ func Test_Are_Images_Cached(t *testing.T) {
 
 	handler := OciImageHandler{}
 	allCached := handler.AreImagesCached(cacheConfig)
-	if !allCached {
-		t.Fatal("According to the index all images should be cached")
-	}
+	assert.True(t, allCached, "According to the index all images should be cached")
 
 	cacheConfig = &ImageCacheConfig{
 		HostCacheDir:      filepath.Join(currDir, "testdata"),
@@ -51,9 +48,7 @@ func Test_Are_Images_Cached(t *testing.T) {
 
 	handler = OciImageHandler{}
 	allCached = handler.AreImagesCached(cacheConfig)
-	if allCached {
-		t.Fatal("According to the index the image should not be cached")
-	}
+	assert.False(t, allCached, "According to the index the image should not be cached")
 }
 
 func Test_Get_Docker_Settings(t *testing.T) {
@@ -73,16 +68,11 @@ func Test_Get_Docker_Settings(t *testing.T) {
 		clientConfig, err := getDockerSettings(envTest.envMap)
 		if err != nil {
 			if envTest.errorMessage != "" {
-				if err.Error() != envTest.errorMessage {
-					t.Errorf("Unexpected error message. Expected '%s'. Got '%s'", envTest.errorMessage, err.Error())
-				}
+				assert.EqualError(t, err, envTest.errorMessage)
 			} else {
-				t.Errorf("There was no error expected. Got '%v'", err)
+				assert.NoError(t, err)
 			}
 		}
-
-		if !reflect.DeepEqual(clientConfig, envTest.dockerSettings) {
-			t.Errorf("Expected and received settings don't match. Got '%v'. Expected '%v'", clientConfig, envTest.dockerSettings)
-		}
+		assert.EqualValues(t, envTest.dockerSettings, clientConfig)
 	}
 }

--- a/pkg/minishift/hostfolder/hostfolder_test.go
+++ b/pkg/minishift/hostfolder/hostfolder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/minishift/minishift/pkg/minikube/tests"
+	"github.com/stretchr/testify/assert"
 
 	instanceState "github.com/minishift/minishift/pkg/minishift/config"
 )
@@ -61,13 +62,9 @@ func TestHostfolderIsMounted(t *testing.T) {
 	state := false
 	mockSsh.CommandToOutput["if grep -qs /mnt/sda1/Users /proc/mounts; then echo '1'; else echo '0'; fi"] = `0`
 	state, _ = isHostfolderMounted(mockDriver, hostfolder)
-	if state {
-		t.Errorf("Hostfolder error: should have returned 0")
-	}
+	assert.False(t, state)
 
 	mockSsh.CommandToOutput["if grep -qs /mnt/sda1/Users /proc/mounts; then echo '1'; else echo '0'; fi"] = `1`
 	state, _ = isHostfolderMounted(mockDriver, hostfolder)
-	if !state {
-		t.Errorf("Hostfolder error: should have returned 1")
-	}
+	assert.True(t, state)
 }

--- a/pkg/minishift/network/settings_test.go
+++ b/pkg/minishift/network/settings_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package network
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFillNetworkSettingsScript(t *testing.T) {
@@ -41,7 +42,5 @@ DNS1=8.8.8.8
 DNS2=8.8.4.4
 `
 
-	if actual != expected {
-		t.Fatal(fmt.Sprintf("Actual: %s does not match expected: %s", actual, expected))
-	}
+	assert.Equal(t, expected, actual)
 }

--- a/pkg/minishift/openshift/service_test.go
+++ b/pkg/minishift/openshift/service_test.go
@@ -25,6 +25,7 @@ import (
 	instanceState "github.com/minishift/minishift/pkg/minishift/config"
 	test "github.com/minishift/minishift/pkg/testing"
 	"github.com/minishift/minishift/pkg/testing/testdata"
+	"github.com/stretchr/testify/assert"
 )
 
 //
@@ -42,9 +43,7 @@ func Test_getServiceSpecs_with_multiple_nodeports_and_routes(t *testing.T) {
 
 	got, err := GetServiceSpecs(namespace)
 
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	assert.NoError(t, err, "Error getting service specs")
 
 	expected := []ServiceSpec{{Namespace: namespace, Name: "guestbook-v1-np", URL: []string(nil), NodePort: "32740", Weight: []string(nil)},
 		{Namespace: namespace, Name: "guestbook-v2-np", URL: []string(nil), NodePort: "30485", Weight: []string(nil)},
@@ -63,26 +62,16 @@ func comapareServiceSpec(t *testing.T, got, expected []ServiceSpec) {
 		sort.Strings(expected[i].URL)
 		sort.Strings(service.Weight)
 		sort.Strings(expected[i].Weight)
-		if service.Namespace != expected[i].Namespace {
-			t.Fatalf("Expected Namespace: %+v, Got Namespace: %+v", expected[i].Namespace, service.Namespace)
-		}
+		assert.Equal(t, expected[i].Namespace, service.Namespace)
 
 		for j := range service.URL {
-			if service.URL[j] != expected[i].URL[j] {
-				t.Fatalf("Expected Route URL: %+v, Got Route URL: %+v", expected[i].URL[j], service.URL[j])
-			}
+			assert.Equal(t, expected[i].URL[j], service.URL[j])
 		}
 
-		if service.Name != expected[i].Name {
-			t.Fatalf("Expected Service: %+v, Got Service: %+v", expected[i].Name, service.Name)
-		}
-		if service.NodePort != expected[i].NodePort {
-			t.Fatalf("Expected NodePort: %+v, Got NodePort: %+v", expected[i].NodePort, service.NodePort)
-		}
+		assert.Equal(t, expected[i].Name, service.Name)
+		assert.Equal(t, expected[i].NodePort, service.NodePort)
 		for j := range service.Weight {
-			if service.Weight[j] != expected[i].Weight[j] {
-				t.Fatalf("Expected Weight: %+v, Got Weight: %+v", expected[i].Weight[j], service.Weight[j])
-			}
+			assert.Equal(t, expected[i].Weight[j], service.Weight[j])
 		}
 	}
 

--- a/pkg/minishift/openshift/version/openshift_versions_test.go
+++ b/pkg/minishift/openshift/version/openshift_versions_test.go
@@ -20,81 +20,56 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/version"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrintUpStreamVersions(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-config-")
-	if err != nil {
-		t.Error()
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
 	f, err := os.Create(testDir + "out.txt")
-	if err != nil {
-		t.Fatal("Error creating test file", err)
-	}
+	assert.NoError(t, err)
 	defer f.Close()
 
 	os.Stdout = f
 	defaultVersion := version.GetOpenShiftVersion()
 	err = PrintUpStreamVersions(f, constants.MinimumSupportedOpenShiftVersion, defaultVersion)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
-	if _, err := f.Seek(0, 0); err != nil {
-		t.Fatal("Error setting offset back", err)
-	}
-
+	_, err = f.Seek(0, 0)
+	assert.NoError(t, err, "Error setting offset back")
 	data, err := ioutil.ReadAll(f)
-	if err != nil {
-		t.Fatal("Error reading file", err)
-	}
+	assert.NoError(t, err)
 	actualStdout := string(data)
-	if !strings.Contains(actualStdout, constants.MinimumSupportedOpenShiftVersion) {
-		t.Fatalf("Should Contain constants.MinimumSupportedOpenShiftVersion in\n %s", actualStdout)
-	}
-	if !strings.Contains(actualStdout, defaultVersion) {
-		t.Fatalf("Should Contain defaultVersion in\n %s", actualStdout)
-	}
+	assert.Contains(t, actualStdout, constants.MinimumSupportedOpenShiftVersion)
+	assert.Contains(t, actualStdout, defaultVersion)
 }
 
 func TestPrintDownStreamVersions(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-config-")
-	if err != nil {
-		t.Error()
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
 	f, err := os.Create(testDir + "out.txt")
-	if err != nil {
-		t.Fatal("Error creating test file", err)
-	}
+	assert.NoError(t, err)
 	defer f.Close()
 
 	os.Stdout = f
 	err = PrintDownStreamVersions(f, "v3.4.1.10")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := f.Seek(0, 0); err != nil {
-		t.Fatal("Error setting offset back", err)
-	}
+	assert.NoError(t, err)
+	_, err = f.Seek(0, 0)
+	assert.NoError(t, err, "Error setting offset back")
 
 	data, err := ioutil.ReadAll(f)
-	if err != nil {
-		t.Fatal("Error reading file", err)
-	}
+	assert.NoError(t, err, "Error reading file")
 
 	actualStdout := string(data)
-	if !strings.Contains(actualStdout, "v3.4.1.10") {
-		t.Fatalf("Should Contain v3.4.1.10 in\n %s", actualStdout)
-	}
+	assert.Contains(t, actualStdout, "v3.4.1.10")
 }
 
 func TestIsGreaterOrEqualToBaseVersion(t *testing.T) {
@@ -118,13 +93,11 @@ func TestIsGreaterOrEqualToBaseVersion(t *testing.T) {
 
 	for _, versionTest := range versionTestData {
 		actualResult, actualErr := IsGreaterOrEqualToBaseVersion(versionTest.openshiftVersion, versionTest.baseOpenshiftVersion)
-		if actualResult != versionTest.expectedResult {
-			t.Errorf("IsGreaterOrEqualToBaseVersion(%s, %s) is expected to return '%v' but returned '%v'",
-				versionTest.openshiftVersion, versionTest.baseOpenshiftVersion, versionTest.expectedResult, actualResult)
-		}
-		if actualErr != nil && actualErr.Error() != versionTest.expectedErr.Error() {
-			t.Errorf("IsGreaterOrEqualToBaseVersion(%s, %s) is expected to return '%v' but returned '%v'",
-				versionTest.openshiftVersion, versionTest.baseOpenshiftVersion, versionTest.expectedErr, actualErr)
+
+		assert.Equal(t, versionTest.expectedResult, actualResult)
+
+		if actualErr != nil {
+			assert.EqualError(t, actualErr, versionTest.expectedErr.Error())
 		}
 	}
 }

--- a/pkg/minishift/profile/profile_test.go
+++ b/pkg/minishift/profile/profile_test.go
@@ -22,12 +22,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"reflect"
-
-	"fmt"
-
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -42,9 +39,7 @@ func TestSetingActiveProfile(t *testing.T) {
 	profileName := "foo"
 	SetActiveProfile(profileName)
 	actualProfileName := GetActiveProfile()
-	if actualProfileName != profileName {
-		t.Errorf("Expected profile name: %s does not match actual profile name: %s", profileName, actualProfileName)
-	}
+	assert.Equal(t, profileName, actualProfileName, "Profile name doesn't match")
 }
 
 func TestSetingGetProfileList(t *testing.T) {
@@ -52,9 +47,7 @@ func TestSetingGetProfileList(t *testing.T) {
 	defer teardown()
 
 	miniPath, err := ioutil.TempDir("", "minishift-test-profile-")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	os.Setenv("MINISHIFT_HOME", miniPath)
 	defer os.Unsetenv("MINISHIFT_HOME")
 
@@ -64,15 +57,11 @@ func TestSetingGetProfileList(t *testing.T) {
 		if profile != constants.DefaultProfileName {
 			dirPath := filepath.Join(miniPath, "profiles", profile)
 			err := os.MkdirAll(dirPath, os.ModePerm)
-			if err != nil {
-				fmt.Println(fmt.Sprintf("%s", err.Error()))
-			}
+			assert.NoError(t, err, "Error creating profiles directory")
 		}
 	}
 	actualProfileList := GetProfileList()
-	if !reflect.DeepEqual(profileList, actualProfileList) {
-		t.Error("Expected profile name does not match actual profile name")
-	}
+	assert.EqualValues(t, profileList, actualProfileList, "Profile lists do not match")
 }
 
 func setup(t *testing.T) {

--- a/pkg/minishift/provisioner/buildroot_provisioner_test.go
+++ b/pkg/minishift/provisioner/buildroot_provisioner_test.go
@@ -27,15 +27,14 @@ import (
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/docker/machine/libmachine/provision/provisiontest"
 	"github.com/docker/machine/libmachine/swarm"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildRootLogLevel(t *testing.T) {
 	p := NewBuildrootProvisioner("", &fakedriver.Driver{})
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{LogLevel: "5"})
-	if p.EngineOptions.LogLevel != "5" {
-		t.Fatal("LogLevel should be 5")
-	}
+	assert.Equal(t, "5", p.EngineOptions.LogLevel)
 }
 
 func TestBuildRootProvisionerGenerateDockerOptions(t *testing.T) {
@@ -43,9 +42,7 @@ func TestBuildRootProvisionerGenerateDockerOptions(t *testing.T) {
 
 	dockerOptions, engineCfg := parseBuildRootTemplate(t, p, engineConfigTemplateBuildRoot)
 
-	if dockerOptions.EngineOptions != engineCfg.String() {
-		t.Fatalf("Expected %s, Got %s", engineCfg.String(), dockerOptions.EngineOptions)
-	}
+	assert.Equal(t, engineCfg.String(), dockerOptions.EngineOptions)
 }
 
 func parseBuildRootTemplate(t *testing.T, p *BuildrootProvisioner, engineConfigTemplate string) (*provision.DockerOptions, bytes.Buffer) {
@@ -53,14 +50,10 @@ func parseBuildRootTemplate(t *testing.T, p *BuildrootProvisioner, engineConfigT
 		engineCfg bytes.Buffer
 	)
 	dockerOptions, err := p.GenerateDockerOptions(22)
-	if err != nil {
-		t.Fatal("Provisioner should Generate Docker Options")
-	}
+	assert.NoError(t, err, "Provisioner should Generate Docker Options")
 
 	parseTemplate, err := template.New("engineConfig").Parse(engineConfigTemplate)
-	if err != nil {
-		t.Fatal("Provisioner should Generate Docker Options")
-	}
+	assert.NoError(t, err, "Provisioner should Generate Docker Options")
 
 	engineConfigContext := provision.EngineConfigContext{
 		DockerPort:       22,

--- a/pkg/minishift/provisioner/minishift_detector_test.go
+++ b/pkg/minishift/provisioner/minishift_detector_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package provisioner
 
 import (
+	"testing"
+
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/pkg/minikube/tests"
-	"reflect"
-	"testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMinishiftProvisionerSelected(t *testing.T) {
@@ -60,19 +61,12 @@ VARIANT_VERSION="1.0.0-alpha.1"
 
 	detector := MinishiftProvisionerDetector{Delegate: provision.StandardDetector{}}
 	provisioner, err := detector.DetectProvisioner(d)
-	if err != nil {
-		t.Fatalf("Error Getting detector: %s", err)
-	}
 
-	expectedProvisioner := "*provisioner.MinishiftProvisioner"
-	if reflect.TypeOf(provisioner).String() != expectedProvisioner {
-		t.Fatalf("Unexpected provisioner type. Expected '%s' but got '%s'", expectedProvisioner, reflect.TypeOf(provisioner).String())
-	}
+	assert.NoError(t, err, "Error Getting detector")
+	assert.IsType(t, new(MinishiftProvisioner), provisioner)
 
 	osRelease, _ := provisioner.GetOsReleaseInfo()
-	if osRelease.Variant != "minishift" {
-		t.Fatal("Release info must contain 'minishift' variant")
-	}
+	assert.Equal(t, "minishift", osRelease.Variant, "Release info must contain 'minishift' variant")
 
 }
 
@@ -96,9 +90,7 @@ REDHAT_SUPPORT_PRODUCT="centos"
 REDHAT_SUPPORT_PRODUCT_VERSION="7"
 `
 	port, err := s.Start()
-	if err != nil {
-		t.Fatalf("Error starting ssh server: %s", err)
-	}
+	assert.NoError(t, err, "Error starting ssh server")
 	d := &tests.MockDriver{
 		Port: port,
 		BaseDriver: drivers.BaseDriver{
@@ -109,17 +101,10 @@ REDHAT_SUPPORT_PRODUCT_VERSION="7"
 
 	detector := MinishiftProvisionerDetector{Delegate: provision.StandardDetector{}}
 	provisioner, err := detector.DetectProvisioner(d)
-	if err != nil {
-		t.Fatalf("Error Getting detector: %s", err)
-	}
+	assert.NoError(t, err, "Error Getting detector")
 
-	expectedProvisioner := "*provision.CentosProvisioner"
-	if reflect.TypeOf(provisioner).String() != expectedProvisioner {
-		t.Fatalf("Unexpected provisioner type. Expected '%s' but got '%s'", expectedProvisioner, reflect.TypeOf(provisioner).String())
-	}
+	assert.IsType(t, new(provision.CentosProvisioner), provisioner)
 
 	osRelease, _ := provisioner.GetOsReleaseInfo()
-	if osRelease.Variant == "minishift" {
-		t.Fatal("Release info should not contain 'minishift' variant")
-	}
+	assert.NotEqual(t, "minishift", osRelease.Variant, "Release info should not contain 'minishift' variant")
 }

--- a/pkg/minishift/update/update_test.go
+++ b/pkg/minishift/update/update_test.go
@@ -27,7 +27,7 @@ import (
 
 	minitesting "github.com/minishift/minishift/pkg/testing"
 	minishiftos "github.com/minishift/minishift/pkg/util/os"
-	"strings"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -67,11 +67,9 @@ func TestDownloadAndVerifyArchive(t *testing.T) {
 		downloadLinkFormat := "https://github.com/" + githubOwner + "/" + githubRepo + "/releases/download/v%s/%s"
 		url := fmt.Sprintf(downloadLinkFormat, testAsset.version, testAsset.archiveName)
 		archivePath, err := downloadAndVerifyArchive(url, testDir)
-		checkErr(t, err)
 
-		if expectedArchivePath != archivePath {
-			t.Fatalf("Expected %s but got %s", expectedArchivePath, archivePath)
-		}
+		assert.NoError(t, err, "Error in downloading and verifying archive")
+		assert.Equal(t, expectedArchivePath, archivePath)
 	}
 }
 
@@ -97,10 +95,8 @@ func TestExtractBinaryforOlderVersionFormat(t *testing.T) {
 	// Copy test archive to tmpDir for testing purpose
 	copyArchive(t, testArchivePath, tmpArchivePath)
 	fileName, err := extractBinary(tmpArchivePath, testDir)
-	if !strings.HasSuffix(fileName, binaryName) {
-		t.Fatalf("Expected minishift binary path, Got : %s\n", fileName)
-	}
-	checkErr(t, err)
+	assert.NoError(t, err, "Error in extracting binary")
+	assert.Contains(t, fileName, binaryName)
 }
 
 func TestExtractBinaryforNewerVersionFormat(t *testing.T) {
@@ -125,10 +121,8 @@ func TestExtractBinaryforNewerVersionFormat(t *testing.T) {
 	// Copy test archive to tmpDir for testing purpose
 	copyArchive(t, testArchivePath, tmpArchivePath)
 	fileName, err := extractBinary(tmpArchivePath, testDir)
-	if !strings.HasSuffix(fileName, binaryName) {
-		t.Fatalf("Expected minishift binary path, Got : %s\n", fileName)
-	}
-	checkErr(t, err)
+	assert.NoError(t, err, "Error in extracting binary")
+	assert.Contains(t, fileName, binaryName)
 
 }
 
@@ -152,29 +146,21 @@ func TestExtractBinaryWithoutHavingMiniShift(t *testing.T) {
 	// Copy test archive to tmpDir for testing purpose
 	copyArchive(t, testArchivePath, tmpArchivePath)
 	fileName, err := extractBinary(tmpArchivePath, testDir)
-	if fileName != "" {
-		t.Fatalf("Expected empty string as filename, Got : %s\n", fileName)
-	}
-	checkErr(t, err)
+	assert.NoError(t, err, "Error in extracting binary")
+	assert.Empty(t, fileName)
 
 }
 
 func setUp(t *testing.T) {
 	testDir, err = ioutil.TempDir("", "minishift-test-")
-	checkErr(t, err)
+	assert.NoError(t, err)
 }
 
 func copyArchive(t *testing.T, src, dest string) {
 	data, err := ioutil.ReadFile(src)
-	checkErr(t, err)
+	assert.NoError(t, err)
 	err = ioutil.WriteFile(dest, data, 0644)
-	checkErr(t, err)
-}
-
-func checkErr(t *testing.T, err error) {
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "Error writing to file")
 }
 
 func addMockResponses(mockTransport *minitesting.MockRoundTripper) {

--- a/pkg/minishift/util/iso_path_test.go
+++ b/pkg/minishift/util/iso_path_test.go
@@ -19,6 +19,8 @@ package util
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetIsoPath(t *testing.T) {
@@ -37,9 +39,7 @@ func TestGetIsoPath(t *testing.T) {
 
 	for _, v := range testData {
 		got := GetIsoPath(v.provided)
-		if got != v.expected {
-			t.Errorf("Expected: %s, Got: %s", v.expected, got)
-		}
+		assert.Equal(t, v.expected, got)
 	}
 }
 
@@ -59,8 +59,6 @@ func Test_getMinikubeIsoVersion(t *testing.T) {
 
 	for _, v := range testData {
 		got := getIsoVersion(v.provided)
-		if got != v.expected {
-			t.Errorf("Expected: %s, Got: %s", v.expected, got)
-		}
+		assert.Equal(t, v.expected, got)
 	}
 }

--- a/pkg/testing/tee_test.go
+++ b/pkg/testing/tee_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_tee_captures_stdout_and_stderr(t *testing.T) {
@@ -33,11 +35,7 @@ func Test_tee_captures_stdout_and_stderr(t *testing.T) {
 
 	tee.Close()
 
-	if tee.StdoutBuffer.String() != "Hello" {
-		t.Fatalf("Wrong stdout capture: '%s'", tee.StdoutBuffer.String())
-	}
+	assert.Equal(t, "Hello", tee.StdoutBuffer.String())
 
-	if tee.StderrBuffer.String() != "world!" {
-		t.Fatalf("Wrong stderr capture: '%s'", tee.StderrBuffer.String())
-	}
+	assert.Equal(t, "world!", tee.StderrBuffer.String())
 }

--- a/pkg/util/cmd/split_args_test.go
+++ b/pkg/util/cmd/split_args_test.go
@@ -16,160 +16,79 @@ limitations under the License.
 
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestReturnsAnArrayOfStrings(t *testing.T) {
 	args := SplitCmdString(`date 1423`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "1423" {
-		t.Errorf("Expected the second arg to be '1423', but was '%s'", args[1])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date', but was '%s'", args[0])
+	assert.Equal(t, args[1], "1423", "Expected the second arg to be '1423', but was '%s'", args[1])
 }
 
 func TestRemovesOuterSingleQuotes(t *testing.T) {
 	args := SplitCmdString(`date '1423'`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "1423" {
-		t.Errorf("Expected the second arg to be '1423', but was '%s'", args[1])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date', but was '%s'", args[0])
+	assert.Equal(t, args[1], "1423", "Expected the second arg to be '1423', but was '%s'", args[1])
 }
 
 func TestRemovesOuterDoubleQuotes(t *testing.T) {
 	args := SplitCmdString(`date "1423"`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "1423" {
-		t.Errorf("Expected the second arg to be '1423', but was '%s'", args[1])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date'")
+	assert.Equal(t, args[1], "1423", "Expected the second arg to be '1423'")
 }
 
 func TestProperlyHandlesWhitespaceWithinSingleQuotes(t *testing.T) {
 	args := SplitCmdString(`date -f '%a %b %d %T %Z %Y' "01/01/1900" '+%s'`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "-f" {
-		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
-	}
-
-	if args[2] != "%a %b %d %T %Z %Y" {
-		t.Errorf("Expected the second arg to be '%%a %%b %%d %%T %%Z %%Y', but was '%s'", args[2])
-	}
-
-	if args[3] != "01/01/1900" {
-		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
-	}
-
-	if args[4] != "+%s" {
-		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date', but was '%s'", args[0])
+	assert.Equal(t, args[1], "-f", "Expected the second arg to be '-f', but was '%s'", args[1])
+	assert.Equal(t, args[2], "%a %b %d %T %Z %Y", "Expected the third arg to be '%%a %%b %%d %%T %%Z %%Y', but was '%s'", args[2])
+	assert.Equal(t, args[3], "01/01/1900", "Expected the fourth arg to be '01/01/1900', but was '%s'", args[3])
+	assert.Equal(t, args[4], "+%s", "Expected the fourth arg to be '+%%s', but was '%s'", args[4])
 }
 
 func TestProperlyHandlesWhitespaceWithinDoubleQuotes(t *testing.T) {
 	args := SplitCmdString(`date -f "%a %b %d %T %Z %Y" "01/01/1900" "+%s"`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "-f" {
-		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
-	}
-
-	if args[2] != "%a %b %d %T %Z %Y" {
-		t.Errorf("Expected the second arg to be '%%a %%b %%d %%T %%Z %%Y', but was '%s'", args[2])
-	}
-
-	if args[3] != "01/01/1900" {
-		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
-	}
-
-	if args[4] != "+%s" {
-		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date', but was '%s'", args[0])
+	assert.Equal(t, args[1], "-f", "Expected the second arg to be '-f', but was '%s'", args[1])
+	assert.Equal(t, args[2], "%a %b %d %T %Z %Y", "Expected the third arg to be '%a %b %d %T %Z %Y', but was '%s'", args[2])
+	assert.Equal(t, args[3], "01/01/1900", "Expected the third arg to be '01/01/1900', but was '%s'", args[3])
+	assert.Equal(t, args[4], "+%s", "Expected the third arg to be '+%%s', but was '%s'", args[4])
 }
 
 func TestProperlyHandlesEscapedDoubleQuotesWithinDoubleQuotes(t *testing.T) {
 	args := SplitCmdString(`date -f "%a %b %d \"%T %Z %Y\"" "01/01/1900" "+%s"`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "-f" {
-		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
-	}
-
-	if args[2] != `%a %b %d \"%T %Z %Y\"` {
-		t.Errorf("Expected the second arg to be '%%a %%b %%d \\\"%%T %%Z %%Y\\\"', but was '%s'", args[2])
-	}
-
-	if args[3] != "01/01/1900" {
-		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
-	}
-
-	if args[4] != "+%s" {
-		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date', but was '%s'", args[0])
+	assert.Equal(t, args[1], "-f", "Expected the second arg to be '-f', but was '%s'", args[1])
+	assert.Equal(t, args[2], `%a %b %d \"%T %Z %Y\"`, "Expected the third arg to be '%%a %%b %%d \\\"%%T %%Z %%Y\\\"', but was '%s'", args[2])
+	assert.Equal(t, args[3], "01/01/1900", "Expected the third arg to be '01/01/1900', but was '%s'", args[3])
+	assert.Equal(t, args[4], "+%s", "Expected the third arg to be '+%%s', but was '%s'", args[4])
 }
 
 func TestProperlyHandlesNestedSingleQuotesWithinDoubleQuotes(t *testing.T) {
 	args := SplitCmdString(`date -f "%a %b %d '%T %Z %Y' -- \"foobar\"" "01/01/1900" "+%s"`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "-f" {
-		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
-	}
-
-	if args[2] != `%a %b %d '%T %Z %Y' -- \"foobar\"` {
-		t.Errorf("Expected the second arg to be '%%a %%b %%d '%%T %%Z %%Y' -- \"foobar\"', but was '%s'", args[2])
-	}
-
-	if args[3] != "01/01/1900" {
-		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
-	}
-
-	if args[4] != "+%s" {
-		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date', but was '%s'", args[0])
+	assert.Equal(t, args[1], "-f", "Expected the second arg to be '-f', but was '%s'", args[1])
+	assert.Equal(t, args[2], `%a %b %d '%T %Z %Y' -- \"foobar\"`, "Expected the third arg to be '%%a %%b %%d '%%T %%Z %%Y' -- \"foobar\"', but was '%s'", args[2])
+	assert.Equal(t, args[3], "01/01/1900", "Expected the third arg to be '01/01/1900', but was '%s'", args[3])
+	assert.Equal(t, args[4], "+%s", "Expected the third arg to be '+%%s', but was '%s'", args[4])
 }
 
 func TestProperlyHandlesNestedSingleQuotesInNestedDoubleQuotes(t *testing.T) {
 	args := SplitCmdString(`date -f "\"The title of the book was 'foobar'\" - %a %b %d %T %Z %Y" "01/01/1900" "+%s"`)
 
-	if args[0] != "date" {
-		t.Errorf("Expected the first arg to be 'date', but was '%s'", args[0])
-	}
-
-	if args[1] != "-f" {
-		t.Errorf("Expected the second arg to be '-f', but was '%s'", args[1])
-	}
-
-	if args[2] != `\"The title of the book was 'foobar'\" - %a %b %d %T %Z %Y` {
-		t.Errorf("Expected the second arg to be '\\\"The title of the book was 'foobar'\\\" - %%a %%b %%d %%T %%Z %%Y', but was '%s'", args[2])
-	}
-
-	if args[3] != "01/01/1900" {
-		t.Errorf("Expected the second arg to be '01/01/1900', but was '%s'", args[2])
-	}
-
-	if args[4] != "+%s" {
-		t.Errorf("Expected the second arg to be '+%%s', but was '%s'", args[2])
-	}
+	assert.Equal(t, args[0], "date", "Expected the first arg to be 'date', but was '%s'", args[0])
+	assert.Equal(t, args[1], "-f", "Expected the second arg to be '-f', but was '%s'", args[1])
+	assert.Equal(t, args[2], `\"The title of the book was 'foobar'\" - %a %b %d %T %Z %Y`, "Expected the third arg to be '\"The title of the book was 'foobar'\" - %a %b %d %T %Z %Y', but was '%s'", args[2])
+	assert.Equal(t, args[3], "01/01/1900", "Expected the third arg to be '01/01/1900', but was '%s'", args[3])
+	assert.Equal(t, args[4], "+%s", "Expected the third arg to be '+%%s', but was '%s'", args[4])
 }

--- a/pkg/util/crypto_test.go
+++ b/pkg/util/crypto_test.go
@@ -18,13 +18,13 @@ package util
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEncryption(t *testing.T) {
 	expectedText := "Hello how are you"
 	encryptedText, _ := EncryptText("Hello how are you")
 	decryptedText, _ := DecryptText(encryptedText)
-	if decryptedText != expectedText {
-		t.Fatalf("Expected %s, Got %s", expectedText, decryptedText)
-	}
+	assert.Equal(t, expectedText, decryptedText)
 }

--- a/pkg/util/filehelper/file_test.go
+++ b/pkg/util/filehelper/file_test.go
@@ -21,106 +21,82 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_non_existent_directory_returns_false(t *testing.T) {
 	path := filepath.Join("this", "path", "really", "should", "not", "exists", "unless", "you", "have", "a", "crazy", "setup")
-	if Exists(path) {
-		t.Fatalf("The path '%s' should not exist", path)
-	}
+	assert.False(t, Exists(path), "The path '%s' should not exist", path)
 }
 
 func Test_existent_directory_returns_true(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-test-filetest-")
 	defer os.RemoveAll(testDir)
 
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err)
 
-	if !Exists(testDir) {
-		t.Fatalf("The path '%s' should exist", testDir)
-	}
+	assert.True(t, Exists(testDir))
 }
 
 func Test_testDir_is_directory(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-test-filetest-")
 	defer os.RemoveAll(testDir)
 
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err)
 
-	if !IsDirectory(testDir) {
-		t.Fatalf("The path '%s' should be a directory", testDir)
-	}
+	assert.True(t, IsDirectory(testDir), "The path '%s' should be a directory", testDir)
 }
 
 func Test_non_existing_file_is_not_a_directory(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-test-filetest-")
 	defer os.RemoveAll(testDir)
 
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err)
 
-	if IsDirectory(filepath.Join(testDir, "foo")) {
-		t.Fatalf("The path '%s' should not be a directory", testDir)
-	}
+	path := IsDirectory(filepath.Join(testDir, "foo"))
+	assert.False(t, path, "The path '%s' should not be a directory", testDir)
 }
 
 func Test_file_is_not_a_directory(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-test-filetest-")
 	defer os.RemoveAll(testDir)
 
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err)
 
 	content := []byte("Hello world")
 	tmpfile, err := ioutil.TempFile(testDir, "example")
 	defer tmpfile.Close()
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err)
 
-	if _, err := tmpfile.Write(content); err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	_, err = tmpfile.Write(content)
+	assert.NoError(t, err)
 
-	if IsDirectory(tmpfile.Name()) {
-		t.Fatalf("The path '%s' should not be a directory", testDir)
-	}
+	assert.False(t, IsDirectory(tmpfile.Name()), "The path '%s' should not be a directory", testDir)
 }
 
 func Test_non_existing_directory(t *testing.T) {
 	testDir := "/foo/bar"
-	if empty := IsEmptyDir(testDir); empty {
-		t.Fatalf("Expected that the directory %s doesn't exist.", testDir)
-	}
+	empty := IsEmptyDir(testDir)
+	assert.False(t, empty, "Expected that the directory %s doesn't exists", testDir)
+
 }
 
 func Test_existing_empty_directory(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "minishift-test-filetest-")
 	defer os.RemoveAll(testDir)
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err)
 
-	if empty := IsEmptyDir(testDir); !empty {
-		t.Fatalf("Expected %s to be empty.", testDir)
-	}
+	empty := IsEmptyDir(testDir)
+	assert.True(t, empty, "Expected  %s to be empty", testDir)
 }
 
 func Test_existing_nonempty_directory(t *testing.T) {
 	testDir, _ := ioutil.TempDir("", "minishift-test-filetest-")
 	_, err := ioutil.TempFile(testDir, "foo")
 	defer os.RemoveAll(testDir)
-	if err != nil {
-		t.Fatal("Unexpected error: " + err.Error())
-	}
+	assert.NoError(t, err)
 
-	if empty := IsEmptyDir(testDir); empty {
-		t.Fatalf("Expected %s to be nonempty.", testDir)
-	}
+	empty := IsEmptyDir(testDir)
+	assert.False(t, empty, "Expected %s to be nonempty.", testDir)
 }

--- a/pkg/util/shell/shell_test.go
+++ b/pkg/util/shell/shell_test.go
@@ -19,6 +19,8 @@ package shell
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type shellTestCase struct {
@@ -41,25 +43,17 @@ func TestUnknownShell(t *testing.T) {
 	os.Setenv("SHELL", "/bin/"+expectedShellName)
 
 	shell, err := GetShell("")
-	if err != nil {
-		t.Fatal("Unexpected err : ", err.Error())
-	}
+	assert.NoError(t, err, "Error in getting shell")
 
-	if shell != expectedShellName {
-		t.Fatalf("Expected shell to be %s but %s", expectedShellName, shell)
-	}
+	assert.Equal(t, expectedShellName, shell)
 }
 
 func TestKnownShell(t *testing.T) {
 	expectedShellName := "bash"
 	shell, err := GetShell("bash")
-	if err != nil {
-		t.Fatal("Unexpected err : ", err.Error())
-	}
+	assert.NoError(t, err, "Error in getting shell")
 
-	if shell != expectedShellName {
-		t.Fatalf("Expected shell to be %s but %s", expectedShellName, shell)
-	}
+	assert.Equal(t, expectedShellName, shell)
 }
 
 func TestNoProxyFromEnvWhenUsedLowerCase(t *testing.T) {
@@ -69,9 +63,7 @@ func TestNoProxyFromEnvWhenUsedLowerCase(t *testing.T) {
 	os.Setenv(expectedNoProxyVarName, expectedNoProxyVarValue)
 
 	_, noProxyValue := FindNoProxyFromEnv()
-	if noProxyValue != expectedNoProxyVarValue {
-		t.Fatalf("Expected no proxy var value as %s but got %s", expectedNoProxyVarValue, noProxyValue)
-	}
+	assert.Equal(t, expectedNoProxyVarValue, noProxyValue)
 }
 
 func TestNoProxyFromEnvWhenUsedUpperCase(t *testing.T) {
@@ -81,9 +73,7 @@ func TestNoProxyFromEnvWhenUsedUpperCase(t *testing.T) {
 	os.Setenv(expectedNoProxyVarName, expectedNoProxyVarValue)
 
 	_, noProxyValue := FindNoProxyFromEnv()
-	if noProxyValue != expectedNoProxyVarValue {
-		t.Fatalf("Expected no proxy var value as %s but got %s", expectedNoProxyVarValue, noProxyValue)
-	}
+	assert.Equal(t, expectedNoProxyVarValue, noProxyValue)
 }
 
 func TestGenerateUsageHint(t *testing.T) {
@@ -117,9 +107,7 @@ REM 	@FOR /f "tokens=*" %i IN ('foo') DO @call %i
 
 	for _, tt := range testData {
 		hint := GenerateUsageHint(tt.name, tt.cmdLine)
-		if tt.expectedHint != hint {
-			t.Fatalf("Expected hint to be \n%s but got \n%s", tt.expectedHint, hint)
-		}
+		assert.Equal(t, tt.expectedHint, hint)
 
 	}
 }

--- a/pkg/util/strings/strings_test.go
+++ b/pkg/util/strings/strings_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package strings
 
 import (
-	minishiftTesting "github.com/minishift/minishift/pkg/testing"
 	"reflect"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func getFunctionName(i interface{}) string {
@@ -40,9 +41,7 @@ func TestContains(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actualResult := Contains(testCase.slice, testCase.element)
-		if actualResult != testCase.expectedResult {
-			t.Errorf("Unexpected result for Contains(%v, %s). Expected '%t', got '%t'", testCase.slice, testCase.element, testCase.expectedResult, actualResult)
-		}
+		assert.Equal(t, testCase.expectedResult, actualResult)
 	}
 }
 
@@ -60,7 +59,7 @@ func TestRemove(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actual := Remove(testCase.slice, testCase.element)
-		minishiftTesting.AssertEqualSlice(testCase.expected, actual, t)
+		assert.EqualValues(t, testCase.expected, actual)
 	}
 }
 
@@ -90,9 +89,7 @@ func TestHasMatcher(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actualResult := testCase.matcher(testCase.testString)
-		if actualResult != testCase.expectedResult {
-			t.Errorf("Unexpected result for '%s'. Expected '%s' to return '%t', but got '%t'", getFunctionName(testCase.matcher), testCase.testString, testCase.expectedResult, actualResult)
-		}
+		assert.Equal(t, testCase.expectedResult, actualResult)
 	}
 }
 
@@ -114,9 +111,7 @@ func TestGetMatcher(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actualResult := testCase.matcher(testCase.testString)
-		if actualResult != testCase.expectedResult {
-			t.Errorf("Unexpected result for '%s'. Expected '%s' to return '%s', but got '%s'", getFunctionName(testCase.matcher), testCase.testString, testCase.expectedResult, actualResult)
-		}
+		assert.Equal(t, testCase.expectedResult, actualResult)
 	}
 }
 
@@ -127,9 +122,7 @@ func TestEscapeSingleQuote(t *testing.T) {
 		`foobar`:   `foobar`,
 	}
 	for pass, expected := range experimentstring {
-		if EscapeSingleQuote(pass) != expected {
-			t.Fatalf("Expected '%s' Got '%s'", expected, EscapeSingleQuote(pass))
-		}
+		assert.Equal(t, expected, EscapeSingleQuote(pass))
 	}
 }
 
@@ -148,6 +141,6 @@ func TestSplitAndTrim(t *testing.T) {
 	for _, testCase := range testCases {
 		tokens, _ := SplitAndTrim(testCase.testString, testCase.separator)
 		actualSlice := []string{tokens[0], tokens[1]}
-		minishiftTesting.AssertEqualSlice(actualSlice, testCase.expectedSlice, t)
+		assert.EqualValues(t, testCase.expectedSlice, actualSlice)
 	}
 }


### PR DESCRIPTION
<strike>This PR is to get comments and reviews on how to proceed with using the `testify` unit testing framework.</strike>

Only the `assert` package is made use of in this PR. Replaced all if conditions with `assert.Equal()`, and other assertions. <strike>probably will have to target another command/pkg that makes use of features such as mocking, which will give a better idea of the framework.</strike>

The `cli` package that we use for checking the exitcodes and messages, i couldn't find a way to replace that with something from testify.

Edit: Redy for review