### PR TITLE
Issue #1814 Fix curl command to trigger minishift-docs job

### DIFF
--- a/docs/source/contributing/writing-docs.adoc
+++ b/docs/source/contributing/writing-docs.adoc
@@ -170,7 +170,7 @@ To view {project} documentation integrated into the OpenShift documentation usin
 $ export API_KEY=<api-key>
 $ export REPO=<user-repo>
 $ export BRANCH=<docs-branch>
-$ curl -H "$(curl --user minishift:$API_KEY 'https://ci.centos.org//crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')" -X POST https://ci.centos.org/job/minishift-docs/build --user "minishift:$API_KEY" --data-urlencode json='{"parameter": [{"name":"REPO", "value":"$REPO"}, {"name":"BRANCH", "value":"$BRANCH"}]}'
+$ curl -H "$(curl --user minishift:$API_KEY 'https://ci.centos.org//crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')" -X POST https://ci.centos.org/job/minishift-docs/build --user "minishift:$API_KEY" --data-urlencode json='{"parameter": [{"name":"REPO", "value":"'$REPO'"}, {"name":"BRANCH", "value":"'$BRANCH'"}]}'
 ----
 
 where


### PR DESCRIPTION
Fix #1814 

The issue with curl command in bash is that string containing variable interpolation need extra string so that it got interpolated and passed as proper string in JSON over the wire.