### PR TITLE
Issue #1831 cmd-version fails due to version string mismatch

### DIFF
--- a/test/integration/features/cmd-version.feature
+++ b/test/integration/features/cmd-version.feature
@@ -4,4 +4,4 @@ Command "minishift version" shows version of minishift binary.
 
   Scenario: User can get information about version of Minishift
       When executing "minishift version" succeeds
-      Then stdout should match "^minishift v[0-9]\.[0-9]\.[0-9]\+[a-z0-9]{7,8}\n$"
+      Then stdout should match "^minishift v[0-9]\.[0-9]\.[0-9]{2}\+[a-z0-9]{7,8}\n$"


### PR DESCRIPTION
Fix #1831 

Refer https://ci.centos.org/job/minishift-nightly/26/console