### PR TITLE
Issue #1761 Maintain a published docs against master branch

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -297,10 +297,10 @@ function perform_docs_publish() {
   REPO_OWNER=$(echo $REPO | cut -d"/" -f4)
   cd gopath/src/github.com/minishift/minishift
 
-  git checkout master
-  git checkout -b docs-branch
-  git pull -f $REPO $BRANCH # Get changes from remote repo/branch
-  git log -n 1              # Display last commit in log as reference
+  git remote add remote-repo $REPO
+  git fetch remote-repo
+  git checkout -b docs-branch --track remote-repo/$BRANCH
+  git log -n 1 # Display last commit in log as reference
 
   install_docs_prerequisite_packages;
   make gen_adoc_tar

--- a/docs/source/contributing/ci.adoc
+++ b/docs/source/contributing/ci.adoc
@@ -39,6 +39,8 @@ Thus it is used to run integration tests in addition to unit tests.
 The artifacts of a successful master build can be found at link:http://artifacts.ci.centos.org/minishift/minishift/master/[artifacts.ci.centos.org/minishift/minishift/master/<BUILD_ID>].
 The artifacts of a successful pull request build can be found at link:http://artifacts.ci.centos.org/minishift/minishift/pr/[artifacts.ci.centos.org/minishift/minishift/pr/<PR_ID>].
 
+As part of master build, {project} documentation which is compiled from the _master_ branch and integrated with OpenShift documentation is hosted at link:http://artifacts.ci.centos.org/minishift/minishift/docs/master/openshift-origin/latest/minishift/index.html[artifacts.ci.centos.org/minishift/minishift/docs/master/openshift-origin/latest/minishift/].
+
 On top of building the master branch and pull requests, CentOS CI is also used to build the tar bundle used for xref:../contributing/writing-docs.adoc#integration-with-docs-openshift-org[integration with docs.openshift.org], as well as to build xref:../contributing/releasing.adoc#automated-release[releases].
 
 The link:https://ci.centos.org/job/minishift-nightly[nightly job] runs daily at midnight.


### PR DESCRIPTION
Fix #1761

Tested with job https://ci.centos.org/job/minishift-pr/2841/console after tweaking `centos_ci.sh` script go via `origin/master` branch condition.