### PR TITLE
Issue #1672 Show error when addon dir name is not equal to its name

### DIFF
--- a/pkg/minishift/addon/manager/addon_manager_test.go
+++ b/pkg/minishift/addon/manager/addon_manager_test.go
@@ -39,7 +39,7 @@ var (
 	basepath   = filepath.Dir(b)
 )
 
-var anyuid string = `# Name: anyuid
+var anyuid = `# Name: anyuid
 # Description: Allows authenticated users to run images to run with USER as per Dockerfile
 
 oc adm policy add-scc-to-group anyuid system:authenticated
@@ -83,7 +83,7 @@ func Test_invalid_addons_get_skipped(t *testing.T) {
 	defer os.RemoveAll(testDir)
 
 	// create a valid addon
-	addOn1Path := filepath.Join(testDir, "addon1")
+	addOn1Path := filepath.Join(testDir, "anyuid")
 	err = os.Mkdir(addOn1Path, 0777)
 	assert.NoError(t, err, "Error in creating directory for addon")
 

--- a/pkg/minishift/addon/parser/addon_parser.go
+++ b/pkg/minishift/addon/parser/addon_parser.go
@@ -83,19 +83,22 @@ func (parser *AddOnParser) getAddOnContent(addOnDir, fileSuffix string) (addon.A
 	}
 	if addonReader != nil {
 		meta, commands, err = parser.parseAddOnContent(addonReader)
+		var name string
+		if meta != nil {
+			name = meta.Name()
+		}
 		if err != nil {
-			name := ""
-			if meta != nil {
-				name = meta.Name()
-			}
 			return nil, nil, NewParseError(err.Error(), name, addOnDir)
+		}
+		if filepath.Base(addOnDir) != name {
+			return nil, nil, NewParseError(fmt.Sprintf("Add-on directory name should match to addon name"), "", addOnDir)
 		}
 	}
 
 	return meta, commands, nil
 }
 
-// Parse parses the addon files containing in a directory provided and returns an AddOn instance.
+// Parse parses the addon files containing in a directory provided via addOnDir and returns an AddOn instance.
 // If an error occurs, the error is returned.
 func (parser *AddOnParser) Parse(addOnDir string) (addon.AddOn, error) {
 	meta, commands, err := parser.getAddOnContent(addOnDir, ".addon")

--- a/pkg/minishift/addon/parser/addon_parser_test.go
+++ b/pkg/minishift/addon/parser/addon_parser_test.go
@@ -276,3 +276,10 @@ func Test_multiple_addon_definitions_create_error(t *testing.T) {
 
 	assert.Nil(t, addon, "No addon should have been returned")
 }
+
+func TestInvalidAddonDirAndName(t *testing.T) {
+	testAddonName := "addon-dir-mismatch"
+	testAddonDir := filepath.Join(basepath, "..", "..", "..", "..", "test", "testdata", "testaddons", testAddonName)
+	_, _, err := testParser.getAddOnContent(testAddonDir, ".addon")
+	assert.EqualError(t, err, "Add-on directory name should match to addon name")
+}

--- a/test/testdata/testaddons/addon-dir-mismatch/addondirmismatch.addon
+++ b/test/testdata/testaddons/addon-dir-mismatch/addondirmismatch.addon
@@ -1,0 +1,5 @@
+# Name: addondirmismatch
+# Description: Demoaddon description
+# Url: https://someurl.html
+
+echo Should fail with error message


### PR DESCRIPTION
Fix #1672 and #2014 

Tried with following addon
```
$ mkdir demoaddon
$ cat demoaddon/demoaddon.addon
# Name: demo-addon
# Description: Demoaddon description
# Url: https://someurl.html
# Required-Vars: FOO
# Var-Defaults: FOO=abc

echo This is demo addon with variable FOO whose value is #{FOO}
```

###  Installing addon
```
$ minishift addon install demoaddon
Add-on installation failed with the error: Unable to parse specified addon: Add-on directory name 'demoaddon' should match to addon name 'demo-addon'
```