### PR TITLE
Issue #1639 Switch to overlay2 as default storage driver for docker

### DIFF
--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -110,7 +110,7 @@ func (provisioner *MinishiftProvisioner) Provision(swarmOptions swarm.Options, a
 	swarmOptions.Env = engineOptions.Env
 
 	// set default storage driver for minishift
-	storageDriver, err := decideStorageDriver(provisioner, "devicemapper", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/pkg/minishift/provisioner/minishift_provisioner_test.go
+++ b/pkg/minishift/provisioner/minishift_provisioner_test.go
@@ -45,7 +45,7 @@ func TestMinishiftDefaultStorageDriver(t *testing.T) {
 	p := NewMinishiftProvisioner("", &fakedriver.Driver{})
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	assert.Equal(t, "devicemapper", p.EngineOptions.StorageDriver, "Default storage driver should be devicemapper")
+	assert.Equal(t, "overlay2", p.EngineOptions.StorageDriver, "Default storage driver should be overlay2")
 }
 
 func TestRhelImage(t *testing.T) {


### PR DESCRIPTION
This depends on https://github.com/minishift/minishift-centos-iso/pull/207. In case you want to test it out then fetch the ISO from http://artifacts.ci.centos.org/minishift/minishift-centos-iso/pr/207 and use this PR against it. After that do `minishift ssh` and execute `docker info` it should show below.

```
# docker info
[...]
Server Version: 1.12.6
Storage Driver: overlay2
 Backing Filesystem: xfs
 Native Overlay Diff: true
Logging Driver: journald
[...]
```