### PR TITLE
Issue #1937 Use warning sign instead of tip for clear-cache info

### DIFF
--- a/docs/source/using/profiles.adoc
+++ b/docs/source/using/profiles.adoc
@@ -24,7 +24,7 @@ You can execute single commands against a non-active profile by using the `--pro
 On top of the `--profile` flag, there are xref:../command-ref/minishift_profile.adoc#[commands] for xref:../command-ref/minishift_profile_list.adoc#[listing], xref:../command-ref/minishift_profile_delete.adoc#[deleting] and xref:../command-ref/minishift_profile_set.adoc#[setting] the active profile.
 These commands are described in the following sections.
 
-[TIP]
+[WARNING]
 ====
 Even though profiles are independent of each other, they share the same cache for ISOs, `oc` binaries and container images.
 `minishift delete --clear-cache` will for this reason affect all profiles.


### PR DESCRIPTION
Fix #1937 

This is how it is displayed now.
![screenshot from 2018-01-25 17-17-38](https://user-images.githubusercontent.com/1132451/35386949-ebc11b3a-01f3-11e8-981f-5ae4df4c8bd5.png)
