### PR TITLE
Issue #1703 Add timeout to rollout step

### DIFF
--- a/test/integration/features/addon-xpaas.feature
+++ b/test/integration/features/addon-xpaas.feature
@@ -21,7 +21,7 @@ which are then available in OpenShift to the user.
    Given Minishift has state "Running"
     When executing "oc new-app <template-name>" succeeds
      And executing "oc set probe dc/<service-name> --readiness --get-url=http://:8080<http-endpoint>" succeeds
-     And service "<service-name>" rollout successfully
+     And service "<service-name>" rollout successfully within "1200" seconds
     Then with up to "10" retries with wait period of "500ms" the "body" of HTTP request to "<http-endpoint>" of service "<service-name>" in namespace "myproject" contains "<expected-hello>"
      And with up to "10" retries with wait period of "500ms" the "status code" of HTTP request to "<http-endpoint>" of service "<service-name>" in namespace "myproject" is equal to "200"
      And executing "oc delete all --all" succeeds

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -148,7 +148,7 @@ Feature: Basic
      And executing "oc new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-ex.git" succeeds
      And executing "oc expose svc/ruby-ex" succeeds
      And executing "oc set probe dc/ruby-ex --readiness --get-url=http://:8080" succeeds
-     And service "ruby-ex" rollout successfully
+     And service "ruby-ex" rollout successfully within "1200" seconds
 
     Then with up to "10" retries with wait period of "500ms" the "status code" of HTTP request to "/" of service "ruby-ex" in namespace "ruby" is equal to "200"
      And with up to "10" retries with wait period of "500ms" the "body" of HTTP request to "/" of service "ruby-ex" in namespace "ruby" contains "Welcome to your Ruby application on OpenShift"

--- a/test/integration/features/coolstore.feature
+++ b/test/integration/features/coolstore.feature
@@ -34,7 +34,7 @@ Feature: Cool Store
      """
      Success
      """
-    When services "web-ui, inventory, catalog, cart, coolstore-gw" rollout successfully
+    When services "web-ui, inventory, catalog, cart, coolstore-gw" rollout successfully within "1200" seconds
     Then executing "oc status -v" succeeds
      And stdout should not contain
      """

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -45,11 +45,7 @@ Feature: Minishift can run behind proxy
      """
      Success
      """
-    When executing "oc rollout status deploymentconfig ruby-ex --watch" succeeds
-     And stdout should contain
-     """
-     "ruby-ex-1" successfully rolled out
-     """
+    When service "ruby-ex" rollout successfully within "1200" seconds
     Then proxy log should contain "Accepting CONNECT to registry-1.docker.io:443"
      And proxy log should contain "Accepting CONNECT to bundler.rubygems.org:443"
      And proxy log should contain "Accepting CONNECT to rubygems.org:443"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -198,6 +198,8 @@ func FeatureContext(s *godog.Suite) {
 	// steps for rollout check
 	s.Step(`^services? "([^"]*)" rollout successfully$`,
 		minishift.rolloutServicesSuccessfully)
+	s.Step(`^services? "([^"]*)" rollout successfully within "(\d+)" seconds$`,
+		minishift.rolloutServicesSuccessfullyBeforeTimeout)
 
 	// steps for proxying
 	s.Step(`^user starts proxy server and sets MINISHIFT_HTTP_PROXY variable$`,


### PR DESCRIPTION
This PR should prevent `freeze` of integration tests on rollout step (when there are problems with rollout) so the tests will continue and not quit after one or two hours. Also it gives us more feedback on the failure which should help us debug better coolstore and other cases when rollout fails.

Changes:

- adds timeout to rollout step, it is needed parameter so it also adds 1200 seconds timeout to all features
- improves feedback from the rollout step, it now prints out stdout and stderr for all services instead of vague `not all successfully rolled out`
- all improvements in feedback also shows up in the log file
- added func runCommandWithTimeout() into `test/integration/minishift.go` 
- func runCommand() in `test/integration/minishift.go` now has default timeout of one hour

The last step is open for discussion, we might keep it without timeout, but I guess the default 1h timeout is basically the same...

To test and see the behaviour you can let fail the coolstore.feature: `make integration GODOG_OPTS=-tags=coolstore`