### PR TITLE
Issue #1874 Don't show 'cache-images' config view listed properties

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -97,7 +97,7 @@ var (
 
 	// Image caching
 	ImageCaching = createConfigSetting("image-caching", SetBool, nil, nil, true)
-	CacheImages  = createConfigSetting("cache-images", SetSlice, nil, nil, true)
+	CacheImages  = createConfigSetting("cache-images", SetSlice, nil, nil, false)
 
 	// Pre-flight checks (before start)
 	SkipCheckKVMDriver     = createConfigSetting("skip-check-kvm-driver", SetBool, nil, nil, true)


### PR DESCRIPTION
Fix #1874

```
$ minishift config | grep cache-images
# Empty
``` 

