### PR TITLE
Issue #1868 Issue #1868 Fix 'make link_check_docs' after nightly URL update

### DIFF
--- a/docs/source/contributing/ci.adoc
+++ b/docs/source/contributing/ci.adoc
@@ -43,11 +43,11 @@ As part of master build, {project} documentation which is compiled from the _mas
 
 On top of building the master branch and pull requests, CentOS CI is also used to build the tar bundle used for xref:../contributing/writing-docs.adoc#integration-with-docs-openshift-org[integration with docs.openshift.org], as well as to build xref:../contributing/releasing.adoc#automated-release[releases].
 
-The link:https://ci.centos.org/job/minishift-nightly[nightly job] runs daily at midnight.
-It executes all integration tests against the _master_ branch of the {project} GitHub repository.
+Nightly jobs(link:https://ci.centos.org/job/minishift-nightly-b2d/[b2d], link:https://ci.centos.org/job/minishift-nightly-centos/[centos], link:https://ci.centos.org/job/minishift-nightly-minikube/[minikube]) run daily at midnight.
+These jobs execute all integration tests against the _master_ branch of the {project} GitHub repository with their respective ISOs.
 
 |link:https://ci.centos.org/job/minishift/[master], link:https://ci.centos.org/job/minishift-pr/[pull requests], link:https://ci.centos.org/job/minishift-docs/[docs],
-link:https://ci.centos.org/job/minishift-release/[release], link:https://ci.centos.org/job/minishift-nightly[nightly]
+link:https://ci.centos.org/job/minishift-release/[release], link:https://ci.centos.org/job/minishift-nightly-b2d/[b2d-nightly], link:https://ci.centos.org/job/minishift-nightly-centos/[centos-nightly], link:https://ci.centos.org/job/minishift-nightly-minikube/[minikube-nightly]
 
 |link:https://github.com/minishift/minishift/blob/master/centos_ci.sh[centos_ci.sh]
 


### PR DESCRIPTION
Now it is rendered as

![screenshot from 2017-12-29 14-47-48](https://user-images.githubusercontent.com/1132451/34433852-0bbfab42-eca8-11e7-9915-fffa04a3dad4.png)

