### PR TITLE
Issue #1861 Ignore checkForValidProfileOrExit function for default profile

### DIFF
--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -76,7 +76,10 @@ var RootCmd = &cobra.Command{
 			isAddonInstallRequired bool
 		)
 
-		checkForValidProfileOrExit(cmd)
+		// If profile name is 'minishift' then ignore the vaild profile check.
+		if constants.ProfileName != constants.DefaultProfileName {
+			checkForValidProfileOrExit(cmd)
+		}
 
 		constants.MachineName = constants.ProfileName
 		constants.Minipath = constants.GetProfileHomeDir(constants.ProfileName)


### PR DESCRIPTION
Default profile name 'minishift' shouldn't be part of checkForValidProfileOrExit function because this is already a valid profile name and globally true.