### PR TITLE
Issue #1513 Network and static IP assignment improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,3 +70,4 @@ writing documentation, see the https://docs.openshift.org/latest/minishift/contr
 
 If you want to contribute, make sure to follow the link:CONTRIBUTING.adoc[contribution guidelines]
 when you open issues or submit pull requests.
+

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -138,11 +138,11 @@ var (
 	CheckNetworkPingHost = createConfigSetting("check-network-ping-host", SetString, nil, nil, true, "8.8.8.8")
 
 	// Network settings (Hyper-V only)
-	NetworkDevice = createConfigSetting("network-device", SetString, nil, nil, true)
-	IPAddress     = createConfigSetting("network-ipaddress", SetString, []setFn{validations.IsValidIPv4Address}, nil, true)
-	Netmask       = createConfigSetting("network-netmask", SetString, []setFn{validations.IsValidNetmask}, nil, true)
-	Gateway       = createConfigSetting("network-gateway", SetString, []setFn{validations.IsValidIPv4Address}, nil, true)
-	NameServers   = createConfigSetting("network-nameserver", SetSlice, []setFn{validations.IsValidIPv4AddressSlice}, nil, true)
+	NetworkDevice = createConfigSetting("network-device", SetString, nil, nil, true, nil)
+	IPAddress     = createConfigSetting("network-ipaddress", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
+	Netmask       = createConfigSetting("network-netmask", SetString, []setFn{validations.IsValidNetmask}, nil, true, nil)
+	Gateway       = createConfigSetting("network-gateway", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
+	NameServers   = createConfigSetting("network-nameserver", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
 )
 
 func createConfigSetting(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool, defaultVal interface{}) *Setting {

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -138,11 +138,11 @@ var (
 	CheckNetworkPingHost = createConfigSetting("check-network-ping-host", SetString, nil, nil, true, "8.8.8.8")
 
 	// Network settings (Hyper-V only)
-	NetworkDevice = createConfigSetting("network-device", SetString, nil, nil, true, nil)
-	IPAddress     = createConfigSetting("network-ipaddress", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
-	Netmask       = createConfigSetting("network-netmask", SetString, []setFn{validations.IsValidNetmask}, nil, true, nil)
-	Gateway       = createConfigSetting("network-gateway", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
-	NameServer    = createConfigSetting("network-nameserver", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
+	NetworkDevice = createConfigSetting("network-device", SetString, nil, nil, true)
+	IPAddress     = createConfigSetting("network-ipaddress", SetString, []setFn{validations.IsValidIPv4Address}, nil, true)
+	Netmask       = createConfigSetting("network-netmask", SetString, []setFn{validations.IsValidNetmask}, nil, true)
+	Gateway       = createConfigSetting("network-gateway", SetString, []setFn{validations.IsValidIPv4Address}, nil, true)
+	NameServers   = createConfigSetting("network-nameserver", SetSlice, []setFn{validations.IsValidIPv4AddressSlice}, nil, true)
 )
 
 func createConfigSetting(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool, defaultVal interface{}) *Setting {

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -132,6 +132,8 @@ var (
 	WarnCheckStorageMount = createConfigSetting("warn-check-storage-mount", SetBool, nil, nil, true, false)
 	SkipCheckStorageUsage = createConfigSetting("skip-check-storage-usage", SetBool, nil, nil, true, nil)
 	WarnCheckStorageUsage = createConfigSetting("warn-check-storage-usage", SetBool, nil, nil, true, false)
+	SkipCheckNameservers  = createConfigSetting("skip-check-nameservers", SetBool, nil, nil, true, nil)
+	WarnCheckNameservers  = createConfigSetting("warn-check-nameservers", SetBool, nil, nil, true, false)
 
 	// Pre-flight values
 	CheckNetworkHttpHost = createConfigSetting("check-network-http-host", SetString, nil, nil, true, "http://minishift.io/index.html")
@@ -142,7 +144,7 @@ var (
 	IPAddress     = createConfigSetting("network-ipaddress", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
 	Netmask       = createConfigSetting("network-netmask", SetString, []setFn{validations.IsValidNetmask}, nil, true, nil)
 	Gateway       = createConfigSetting("network-gateway", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
-	NameServers   = createConfigSetting("network-nameserver", SetString, []setFn{validations.IsValidIPv4Address}, nil, true, nil)
+	NameServers   = createConfigSetting("network-nameserver", SetSlice, []setFn{validations.IsValidIPv4AddressSlice}, nil, true, nil)
 )
 
 func createConfigSetting(name string, set func(MinishiftConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool, defaultVal interface{}) *Setting {

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -330,6 +330,8 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 		HostOnlyCIDR:     viper.GetString(configCmd.HostOnlyCIDR.Name),
 		ShellProxyEnv:    shellProxyEnv,
 	}
+	minishiftConfig.InstanceConfig.VMDriver = machineConfig.VMDriver
+	minishiftConfig.InstanceConfig.Write()
 
 	fmt.Printf(" using '%s' hypervisor ...\n", machineConfig.VMDriver)
 	var hostVm *host.Host
@@ -355,7 +357,7 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 
 		// Configure networking on startup only works on Hyper-V
 		if networkSettings.IPAddress != "" {
-			minishiftNetwork.ConfigureNetworking(constants.MachineName, machineConfig.VMDriver, networkSettings)
+			minishiftNetwork.ConfigureNetworking(constants.MachineName, networkSettings)
 		}
 	}
 

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -570,9 +570,9 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.AddFlag(cmdUtil.AddOnEnvFlag)
 
 	if runtime.GOOS == "windows" {
-		startFlagSet.String(configCmd.NetworkDevice.Name, "eth0", "Specify the network device to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
+		startFlagSet.String(configCmd.NetworkDevice.Name, "", "Specify the network device to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
 		startFlagSet.String(configCmd.IPAddress.Name, "", "Specify IP address to assign to the instance (Hyper-V only)")
-		startFlagSet.String(configCmd.Netmask.Name, "24", "Specify netmask to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
+		startFlagSet.String(configCmd.Netmask.Name, "", "Specify netmask to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
 		startFlagSet.String(configCmd.Gateway.Name, "", "Specify gateway to use for the instance. Ignored if no IP address specified (Hyper-V only)")
 	}
 	startFlagSet.AddFlag(nameServersFlag)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -376,6 +376,7 @@ func configureNetworkSettings() {
 		Netmask:   viper.GetString(configCmd.Netmask.Name),
 		Gateway:   viper.GetString(configCmd.Gateway.Name),
 	}
+
 	nameservers := getSlice(configCmd.NameServers.Name)
 	if len(nameservers) > 0 {
 		networkSettings.DNS1 = nameservers[0]

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -559,12 +559,12 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.AddFlag(registryMirrorFlag)
 	startFlagSet.AddFlag(cmdUtil.AddOnEnvFlag)
 
-	if minishiftConfig.EnableExperimental && runtime.GOOS == "windows" {
-		startFlagSet.String(configCmd.NetworkDevice.Name, "eth0", "Specify the network device to use for the IP address. Ignored if no IP address specified (experimental - Hyper-V only)")
-		startFlagSet.String(configCmd.IPAddress.Name, "", "Specify IP address to assign to the instance (experimental - Hyper-V only)")
-		startFlagSet.String(configCmd.Netmask.Name, "24", "Specify netmask to use for the IP address. Ignored if no IP address specified (experimental - Hyper-V only)")
-		startFlagSet.String(configCmd.Gateway.Name, "", "Specify gateway to use for the instance. Ignored if no IP address specified (experimental - Hyper-V only)")
-		startFlagSet.String(configCmd.NameServers.Name, "8.8.8.8", "Specify nameserver to use for the instance. Ignored if no IP address specified (experimental - Hyper-V only)")
+	if runtime.GOOS == "windows" {
+		startFlagSet.String(configCmd.NetworkDevice.Name, "eth0", "Specify the network device to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
+		startFlagSet.String(configCmd.IPAddress.Name, "", "Specify IP address to assign to the instance (Hyper-V only)")
+		startFlagSet.String(configCmd.Netmask.Name, "24", "Specify netmask to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
+		startFlagSet.String(configCmd.Gateway.Name, "", "Specify gateway to use for the instance. Ignored if no IP address specified (Hyper-V only)")
+		startFlagSet.String(configCmd.NameServers.Name, "", "Specify nameserver to use for the instance. Ignored if no IP address specified (Hyper-V only)")
 	}
 
 	if minishiftConfig.EnableExperimental {

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -100,6 +100,13 @@ var (
 		Value:     cmdUtil.NewStringSliceValue([]string{}, &[]string{}),
 	}
 
+	nameServersFlag = &flag.Flag{
+		Name:      configCmd.NameServers.Name,
+		Shorthand: "",
+		Usage:     "Specify nameserver to use for the instance.",
+		Value:     cmdUtil.NewStringSliceValue([]string{}, &[]string{}),
+	}
+
 	startCmd *cobra.Command
 
 	// Set default value for host data and config dir
@@ -177,6 +184,9 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	hostVm := startHost(libMachineClient)
 	registrationUtil.RegisterHost(libMachineClient)
+
+	// Forcibly set nameservers when configured
+	minishiftNetwork.AddNameserversToInstance(hostVm.Driver, getSlice(configCmd.NameServers.Name))
 
 	// preflight checks (after start)
 	preflightChecksAfterStartingHost(hostVm.Driver)
@@ -564,8 +574,8 @@ func initStartFlags() *flag.FlagSet {
 		startFlagSet.String(configCmd.IPAddress.Name, "", "Specify IP address to assign to the instance (Hyper-V only)")
 		startFlagSet.String(configCmd.Netmask.Name, "24", "Specify netmask to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
 		startFlagSet.String(configCmd.Gateway.Name, "", "Specify gateway to use for the instance. Ignored if no IP address specified (Hyper-V only)")
-		startFlagSet.String(configCmd.NameServers.Name, "", "Specify nameserver to use for the instance. Ignored if no IP address specified (Hyper-V only)")
 	}
+	startFlagSet.AddFlag(nameServersFlag)
 
 	if minishiftConfig.EnableExperimental {
 		startFlagSet.String(configCmd.ISOUrl.Name, minishiftConstants.B2dIsoAlias, "Location of the minishift ISO. Can be an URL, file URI or one of the following short names: [b2d centos minikube].")

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -30,13 +30,13 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	validations "github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/minishift/shell/powershell"
-	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
 	"github.com/minishift/minishift/pkg/util/github"
 
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/viper"
 
 	cmdUtils "github.com/minishift/minishift/cmd/minishift/cmd/util"
+	minishiftNetwork "github.com/minishift/minishift/pkg/minishift/network"
 	openshiftVersion "github.com/minishift/minishift/pkg/minishift/openshift/version"
 	stringUtils "github.com/minishift/minishift/pkg/util/strings"
 )
@@ -430,7 +430,7 @@ func checkIPConnectivity(driver drivers.Driver) bool {
 	ipToPing := viper.GetString(configCmd.CheckNetworkPingHost.Name)
 
 	fmt.Printf("\n   Pinging %s ... ", ipToPing)
-	return minishiftUtil.IsIPReachable(driver, ipToPing, false)
+	return minishiftNetwork.IsIPReachable(driver, ipToPing, false)
 }
 
 // checkHttpConnectivity allows to test outside connectivity and possible proxy support
@@ -438,7 +438,7 @@ func checkHttpConnectivity(driver drivers.Driver) bool {
 	urlToRetrieve := viper.GetString(configCmd.CheckNetworkHttpHost.Name)
 
 	fmt.Printf("\n   Retrieving %s ... ", urlToRetrieve)
-	return minishiftUtil.IsRetrievable(driver, urlToRetrieve, false)
+	return minishiftNetwork.IsRetrievable(driver, urlToRetrieve, false)
 }
 
 // checkStorageMounted checks if the persistent storage volume, storageDisk, is

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -154,6 +154,12 @@ func preflightChecksAfterStartingHost(driver drivers.Driver) {
 		configCmd.WarnInstanceIP.Name,
 		"Error determining IP address")
 	preflightCheckSucceedsOrFailsWithDriver(
+		configCmd.SkipCheckNameservers.Name,
+		checkNameservers, driver,
+		"Checking for nameservers",
+		configCmd.WarnCheckNameservers.Name,
+		"VM does not have any nameserver setup")
+	preflightCheckSucceedsOrFailsWithDriver(
 		configCmd.SkipCheckNetworkPing.Name,
 		checkIPConnectivity, driver,
 		"Checking if external host is reachable from the Minishift VM",
@@ -423,6 +429,11 @@ func checkInstanceIP(driver drivers.Driver) bool {
 		return true
 	}
 	return false
+}
+
+// checkNameservers will return true if the instance has nameservers
+func checkNameservers(driver drivers.Driver) bool {
+	return minishiftNetwork.HasNameserversConfigured(driver)
 }
 
 // checkIPConnectivity checks if the VM has connectivity to the outside network

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -44,7 +44,7 @@ For Hyper-V a functionality is provided to assign an IP address on startup using
 
 [IMPORTANT]
 ====
-While the default image is B2D, this only works with the CentOS/RHEL based image in combination with Hyper-V.
+This only works with the CentOS/RHEL based image in combination with Hyper-V.
 The B2D image experiences a problem when the values are being sent to the {project} instance and consumed by the B2D iso.
 We are looking into the issue and hope to provide a solution in the future.
 ====
@@ -87,3 +87,29 @@ PS> minishift.exe start `
 Be sure to specify a valid gateway and nameserver.
 Failing to do so will result in connectivity issues.
 ====
+
+
+[[set-fixed-ip]]
+== Set Fixed IP Address
+
+[NOTE]
+====
+Currently not supported on KVM as the driver plugin relies on the DHCP offer to determine the IP address.
+====
+
+Most hypervisors do not support extending the lease time when the IP is assigned using DHCP.
+This might lead to a new IP getting assigned to the VM after a restart as it will conflict with the security certificates generated for the old IP. This will make Minishift completely unusable.
+
+For this purpose, {project} includes the functionality to set a static address to the VM. This will prevent it from changing between restarts. However, it will not work on all the driver plugins at the moment due to the way the IP address is resolved.
+
+The following command will set the IP address that was assigned as fixed:
+
+----
+$ minishift ip --set-static 
+----
+
+If you prefer to use dynamic assignment, you can use:
+
+----
+$ minishift ip --set-dhcp
+----

--- a/pkg/minishift/config/functions.go
+++ b/pkg/minishift/config/functions.go
@@ -14,34 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package powershell
+package config
 
-import (
-	ps "github.com/gorillalabs/go-powershell"
-	"github.com/gorillalabs/go-powershell/backend"
-)
-
-type PowerShell struct {
-	powerShell ps.Shell
-}
-
-func New() *PowerShell {
-	return &PowerShell{
-		powerShell: createPowerShell(),
+func checkDriver(driverName string) bool {
+	if InstanceConfig.VMDriver == driverName {
+		return true
 	}
+	return false
 }
 
-func (p *PowerShell) Close() {
-	p.powerShell.Exit()
+func IsVirtualBox() bool {
+	return checkDriver("virtualbox")
 }
 
-func (p *PowerShell) Execute(command string) (stdOut string, stdErr string) {
-	stdOut, stdErr, _ = p.powerShell.Execute(command)
-	return
+func IsHyperV() bool {
+	return checkDriver("hyperv")
 }
 
-func createPowerShell() ps.Shell {
-	back := &backend.Local{}
-	shell, _ := ps.New(back)
-	return shell
+func IsXhyve() bool {
+	return checkDriver("xhyve")
+}
+
+func IsKVM() bool {
+	return checkDriver("kvm")
 }

--- a/pkg/minishift/config/instanceconfig.go
+++ b/pkg/minishift/config/instanceconfig.go
@@ -26,12 +26,15 @@ import (
 var InstanceConfig *InstanceConfigType
 
 type InstanceConfigType struct {
-	FilePath     string `json:"-"`
-	OcPath       string
-	IsRegistered bool
-	IsRHELBased  bool
+	FilePath                  string `json:"-"`
+	OcPath                    string // minishift state
+	IsRegistered              bool   // minishift state
+	IsRHELBased               bool   // minishift state
+	SupportsNetworkAssignment bool   // minishift state
 
 	HostFolders []config.HostFolderConfig
+
+	VMDriver string // general config
 }
 
 // Create new object with data if file exists or

--- a/pkg/minishift/config/validations.go
+++ b/pkg/minishift/config/validations.go
@@ -155,6 +155,19 @@ func IsValidISOUrl(_ string, isoURL string) error {
 	return nil
 }
 
+func IsValidIPv4AddressSlice(name string, addressSlice string) error {
+	addresses := strings.Split(addressSlice, ",")
+
+	for _, address := range addresses {
+		err := IsValidIPv4Address(name, address)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func IsValidIPv4Address(name string, address string) error {
 	ip := net.ParseIP(address).To4()
 	if ip == nil {

--- a/pkg/minishift/network/hostip.go
+++ b/pkg/minishift/network/hostip.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package network
 
 import (
 	"fmt"

--- a/pkg/minishift/network/settings.go
+++ b/pkg/minishift/network/settings.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"net"
 	"strconv"
 	"strings"
 	"text/template"
@@ -179,14 +178,6 @@ func fillNetworkSettingsScript(networkSettings NetworkSettings) string {
 	}
 
 	return result.String()
-}
-
-func determineDefaultGateway(ipaddress string) string {
-	ip := net.ParseIP(ipaddress)
-	ip = ip.To4()
-	//ip = ip.Mask(ip.DefaultMask())
-	ip[3] = 1
-	return ip.String()
 }
 
 func executeCommandOrExit(driver drivers.Driver, command string, errorMessage string) string {

--- a/pkg/minishift/network/settings.go
+++ b/pkg/minishift/network/settings.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"text/template"
@@ -178,6 +179,14 @@ func fillNetworkSettingsScript(networkSettings NetworkSettings) string {
 	}
 
 	return result.String()
+}
+
+func determineDefaultGateway(ipaddress string) string {
+	ip := net.ParseIP(ipaddress)
+	ip = ip.To4()
+	//ip = ip.Mask(ip.DefaultMask())
+	ip[3] = 1
+	return ip.String()
 }
 
 func executeCommandOrExit(driver drivers.Driver, command string, errorMessage string) string {

--- a/pkg/minishift/network/settings.go
+++ b/pkg/minishift/network/settings.go
@@ -191,6 +191,7 @@ func determineDefaultGateway(ipaddress string) string {
 
 func executeCommandOrExit(driver drivers.Driver, command string, errorMessage string) string {
 	result, err := drivers.RunSSHCommandFromDriver(driver, command)
+
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("%s: %s", errorMessage, err.Error()))
 	}

--- a/pkg/minishift/network/settings.go
+++ b/pkg/minishift/network/settings.go
@@ -18,21 +18,35 @@ package network
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
+	"strconv"
+	"strings"
 	"text/template"
 
+	"github.com/docker/machine/libmachine/drivers"
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 )
 
 const (
-	configureIPAddressMessage      = "-- Attempting to set network settings ..."
-	configureIPAddressFailure      = "FAIL\n   not supported on this platform or hypervisor"
-	configureNetworkScriptTemplate = `DEVICE={{.Device}}
+	configureIPAddressMessage                   = "-- Set the following network settings to VM ..."
+	configureRestartNeededMessage               = "Network settings get applied to the instance on restart"
+	configureIPAddressFailure                   = "Not supported on this platform or hypervisor"
+	configureIPAddressAlreadySetFailure         = "Static IP address has already been assigned"
+	configureNetworkNotSupportedMessage         = "The Minishift VM does not support network assignment"
+	configureNetworkScriptStaticAddressTemplate = `DEVICE={{.Device}}
 IPADDR={{.IPAddress}}
 NETMASK={{.Netmask}}
 GATEWAY={{.Gateway}}
 DNS1={{.DNS1}}
 DNS2={{.DNS2}}
+`
+	configureNetworkScriptDynamicAddressTemplate = `DEVICE={{.Device}}
+USEDHCP={{.UseDHCP}}
+`
+	configureNetworkScriptDisabledAddressTemplate = `DEVICE={{.Device}}
+DISABLED={{.Disabled}}
 `
 )
 
@@ -43,8 +57,92 @@ type NetworkSettings struct {
 	Gateway   string
 	DNS1      string
 	DNS2      string
+	UseDHCP   bool
+	Disabled  bool
 }
 
+// checkSupportForAddressAssignment returns true when the instance can support
+// minishift-set-ipaddress
+func checkSupportForAddressAssignment() bool {
+	if minishiftConfig.InstanceConfig.IsRHELBased &&
+		minishiftConfig.InstanceConfig.SupportsNetworkAssignment {
+		return true
+	} else {
+		atexit.ExitWithMessage(1, configureNetworkNotSupportedMessage)
+	}
+	return false
+}
+
+// ConfigureDynamicAssignment will write configuration files which will force DHCP
+// assignment, which will be used by minishift-set-ipaddress on start of the instance.
+func ConfigureDynamicAssignment(driver drivers.Driver) {
+	if checkSupportForAddressAssignment() {
+		fmt.Println("Writing configuration for dynamic assignment of IP address")
+	}
+
+	networkSettingsEth0 := NetworkSettings{
+		Device:  "eth0",
+		UseDHCP: true,
+	}
+	WriteNetworkSettingsToInstance(driver, networkSettingsEth0)
+
+	networkSettingsEth1 := NetworkSettings{
+		Device:  "eth1",
+		UseDHCP: true,
+	}
+	WriteNetworkSettingsToInstance(driver, networkSettingsEth1)
+
+	fmt.Println(configureRestartNeededMessage)
+}
+
+// ConfigureStaticAssignment will collect NetworkSettings from the current running
+// instance and write this the values as configuration files, which will be used
+// by minishift-set-ipaddress on start of the instance.
+func ConfigureStaticAssignment(driver drivers.Driver) {
+	// Not supported for KVM
+	if minishiftConfig.IsKVM() {
+		atexit.ExitWithMessage(1, configureIPAddressFailure)
+		// related to issues with the driver (ip is retrieved from the lease)
+	}
+
+	if checkSupportForAddressAssignment() {
+		fmt.Println("Writing current configuration for static assignment of IP address")
+	}
+
+	// populate the network settings struct with known values
+	networkSettings := GetNetworkSettingsFromInstance(driver)
+
+	// VirtualBox and KVM rely on two interfaces
+	// eth0 is used for host communication
+	// eth1 is used for the external communication
+	if minishiftConfig.IsVirtualBox() {
+		dhcpNetworkSettings := NetworkSettings{
+			Device:  "eth0",
+			UseDHCP: true,
+		}
+		WriteNetworkSettingsToInstance(driver, networkSettings)
+		WriteNetworkSettingsToInstance(driver, dhcpNetworkSettings)
+	}
+
+	// HyperV and Xhyve rely on a single interface
+	// eth0 is used for hpst and external communication
+	// eth1 is disabled
+	if minishiftConfig.IsHyperV() || minishiftConfig.IsXhyve() {
+		disabledNetworkSettings := NetworkSettings{
+			Device:   "eth1",
+			Disabled: true,
+		}
+		WriteNetworkSettingsToInstance(driver, networkSettings)
+		WriteNetworkSettingsToInstance(driver, disabledNetworkSettings)
+	}
+
+	printNetworkSettings(networkSettings)
+
+	fmt.Println(configureRestartNeededMessage)
+}
+
+// printNetworkSettings will print to stdout the values from the struct
+// NetworkSettings.
 func printNetworkSettings(networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage)
 	fmt.Println("   Device:     ", networkSettings.Device)
@@ -52,22 +150,160 @@ func printNetworkSettings(networkSettings NetworkSettings) {
 	if networkSettings.Gateway != "" {
 		fmt.Println("   Gateway:    ", networkSettings.Gateway)
 	}
-	if networkSettings.DNS1 != "" {
+	if networkSettings.DNS1 != "" || networkSettings.DNS2 != "" {
 		fmt.Println("   Nameservers:", fmt.Sprintf("%s %s", networkSettings.DNS1, networkSettings.DNS2))
 	}
 }
 
+// fillNetworkSettings will populate the network configuration file for use
+// by the minishift-set-ipaddress script inside the VM. It takes the struct
+// NetworkSettings containing the values and retuns a string containing
+// a multiline config file.
 func fillNetworkSettingsScript(networkSettings NetworkSettings) string {
 	result := &bytes.Buffer{}
 
-	tmpl, err := template.New("networkScript").Parse(configureNetworkScriptTemplate)
-	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating network script template: %s", err.Error()))
+	tmpl := template.New("networkScript")
+
+	if networkSettings.Disabled {
+		tmpl.Parse(configureNetworkScriptDisabledAddressTemplate)
+	} else if networkSettings.UseDHCP {
+		tmpl.Parse(configureNetworkScriptDynamicAddressTemplate)
+	} else {
+		tmpl.Parse(configureNetworkScriptStaticAddressTemplate)
 	}
-	err = tmpl.Execute(result, networkSettings)
+
+	err := tmpl.Execute(result, networkSettings)
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error executing network script template:: %s", err.Error()))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error executing network script template: %s", err.Error()))
 	}
 
 	return result.String()
+}
+
+func executeCommandOrExit(driver drivers.Driver, command string, errorMessage string) string {
+	result, err := drivers.RunSSHCommandFromDriver(driver, command)
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("%s: %s", errorMessage, err.Error()))
+	}
+	return result
+}
+
+// HasNameserversConfigured returns true if the instance uses nameservers
+// This is related to an issues when LCOW is used on Windows.
+func HasNameserversConfigured(driver drivers.Driver) bool {
+	cmd := "cat /etc/resolv.conf | grep -i '^nameserver' | wc -l | tr -d '\n'"
+	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
+
+	if err != nil {
+		return false
+	}
+
+	i, _ := strconv.Atoi(out)
+
+	return i != 0
+}
+
+// AddNameserversToInstance will add additional nameservers to the end of the
+// /etc/resolv.conf file inside the instance.
+func AddNameserversToInstance(driver drivers.Driver, nameservers []string) {
+	// TODO: verify values to be valid
+
+	for _, ns := range nameservers {
+		addNameserverToInstance(driver, ns)
+	}
+}
+
+// writes nameserver to the /etc/resolv.conf inside the instance
+func addNameserverToInstance(driver drivers.Driver, nameserver string) {
+	executeCommandOrExit(driver,
+		fmt.Sprintf("NS=%s; cat /etc/resolv.conf |grep -i \"^nameserver $NS\" || echo \"nameserver $NS\" | sudo tee -a /etc/resolv.conf", nameserver),
+		"Error adding nameserver")
+}
+
+// retrieve the device used for the IP address from the instance
+func getInstanceNetworkDevice(driver drivers.Driver, ip string) string {
+	return executeCommandOrExit(driver,
+		fmt.Sprintf("ip a |grep -i '%s' | awk '{print $NF}' | tr -d '\n'", ip),
+		"Error getting device")
+}
+
+// retrieve IP address and netmask from the instance
+func getInstanceIPAddress(driver drivers.Driver, device string) (string, string) {
+	addressInfo := executeCommandOrExit(driver,
+		fmt.Sprintf("ip -o -f inet addr show %s | head -n1 | awk '/scope global/ {print $4}'", device),
+		"Error getting netmask")
+	ipaddress := strings.Split(strings.TrimSpace(addressInfo), "/")[0]
+	netmask := strings.Split(strings.TrimSpace(addressInfo), "/")[1]
+
+	return ipaddress, netmask
+}
+
+// get nameservers used from the instance
+func getInstanceNameservers(driver drivers.Driver) []string {
+	resolveInfo := executeCommandOrExit(driver,
+		"cat /etc/resolv.conf |grep -i '^nameserver' | cut -d ' ' -f2 | tr '\n' ' '",
+		"Error getting nameserver")
+	return strings.Split(strings.TrimSpace(resolveInfo), " ")
+}
+
+// get gateway used from the instance
+func getInstanceGateway(driver drivers.Driver) string {
+	return executeCommandOrExit(driver,
+		"route -n | grep 'UG[ \t]' | awk '{print $2}' | tr -d '\n'",
+		"Error getting gateway")
+}
+
+// GetNetworkSettingsFromInstance will collect various network settings from the
+// running instance and will populate a NetworkSettings struct with these values
+func GetNetworkSettingsFromInstance(driver drivers.Driver) NetworkSettings {
+	instanceip, err := driver.GetIP()
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting IP address: %s", err.Error()))
+	}
+	if instanceip == "" {
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting IP address: %s", "No address available"))
+	}
+
+	device := getInstanceNetworkDevice(driver, instanceip)
+	ipaddress, netmask := getInstanceIPAddress(driver, device)
+
+	if instanceip != ipaddress {
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error with IP address: %s", "device has different address assigned"))
+	}
+
+	nameservers := getInstanceNameservers(driver)
+	gateway := getInstanceGateway(driver)
+
+	networkSettings := NetworkSettings{
+		Device:    device,
+		IPAddress: ipaddress, // ~= instanceip
+		Netmask:   netmask,
+		Gateway:   gateway,
+	}
+	if len(nameservers) > 0 {
+		networkSettings.DNS1 = nameservers[0]
+	}
+	if len(nameservers) > 1 {
+		networkSettings.DNS2 = nameservers[1]
+	}
+
+	return networkSettings
+}
+
+// WriteNetworkSettingsToInstance takes NetworkSettings and writes the values
+// as a configuration file to be used by minishift-set-ipaddress
+func WriteNetworkSettingsToInstance(driver drivers.Driver, networkSettings NetworkSettings) bool {
+	networkScript := fillNetworkSettingsScript(networkSettings) // perhaps move this to the struct as a ToString()
+	encodedScript := base64.StdEncoding.EncodeToString([]byte(networkScript))
+
+	cmd := fmt.Sprintf(
+		"echo %s | base64 --decode | sudo tee /var/lib/minishift/networking-%s > /dev/null",
+		encodedScript,
+		networkSettings.Device)
+
+	if _, err := drivers.RunSSHCommandFromDriver(driver, cmd); err != nil {
+		return false
+	}
+
+	return true
 }

--- a/pkg/minishift/network/settings_darwin.go
+++ b/pkg/minishift/network/settings_darwin.go
@@ -20,6 +20,6 @@ import (
 	"fmt"
 )
 
-func ConfigureNetworking(machineName string, vmDriver string, networkSettings NetworkSettings) {
+func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }

--- a/pkg/minishift/network/settings_darwin.go
+++ b/pkg/minishift/network/settings_darwin.go
@@ -23,3 +23,7 @@ import (
 func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }
+
+func determineNameservers() string {
+	return "" // not implemented
+}

--- a/pkg/minishift/network/settings_darwin.go
+++ b/pkg/minishift/network/settings_darwin.go
@@ -24,6 +24,7 @@ func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }
 
+// Not implemented for this platform
 func determineNameservers() string {
-	return "" // not implemented
+	return ""
 }

--- a/pkg/minishift/network/settings_linux.go
+++ b/pkg/minishift/network/settings_linux.go
@@ -20,6 +20,6 @@ import (
 	"fmt"
 )
 
-func ConfigureNetworking(machineName string, vmDriver string, networkSettings NetworkSettings) {
+func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }

--- a/pkg/minishift/network/settings_linux.go
+++ b/pkg/minishift/network/settings_linux.go
@@ -23,3 +23,7 @@ import (
 func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }
+
+func determineNameservers() string {
+	return "" // not implemented
+}

--- a/pkg/minishift/network/settings_linux.go
+++ b/pkg/minishift/network/settings_linux.go
@@ -24,6 +24,7 @@ func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 	fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 }
 
+// Not implemented for this platform
 func determineNameservers() string {
-	return "" // not implemented
+	return ""
 }

--- a/pkg/minishift/network/settings_windows.go
+++ b/pkg/minishift/network/settings_windows.go
@@ -24,6 +24,7 @@ import (
 
 	hvkvp "github.com/gbraad/go-hvkvp"
 	"github.com/golang/glog"
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/minishift/shell/powershell"
 )
 
@@ -33,9 +34,9 @@ const (
 	networkingMessageName = "PROVISION_NETWORKING"
 )
 
-func ConfigureNetworking(machineName string, vmDriver string, networkSettings NetworkSettings) {
+func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 	// Instruct the user that this does not work for other Hypervisors on Windows
-	if vmDriver != "hyperv" {
+	if !minishiftConfig.IsHyperV() {
 		fmt.Println(configureIPAddressMessage, configureIPAddressFailure)
 		return
 	}
@@ -55,6 +56,7 @@ func ConfigureNetworking(machineName string, vmDriver string, networkSettings Ne
 
 func doConfigure(success chan bool, command string) {
 	posh := powershell.New()
+	defer posh.Close()
 	result, _ := posh.Execute(command)
 
 	if strings.Contains(result, resultSuccess) {

--- a/pkg/minishift/network/settings_windows.go
+++ b/pkg/minishift/network/settings_windows.go
@@ -41,6 +41,10 @@ func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 		return
 	}
 
+	if networkSettings.Gateway == "" {
+		networkSettings.Gateway = determineDefaultGateway(networkSettings.IPAddress)
+	}
+
 	printNetworkSettings(networkSettings)
 
 	networkScript := fillNetworkSettingsScript(networkSettings)

--- a/pkg/minishift/network/settings_windows.go
+++ b/pkg/minishift/network/settings_windows.go
@@ -60,19 +60,35 @@ func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 		return
 	}
 
+	if networkSettings.Device == "" {
+		networkSettings.Device = "eth0"
+	}
+
 	if networkSettings.Gateway == "" {
+		fmt.Println("-- Determing default gateway ... ")
 		networkSettings.Gateway = determineDefaultGateway(networkSettings.IPAddress)
 	}
 
 	if networkSettings.DNS1 == "" && networkSettings.DNS2 == "" {
+		fmt.Printf("-- Determing nameservers to use ... ")
 		nameservers := determineNameservers()
 
+		if len(nameservers) == 0 {
+			fmt.Println("FAIL")
+			fmt.Println("   Consider to configure using '--network-nameserver'")
+		}
+
 		if len(nameservers) > 0 {
+			fmt.Println("OK")
 			networkSettings.DNS1 = nameservers[0]
 		}
 		if len(nameservers) > 1 {
 			networkSettings.DNS2 = nameservers[1]
 		}
+		if len(nameservers) > 2 {
+			fmt.Println("   WARN: found more than 2 nameservers")
+		}
+
 	}
 
 	printNetworkSettings(networkSettings)

--- a/pkg/minishift/network/utils.go
+++ b/pkg/minishift/network/utils.go
@@ -1,0 +1,53 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"errors"
+	"net"
+
+	"github.com/docker/machine/libmachine/drivers"
+)
+
+// This will return the address as used by libmachine
+func GetIP(driver drivers.Driver) (string, error) {
+	ip, err := driver.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return ip, nil
+}
+
+func DetermineHostIP(driver drivers.Driver) (string, error) {
+	instanceIP, err := driver.GetIP()
+	if err != nil {
+		return "", err
+	}
+
+	for _, hostaddr := range HostIPs() {
+
+		if NetworkContains(hostaddr, instanceIP) {
+			hostip, _, _ := net.ParseCIDR(hostaddr)
+			if IsIPReachable(driver, hostip.String(), false) {
+				return hostip.String(), nil
+			}
+			return "", errors.New("unreachable")
+		}
+	}
+
+	return "", errors.New("unknown error occurred")
+}

--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -138,6 +138,8 @@ func (provisioner *MinishiftProvisioner) Provision(swarmOptions swarm.Options, a
 		return err
 	}
 
+	doFeatureDetection(provisioner)
+
 	return nil
 }
 

--- a/test/integration/proxy/proxy.go
+++ b/test/integration/proxy/proxy.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 
 	"github.com/elazarl/goproxy"
-	minishiftUtil "github.com/minishift/minishift/pkg/minishift/util"
+	minishiftNetwork "github.com/minishift/minishift/pkg/minishift/network"
 )
 
 var (
@@ -90,7 +90,7 @@ func getIP() (string, error) {
 		return value, nil
 	}
 
-	ips := minishiftUtil.HostIPs()
+	ips := minishiftNetwork.HostIPs()
 	if ips == nil {
 		return "", errors.New(`No IP found. This might be an error in automated detection of available network devices.
 							   You can use INTEGRATION_PROXY_CUSTOM_IP to set IP manually.`)


### PR DESCRIPTION
Fixes #1457, #1513, #1497, #1492 , #1493, #1496 , #1792, #1676 

This allows you to use just `--network-ipaddress` and have the rest of the information like gateway and nameservers being guessed (to some degree).

Note: this NEEDS https://github.com/minishift/minishift-centos-iso/pull/179/ to work.
  
  