### PR TITLE
Issue #1799 Make image caching default and run integration tests 

### DIFF
--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -283,12 +283,17 @@ func initializeProfile() string {
 	return ""
 }
 
+func setViperConfigDefaults() {
+	viper.SetDefault(configCmd.ImageCaching.Name, constants.DefaultImageCaching)
+}
+
 func setupViper() {
 	viper.SetEnvPrefix(constants.MiniShiftEnvPrefix)
 	// Replaces '-' in flags with '_' in env variables
 	// e.g. show-libmachine-logs => $ENVPREFIX_SHOW_LIBMACHINE_LOGS
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
+	setViperConfigDefaults()
 	setFlagsUsingViper()
 }
 

--- a/docs/source/using/image-caching.adoc
+++ b/docs/source/using/image-caching.adoc
@@ -125,19 +125,19 @@ We recommend using this feature with caution.
 [[implicit-image-caching]]
 == Implicit Image Caching
 
-Image caching can be configured to automatically occur during the creation of the {project} VM while executing `minishift start`.
-To enable this feature you need to enable the `image-caching` property in the persistent configuration using the xref:../command-ref/minishift_config_set#[`minishift config set`] command:
-
-----
-$ minishift config set image-caching true
-----
-
-Once enabled, caching occurs in a background process, the first time you use the xref:../command-ref/minishift_start#[`minishift start`] command.
+Image caching is enabled by default for {project}.
+It occurs in a background process after the xref:../command-ref/minishift_start#[`minishift start`] command is completed for the first time.
 Once the images are cached under *_$MINISHIFT_HOME/cache/images_*, successive {project} VM creations will use these cached images.
+
+To disable this feature you need to disable the `image-caching` property in the persistent configuration using the xref:../command-ref/minishift_config_set#[`minishift config set`] command:
+
+----
+$ minishift config set image-caching false
+----
 
 [NOTE]
 ====
-Enabling implicit image caching will transparently add the required OpenShift images to the list of cached images as specified per `cache-images` configuration option.
+Implicit image caching will transparently add the required OpenShift images to the list of cached images as specified per `cache-images` configuration option.
 See xref:../using/image-caching.adoc#persisting-image-names[Persisting Cached Image Names].
 ====
 
@@ -146,7 +146,7 @@ See xref:../using/image-caching.adoc#persisting-image-names[Persisting Cached Im
 Each time an image exporting background process runs, a log file is generated under *_$MINISHIFT_HOME/logs_* which can be used to verify the progress of the export.
 ====
 
-You can disable the caching of the OpenShift images by setting `image-caching` to `false` or removing the setting altogether using xref:../command-ref/minishift_config_unset#[`minishift config unset`]:
+You can re-enable the caching of the OpenShift images by setting `image-caching` to `true` or removing the setting altogether using xref:../command-ref/minishift_config_unset#[`minishift config unset`]:
 
 ----
 $ minishift config unset image-caching

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -38,6 +38,7 @@ const (
 	UpdateMarkerFileName             = "updated"
 	DefaultMachineName               = "minishift"
 	DefaultProfileName               = "minishift"
+	DefaultImageCaching              = true
 )
 
 var (

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -38,7 +38,7 @@ func Contains(slice []string, s string) bool {
 	return false
 }
 
-// Remove takes a slice os strings and returns a slice with the first occurance of the string value removed.
+// Remove takes a slice of strings and returns a slice with the first occurrence of the string value removed.
 func Remove(slice []string, value string) []string {
 	for i, s := range slice {
 		if s == value {

--- a/test/integration/features/addon-xpaas.feature
+++ b/test/integration/features/addon-xpaas.feature
@@ -9,6 +9,7 @@ which are then available in OpenShift to the user.
 
   Scenario: User starts Minishift
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start --memory 4GB" succeeds
      Then Minishift should have state "Running"
       And stdout should contain

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -27,8 +27,11 @@ Feature: Basic
 
   Scenario: Starting Minishift
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start" succeeds
      Then Minishift should have state "Running"
+     When executing "minishift image list" succeeds
+     Then stdout should be empty
 
   Scenario: OpenShift is ready after startup
     After startup of Minishift OpenShift instance should respond correctly on its html endpoints

--- a/test/integration/features/cmd-addons.feature
+++ b/test/integration/features/cmd-addons.feature
@@ -82,6 +82,7 @@ Feature: Addons command and its subcommands
   Scenario: Starting Minishift with anyuid and xpaas add-ons enabled
   The addons are being applied in correct order.
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start" succeeds
      Then Minishift should have state "Running"
      Then stdout should match

--- a/test/integration/features/cmd-config.feature
+++ b/test/integration/features/cmd-config.feature
@@ -203,6 +203,8 @@ user defined options which changes default behaviour of Minishift.
   Scenario: Minishift informs about starting with correct setup of memory, disk and CPU
   Note: Minishift rounds the values for the report to make it more readable.
         However original non-rounded values are used for the startup.
+    Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start" succeeds
      Then stdout should match "Memory\s*:\s*3 GB"
      Then stdout should match "Disk size\s*:\s*25 GB"

--- a/test/integration/features/cmd-docker-env.feature
+++ b/test/integration/features/cmd-docker-env.feature
@@ -13,6 +13,7 @@ one from: bash, cmd, powershell, tcsh, zsh with TEST_WITH_SPECIFIED_SHELL parame
 
   Scenario: Starting minishift
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start" succeeds
      Then Minishift has state "Running"
 

--- a/test/integration/features/cmd-oc-env.feature
+++ b/test/integration/features/cmd-oc-env.feature
@@ -12,6 +12,7 @@ one from: bash, cmd, powershell, tcsh, zsh with TEST_WITH_SPECIFIED_SHELL parame
 
   Scenario: Starting minishift
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start" succeeds
      Then Minishift has state "Running"
 

--- a/test/integration/features/cmd-openshift.feature
+++ b/test/integration/features/cmd-openshift.feature
@@ -13,6 +13,9 @@ cluster in VM provided by Minishift.
 
   Scenario: Minishift start
   Minishift must be started in order to interact with OpenShift via "minishift openshift" command
+
+     Given Minishift has state "Does Not Exist"
+       And image caching is disabled
       When executing "minishift start" succeeds
 
   Scenario: Service list sub-command

--- a/test/integration/features/coolstore.feature
+++ b/test/integration/features/coolstore.feature
@@ -8,6 +8,7 @@ Feature: Cool Store
   
   Scenario: User enables the 'xpaas' add-on and creates a Minishift instance
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift addons enable xpaas"
      Then stdout should contain
       """

--- a/test/integration/features/flags.feature
+++ b/test/integration/features/flags.feature
@@ -20,6 +20,7 @@ Feature: Flags
 
   Scenario: Starting Minishift
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start --insecure-registry test-registry:5000 --docker-env=FOO=BAR" succeeds
      Then Minishift should have state "Running"
 

--- a/test/integration/features/profile.feature
+++ b/test/integration/features/profile.feature
@@ -66,6 +66,7 @@ Feature: Profile
   Scenario: As user, I can start Minishift with default profile 'minishift'
     Given profile "minishift" has state "Does Not Exist"
       And profile "minishift" is the active profile
+      And image caching is disabled
      When executing "minishift start" succeeds
      Then profile "minishift" should have state "Running"
      When executing "minishift profile list" succeeds

--- a/test/integration/features/provision_earlier_version.feature
+++ b/test/integration/features/provision_earlier_version.feature
@@ -4,6 +4,7 @@ Feature: Provision an older major release
 
   Scenario: Starting Minishift with v1.5.1
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start --openshift-version v1.5.1" succeeds
      Then Minishift should have state "Running"
      When executing "minishift openshift version" succeeds

--- a/test/integration/features/provision_various_versions.feature
+++ b/test/integration/features/provision_various_versions.feature
@@ -4,6 +4,7 @@ Feature: Provision all major OpenShift versions
 
   Scenario Outline: Provision all major OpenShift versions
     Given Minishift has state "Does Not Exist"
+      And image caching is disabled
      When executing "minishift start --openshift-version <serverVersion>" succeeds
      Then Minishift should have state "Running"
      When executing "minishift openshift version" succeeds

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -12,6 +12,7 @@ Feature: Minishift can run behind proxy
 
   Scenario: Start behind the proxy
    Given user starts proxy server and sets MINISHIFT_HTTP_PROXY variable
+     And image caching is disabled
     When executing "minishift start" succeeds
     Then proxy log should contain "Accepting CONNECT to registry-1.docker.io:443"
      And proxy log should contain "Accepting CONNECT to auth.docker.io:443"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -176,6 +176,11 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^([^"]*) of command "minishift (.*)" (contains|does not contain) "(.*)"$`,
 		commandReturnContains)
 
+	// setting image caching operation
+	s.Step(`^image caching is (disabled|enabled)$`, minishift.setImageCaching)
+	s.Step(`^image export completes with (\d+) images$`, minishift.imageExportShouldComplete)
+	s.Step(`^container image "(.*)" is cached$`, minishift.imageShouldHaveCached)
+
 	// steps to execute `oc` commands
 	s.Step(`^executing "oc (.*)" retrying (\d+) times with wait period of (\d+) seconds$`,
 		minishift.executingRetryingTimesWithWaitPeriodOfSeconds)
@@ -402,12 +407,7 @@ func ensureTestDirEmpty() {
 	}
 
 	for _, file := range files {
-		fullPath := filepath.Join(testDir, file.Name())
-		if filepath.Base(file.Name()) == "cache" {
-			fmt.Println(fmt.Sprintf("Keeping Minishift cache directory '%s' for test run.", fullPath))
-			continue
-		}
-		os.RemoveAll(fullPath)
+		os.RemoveAll(filepath.Join(testDir, file.Name()))
 	}
 }
 
@@ -415,6 +415,7 @@ func cleanTestDirConfiguration() {
 	var foldersToClean []string
 	foldersToClean = append(foldersToClean, filepath.Join(testDir, "addons"))
 	foldersToClean = append(foldersToClean, filepath.Join(testDir, "config"))
+	foldersToClean = append(foldersToClean, filepath.Join(testDir, "cache/images"))
 
 	for index := range foldersToClean {
 		err := os.RemoveAll(foldersToClean[index])


### PR DESCRIPTION
Fix #1799 and #1798 

The verifying of cached images is not based on the suggestion provided by Hardy here https://github.com/minishift/minishift/issues/1799#issuecomment-349320277.
It is more based on the output of `minishift image list` suggested by @agajdosi . 

In both cases, we had to poll for something like in monitoring PID case, we have to poll for process end.

Tested following cases:
- Fresh start
- Fresh start with image-caching true
- Fresh start with image-caching false