### PR TITLE
Issue #1585 - Add option to use different oc binary in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,21 +204,21 @@ integration: GODOG_OPTS = --tags=basic
 integration: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
-	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" $(GODOG_OPTS)
+	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" --copy-oc-from="$(COPY_OC_FROM)" $(GODOG_OPTS)
 
 .PHONY: integration_all
 integration_all: GODOG_OPTS = --tags=~coolstore
 integration_all: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
-	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" $(GODOG_OPTS)
+	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" --copy-oc-from="$(COPY_OC_FROM)" $(GODOG_OPTS)
 
 .PHONY: integration_pr
 integration_pr: GODOG_OPTS = --tags=~coolstore\&\&~addon-xpaas
 integration_pr: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
-	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" $(GODOG_OPTS)
+	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" --copy-oc-from="$(COPY_OC_FROM)" $(GODOG_OPTS)
 
 .PHONY: fmt
 fmt:

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -280,6 +280,17 @@ For example, tests can be run against a stopped {project} instance with the imag
 $ make integration_all RUN_BEFORE_FEATURE="start; stop; config set image-caching true"
 ----
 
+COPY_OC_FROM::
+
+To test {project} with a non-default `oc` binary you can use the `COPY_OC_FROM` parameter.
+This parameter specifies the path to the `oc` binary which will be copied into the `$MINISHIFT_HOME` folder before each feature run.
+Note that the `oc` binary must be contained in the same directory structure which {project} uses for the storage of `oc` binaries, for example: `<version>/<platform>/oc(.exe)`.
+For example, to test {project} with locally stored `oc v3.7.23` run:
+
+----
+$ make integration COPY_OC_FROM=<path-to-oc-directory>/v3.7.23/<linux or windows or darwin>/oc RUN_BEFORE_FEATURE="config set openshift-version v3.7.23"
+----
+
 TEST_WITH_SHELL::
 
 About:::

--- a/scripts/boilerplate/boilerplate.py
+++ b/scripts/boilerplate/boilerplate.py
@@ -160,8 +160,8 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
-    # dates can be 2014, 2015 or 2016, company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016|2017)' )
+    # dates can be 2014 to 2018, company holder names can be anything
+    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts

--- a/test/integration/util/test-preparation.go
+++ b/test/integration/util/test-preparation.go
@@ -1,0 +1,96 @@
+// +build integration
+
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	delimiterConst = ";"
+)
+
+// RunBeforeFeature executes minishift commands delimited by a semicolon before the feature starts.
+func RunBeforeFeature(commands string, runner *MinishiftRunner) error {
+	var errorMessage string
+	splittedCommands := strings.Split(commands, delimiterConst)
+	fmt.Println("Going to run commands:", commands)
+
+	for i := range splittedCommands {
+		_, stdErr, exitCode := runner.RunCommand(splittedCommands[i])
+		if exitCode != 0 {
+			errorMessage += fmt.Sprintf("Error executing command 'minishift %v'.\nExit code: '%v',\nStderr: '%v'\n", splittedCommands[i], exitCode, stdErr)
+		}
+	}
+
+	if errorMessage != "" {
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+//CopyOc copies the oc binary contained in directory structure of /<version>/<platform>/oc(.exe)
+//to cache/oc inside of the testDir.
+func CopyOc(ocPath string, testDir string) error {
+	ocPath = filepath.Clean(ocPath)
+	dir, ocFileName := filepath.Split(ocPath)
+	dir, platformDir := filepath.Split(filepath.Clean(dir))
+	_, versionDir := filepath.Split(filepath.Clean(dir))
+
+	targetDirectory := filepath.Join(testDir, "cache", "oc", versionDir, platformDir)
+	err := os.MkdirAll(targetDirectory, 0777)
+	if err != nil {
+		return fmt.Errorf("Error creating target directory:%v\n", err)
+	}
+
+	ocFile, err := os.Open(ocPath)
+	if err != nil {
+		return fmt.Errorf("Error accessing oc binary:%v\n", err)
+	}
+	defer ocFile.Close()
+
+	targetOcPath := filepath.Join(targetDirectory, ocFileName)
+	targetOc, err := os.Create(targetOcPath)
+	if err != nil {
+		return fmt.Errorf("oc binary target location cannot be opened:%v\n", err)
+	}
+	defer targetOc.Close()
+
+	_, err = io.Copy(targetOc, ocFile)
+	if err != nil {
+		return fmt.Errorf("Error copying the binary:%v\n", err)
+	}
+
+	err = os.Chmod(targetOcPath, 0755)
+	if err != nil {
+		return fmt.Errorf("Error setting up the mode of oc binary:%v", err)
+	}
+
+	message := fmt.Sprintf("The oc binary has been copied from:'%v' into:'%v'.", ocPath, targetOcPath)
+	LogMessage("info", message)
+	fmt.Println(message)
+
+	return nil
+}


### PR DESCRIPTION
This PR adds `COPY_OC_FROM` parameter to the integration tests. It can be used to test the Minishift with local version of oc binary and thus can be used for testing of unreleased oc versions. The oc binary must be placed in 2 levels of directories which follows the format which Minishift uses for storing the oc binary in its home: `<version>/<platform>/oc(.exe)`. This whole structure is then copied into the `MINISHIFT_HOME/cache/oc/` before the start of the feature and thus can be used in the following tests.

For example:
- download oc version 3.7.23
- put it into ~/custom-oc/v3.7.23/linux/oc
- run `make integration COPY_OC_FROM=~/custom-oc/v3.7.23/linux/oc RUN_BEFORE_FEATURE="config set openshift-version v3.7.23"`

Was thinking about creating minishift/test/integration/util/test-preparation.go into which I would move code from this PR and also code around `RUN_BEFORE_FEATURE` and `TEST_WITH_SHELL`. Please, let me know your ideas here.