### PR TITLE
Issue #1698 Add separate metadata for .addon.remove file

### DIFF
--- a/cmd/minishift/cmd/addon/addon_remove.go
+++ b/cmd/minishift/cmd/addon/addon_remove.go
@@ -57,7 +57,7 @@ func runRemoveAddon(cmd *cobra.Command, args []string) {
 		if addOnManager.Get(addonName) == nil {
 			atexit.ExitWithMessage(0, fmt.Sprintf(noAddOnMessage, addonName))
 		}
-		if addOnManager.Get(addonName).RemoveCommands() == nil {
+		if addOnManager.Get(addonName).MetaDataForAddonRemove() == nil {
 			atexit.ExitWithMessage(0, fmt.Sprintf(noRemoveAddOnMessage, addonName, addonName))
 		}
 	}

--- a/pkg/minishift/addon/addon.go
+++ b/pkg/minishift/addon/addon.go
@@ -25,8 +25,11 @@ import (
 // AddOn is the internal representation of an AddOn including the addon metadata and the actual commands
 // the Addon consists off.
 type AddOn interface {
-	// GetMetaData returns the meta data of this addon.
+	// MetaData returns the meta data of this addon.
 	MetaData() AddOnMeta
+
+	// MetaDataForAddonRemove returns the meta data for this addon when remove subcommand used.
+	MetaDataForAddonRemove() AddOnMeta
 
 	// Commands returns a Command slice of the commands this addon consists of.
 	Commands() []command.Command
@@ -56,20 +59,22 @@ type AddOn interface {
 type DefaultAddOn struct {
 	AddOn
 
-	metaData       AddOnMeta
-	commands       []command.Command
-	removeCommands []command.Command
-	enabled        bool
-	path           string
-	priority       int
+	metaData               AddOnMeta
+	metaDataForAddonRemove AddOnMeta
+	commands               []command.Command
+	removeCommands         []command.Command
+	enabled                bool
+	path                   string
+	priority               int
 }
 
-func NewAddOn(meta AddOnMeta, commands []command.Command, removeCommands []command.Command, path string) AddOn {
+func NewAddOn(meta AddOnMeta, metaDataForAddonRemove AddOnMeta, commands []command.Command, removeCommands []command.Command, path string) AddOn {
 	addOn := DefaultAddOn{
-		metaData:       meta,
-		commands:       commands,
-		removeCommands: removeCommands,
-		path:           path,
+		metaData:               meta,
+		metaDataForAddonRemove: metaDataForAddonRemove,
+		commands:               commands,
+		removeCommands:         removeCommands,
+		path:                   path,
 	}
 	return &addOn
 }
@@ -84,6 +89,10 @@ func (a *DefaultAddOn) RemoveCommands() []command.Command {
 
 func (a *DefaultAddOn) MetaData() AddOnMeta {
 	return a.metaData
+}
+
+func (a *DefaultAddOn) MetaDataForAddonRemove() AddOnMeta {
+	return a.metaDataForAddonRemove
 }
 
 func (a *DefaultAddOn) IsEnabled() bool {

--- a/pkg/minishift/addon/manager/addon_manager.go
+++ b/pkg/minishift/addon/manager/addon_manager.go
@@ -233,7 +233,7 @@ func (m *AddOnManager) RemoveAddOn(addOn addon.AddOn, context *command.Execution
 		return err
 	}
 
-	addonMetadata := addOn.MetaData()
+	addonMetadata := addOn.MetaDataForAddonRemove()
 	if err := verifyRequiredOpenshiftVersion(context, addonMetadata); err != nil {
 		return err
 	}

--- a/pkg/minishift/addon/parser/addon_parser.go
+++ b/pkg/minishift/addon/parser/addon_parser.go
@@ -91,18 +91,19 @@ func (parser *AddOnParser) Parse(addOnDir string) (addon.AddOn, error) {
 	}
 
 	var removeCommands []command.Command
+	var metaDataForAddonRemove addon.AddOnMeta
 	if addonRemoveReader != nil {
-		_, removeCommands, err = parser.parseAddOnContent(addonRemoveReader)
+		metaDataForAddonRemove, removeCommands, err = parser.parseAddOnContent(addonRemoveReader)
 		if err != nil {
 			name := ""
-			if meta != nil {
-				name = meta.Name()
+			if metaDataForAddonRemove != nil {
+				name = metaDataForAddonRemove.Name()
 			}
 			return nil, NewParseError(err.Error(), name, addOnDir)
 		}
 	}
 
-	addOn := addon.NewAddOn(meta, commands, removeCommands, addOnDir)
+	addOn := addon.NewAddOn(meta, metaDataForAddonRemove, commands, removeCommands, addOnDir)
 
 	return addOn, nil
 }

--- a/test/testdata/testaddons/metaaddon/metaaddon.addon
+++ b/test/testdata/testaddons/metaaddon/metaaddon.addon
@@ -1,0 +1,6 @@
+# Name: metaaddon
+# Description: Meta addon description
+# URL: http://foo.bar.com
+# Required-Vars: TEST
+
+echo This metaaddon is having variable TEST with #{TEST} value

--- a/test/testdata/testaddons/metaaddon/metaaddon.addon.remove
+++ b/test/testdata/testaddons/metaaddon/metaaddon.addon.remove
@@ -1,0 +1,5 @@
+# Name: metaaddon
+# Description: Meta addon description
+# URL: http://foo.bar.com
+
+echo Removing metaaddon without depending on addon default variables


### PR DESCRIPTION
Fix #1698 

    - Addon enable/install should use meta data different then remove
    to avoid conflict when required var and OpenShift version is used.