### PR TITLE
Issue #1994 Show app builds logs during integration tests on failure

### DIFF
--- a/test/integration/testsuite/minishift.go
+++ b/test/integration/testsuite/minishift.go
@@ -268,12 +268,21 @@ func (m *Minishift) checkServiceRolloutForSuccess(service string, timeout int, d
 	if strings.Contains(cmdOut, expected) {
 		done <- rolloutMessage{passed: true, stdErr: cmdErr, stdOut: cmdOut}
 	} else {
+		// get application's build logs if rollout fails
+		command = fmt.Sprintf("logs bc/%s", service)
+		m.executingOcCommand(command)
+
+		lastCmdResult := getLastCommandOutput()
+
+		cmdOut += fmt.Sprintf("\n Service build output logs: %s\n", lastCmdResult.StdOut)
+		cmdErr += fmt.Sprintf("\n Service build error logs: %s\n", lastCmdResult.StdErr)
+
 		done <- rolloutMessage{passed: false, stdErr: cmdErr, stdOut: cmdOut}
 	}
 }
 
 func (m *Minishift) rolloutServicesSuccessfully(servicesToCheck string) error {
-	return minishift.rolloutServicesSuccessfullyBeforeTimeout(servicesToCheck, 0)
+	return m.rolloutServicesSuccessfullyBeforeTimeout(servicesToCheck, 0)
 }
 
 func (m *Minishift) rolloutServicesSuccessfullyBeforeTimeout(servicesToCheck string, timeout int) error {


### PR DESCRIPTION
Fix #1994

This will help in debugging rollout steps which is often used in application deployment which is the reason of nightly jobs failure in Minikube ISO.

![screenshot from 2018-02-09 16-33-34](https://user-images.githubusercontent.com/1132451/36024965-70fe5546-0db7-11e8-8b5d-0772dbb1d4b8.png)
