### PR TITLE
Issue #1911 Github security warning for nokogiri version < 1.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ADDON_BINDATA_DIR = $(CURDIR)/$(BUILD_DIR)/bindata
 ADDON_ASSET_FILE = $(ADDON_BINDATA_DIR)/addon_assets.go
 
 # Setup for the docs tasks
-DOCS_BUILDER_IMAGE = minishift/minishift-docs-builder:1.0.0
+DOCS_BUILDER_IMAGE = minishift/minishift-docs-builder:1.0.1
 LOCAL_DOCS_DIR ?= $(CURDIR)/docs
 CONTAINER_DOCS_DIR = /minishift-docs
 DOCS_SYNOPISIS_DIR = docs/source/_tmp

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -8,6 +8,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
+gem 'nokogiri', '~> 1.8.1' # CVE-2017-9050 fix
 # Middleman Gems
 gem 'middleman', '~> 4.2'
 gem 'middleman-livereload', '~> 3.4'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -101,10 +101,10 @@ GEM
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     padrino-helpers (0.13.3.3)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.3)
@@ -149,10 +149,11 @@ DEPENDENCIES
   middleman-asciidoc
   middleman-livereload (~> 3.4)
   middleman-syntax
+  nokogiri (~> 1.8.1)
   redcarpet
   therubyracer
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.0


### PR DESCRIPTION
Fix #1911 

Now, not able to see those security warning in my fork 
![screenshot from 2018-01-15 12-55-09](https://user-images.githubusercontent.com/1132451/34931183-5905d144-f9f3-11e7-909e-4d07ddc7011b.png)
