### PR TITLE
Issue #1759 Add -f to other commands

### DIFF
--- a/cmd/minishift/cmd/addon/addon_install.go
+++ b/cmd/minishift/cmd/addon/addon_install.go
@@ -49,7 +49,7 @@ var addonsInstallCmd = &cobra.Command{
 }
 
 func init() {
-	addonsInstallCmd.Flags().BoolVar(&force, forceFlag, false, "Forces the installation of the add-on even if the add-on was previously installed.")
+	addonsInstallCmd.Flags().BoolVarP(&force, forceFlag, "f", false, "Forces the installation of the add-on even if the add-on was previously installed.")
 	addonsInstallCmd.Flags().BoolVar(&enable, enableFlag, false, "If true, installs and enables the specified add-on with the default priority.")
 	addonsInstallCmd.Flags().BoolVar(&defaults, defaultsFlag, false,
 		fmt.Sprintf("If true, installs all default add-ons. (%s)",

--- a/cmd/minishift/cmd/update.go
+++ b/cmd/minishift/cmd/update.go
@@ -116,7 +116,7 @@ func init() {
 	RootCmd.AddCommand(updateCmd)
 	updateCmd.Flags().AddFlag(cmdutil.HttpProxyFlag)
 	updateCmd.Flags().AddFlag(cmdutil.HttpsProxyFlag)
-	updateCmd.Flags().BoolVar(&addonForce, addonForceFlag, false, "Force update the add-ons after the binary update. Otherwise, prompt the user to update add-ons.")
+	updateCmd.Flags().BoolVarP(&addonForce, addonForceFlag, "f", false, "Force update the add-ons after the binary update. Otherwise, prompt the user to update add-ons.")
 }
 
 func createUpdateMarker(markerPath string, data UpdateMarker) error {


### PR DESCRIPTION
Adds `-f` shorthand to the `update` and `addon install` commands.
Fixes #1759 