### PR TITLE
Issue #1837 Making sure start command does not print misleading messages

### DIFF
--- a/cmd/minishift/cmd/image/export.go
+++ b/cmd/minishift/cmd/image/export.go
@@ -97,7 +97,7 @@ func exportImage(cmd *cobra.Command, args []string) {
 		ImageMissStrategy: image.Pull,
 	}
 
-	err = handler.ExportImages(imageCacheConfig)
+	_, err = handler.ExportImages(imageCacheConfig)
 	if err != nil {
 		msg := fmt.Sprintf("Container image export failed:\n%v", err)
 		if logToFile {

--- a/cmd/minishift/cmd/image/import.go
+++ b/cmd/minishift/cmd/image/import.go
@@ -100,9 +100,13 @@ func importImage(cmd *cobra.Command, args []string) {
 		ImageMissStrategy: image.Skip,
 	}
 
-	err = handler.ImportImages(imageCacheConfig)
+	importedImages, err := handler.ImportImages(imageCacheConfig)
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Container image import failed:\n%v", err))
+	}
+
+	if len(importedImages) < len(normalizedImageNames) {
+		atexit.ExitWithMessage(1, "At least one image could not be imported.")
 	}
 }
 

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -418,9 +418,9 @@ func importContainerImages(driver drivers.Driver, api libmachine.API, openShiftV
 		CachedImages: images,
 		Out:          os.Stdout,
 	}
-	err = handler.ImportImages(config)
+	_, err = handler.ImportImages(config)
 	if err != nil {
-		fmt.Println(fmt.Sprintf("  WARN: Import of cached images failed. Continuing without importing images. Error: %s ", err.Error()))
+		fmt.Println(fmt.Sprintf("  WARN: At least one image could not be imported. Error: %s ", err.Error()))
 	}
 }
 

--- a/pkg/minishift/docker/image/image_handler.go
+++ b/pkg/minishift/docker/image/image_handler.go
@@ -16,13 +16,36 @@ limitations under the License.
 
 package image
 
+// ProgressStatus defines a status code for import/export operations.
+type ProgressStatus int
+
+const (
+	OK ProgressStatus = iota
+	FAIL
+	CACHE_MISS
+)
+
+func (ps ProgressStatus) String() string {
+	switch ps {
+	case OK:
+		return "OK"
+	case FAIL:
+		return "FAIL"
+	case CACHE_MISS:
+		return "CACHE MISS"
+	}
+	return ""
+}
+
 // ImageHandler is responsible for the import and export of images into the Docker daemon of the VM
 type ImageHandler interface {
 	// ImportImages imports cached images from the host into the Docker daemon of the VM.
-	ImportImages(config *ImageCacheConfig) error
+	// The method returns the list of successfully imported images and an error if one occurred.
+	ImportImages(config *ImageCacheConfig) ([]string, error)
 
 	// ExportImages exports the images specified as part of the ImageCacheConfig from the VM to the host.
-	ExportImages(config *ImageCacheConfig) error
+	// The method returns the list of successfully exported images and an error if one occurred.
+	ExportImages(config *ImageCacheConfig) ([]string, error)
 
 	// IsImageCached returns true if the specified image is cached, false otherwise.
 	IsImageCached(config *ImageCacheConfig, image string) bool

--- a/test/integration/features/cmd-image.feature
+++ b/test/integration/features/cmd-image.feature
@@ -74,7 +74,7 @@ Feature: Basic image caching test
 
      When executing "minishift image import foo:latest alpine:latest"
      Then exitcode should equal "1"
-      And stdout should match "Importing foo:latest.*FAIL"
+      And stdout should match "Importing foo:latest.*CACHE MISS"
       And stdout should match "Importing alpine:latest.*OK"
 
      When executing "minishift image import foo:latest:"
@@ -83,7 +83,7 @@ Feature: Basic image caching test
 
      When executing "minishift image import foo:latest"
      Then exitcode should equal "1"
-      And stderr should contain "Unable to import image 'foo:latest' because it is not available in the local cache."
+      And stderr should contain "At least one image could not be imported."
 
      When executing "minishift image export foo:latest alpine:latest"
      Then exitcode should equal "1"


### PR DESCRIPTION
Addresses #1837

- Making sure that on empty cache the start command is not printing misleading error messages
- Changing ImageHandler.ExportImages and ImageHandlerImportImages to also returns the list of successfully imported/exported images