### PR TITLE
Issue #1933 Allow docker push from exposed registry-route

### DIFF
--- a/addons/registry-route/registry-route.addon
+++ b/addons/registry-route/registry-route.addon
@@ -16,4 +16,9 @@ docker cp origin:/var/lib/origin/openshift.local.config/master/ca.crt /etc/docke
 echo Add-on '#{addon-name}' created docker-registry route. Please run following commands to login to the OpenShift docker registry:
 echo $ eval $(minishift docker-env)
 echo $ eval $(minishift oc-env)
+echo
+echo If your deployed version of OpenShift is < 3.7.0 use.
 echo $ docker login -u developer -p `oc whoami -t` docker-registry-default.#{routing-suffix}:443
+echo
+echo If your deployed version of OpenShift is >= 3.7.0 use.
+echo $ docker login -u developer -p `oc whoami -t` docker-registry-default.#{routing-suffix}

--- a/cmd/minishift/cmd/openshift/registry.go
+++ b/cmd/minishift/cmd/openshift/registry.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/cmd/minishift/cmd/addon"
 	"github.com/minishift/minishift/cmd/minishift/cmd/util"
 	"github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/openshift"
+	openshiftVersions "github.com/minishift/minishift/pkg/minishift/openshift/version"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -52,7 +54,12 @@ var registryCmd = &cobra.Command{
 		if registryRoute == nil || !registryRoute.IsEnabled() {
 			registryAddonEnabled = false
 		}
-		registryInfo, err := openshift.GetDockerRegistryInfo(registryAddonEnabled)
+		sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+		openshiftVersion, err := openshiftVersions.GetOpenshiftVersionWithoutK8sAndEtcd(sshCommander)
+		if err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		}
+		registryInfo, err := openshift.GetDockerRegistryInfo(registryAddonEnabled, openshiftVersion)
 		if err != nil {
 			atexit.ExitWithMessage(1, err.Error())
 		}

--- a/cmd/minishift/cmd/openshift/version.go
+++ b/cmd/minishift/cmd/openshift/version.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/provision"
 	"github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	openshiftVersions "github.com/minishift/minishift/pkg/minishift/openshift/version"
@@ -44,7 +45,9 @@ func runVersion(cmd *cobra.Command, args []string) {
 	if err != nil {
 		atexit.ExitWithMessage(1, nonExistentMachineError)
 	}
-	version, err := openshiftVersions.GetOpenshiftVersion(host)
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+
+	version, err := openshiftVersions.GetOpenshiftVersion(sshCommander)
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting the OpenShift cluster version: %s", err.Error()))
 	}

--- a/cmd/minishift/cmd/status.go
+++ b/cmd/minishift/cmd/status.go
@@ -23,6 +23,7 @@ import (
 	"text/template"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/provision"
 	"github.com/docker/machine/libmachine/state"
 	cmdState "github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
@@ -65,6 +66,7 @@ func runStatus(cmd *cobra.Command, args []string) {
 		}
 		atexit.ExitWithMessage(0, s)
 	}
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
 
 	openshiftStatus := "Stopped"
 	diskUsage := "Unknown"
@@ -76,7 +78,7 @@ func runStatus(cmd *cobra.Command, args []string) {
 	}
 
 	if vmStatus == state.Running.String() {
-		openshiftVersion, err := openshiftVersion.GetOpenshiftVersion(host)
+		openshiftVersion, err := openshiftVersion.GetOpenshiftVersion(sshCommander)
 		if err == nil {
 			openshiftStatus = fmt.Sprintf("Running (%s)", strings.Split(openshiftVersion, "\n")[0])
 		}

--- a/pkg/minishift/addon/manager/addon_manager.go
+++ b/pkg/minishift/addon/manager/addon_manager.go
@@ -25,11 +25,10 @@ import (
 
 	"strings"
 
-	minikubeConstants "github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/addon"
 	"github.com/minishift/minishift/pkg/minishift/addon/command"
 	"github.com/minishift/minishift/pkg/minishift/addon/parser"
-	"github.com/minishift/minishift/pkg/minishift/constants"
+	openshiftVersions "github.com/minishift/minishift/pkg/minishift/openshift/version"
 	"github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/filehelper"
 	utilStrings "github.com/minishift/minishift/pkg/util/strings"
@@ -292,21 +291,10 @@ func verifyRequiredVariablesInContext(context *command.ExecutionContext, meta ad
 }
 
 func verifyRequiredOpenshiftVersion(context *command.ExecutionContext, meta addon.AddOnMeta) error {
-	dockerCommander := context.GetDockerCommander()
-	versionInfo, err := dockerCommander.Exec(" ", constants.OpenshiftContainerName, "openshift", "version")
+	openShiftVersion, err := openshiftVersions.GetOpenshiftVersionWithoutK8sAndEtcd(context.GetSSHCommander())
 	if err != nil {
 		return err
 	}
-
-	// verionInfo variable have below string as value along with new line
-	// openshift v3.6.0+c4dd4cf
-	// kubernetes v1.6.1+5115d708d7
-	// etcd 3.2.1
-	// openShiftVersionAlongWithCommitSha is contain *v3.6.0+c4dd4cf* (first split on new line and second on space)
-	openShiftVersionAlongWithCommitSha := strings.Split(strings.Split(versionInfo, "\n")[0], " ")[1]
-	// openshiftVersion is contain *3.6.0* (split on *+* string and then trim the *v* as perfix)
-	// TrimSpace is there to make sure no whitespace around version string
-	openShiftVersion := strings.TrimSpace(strings.TrimPrefix(strings.Split(openShiftVersionAlongWithCommitSha, "+")[0], minikubeConstants.VersionPrefix))
 	requiredOpenshiftVersions := strings.TrimSpace(meta.OpenShiftVersion())
 	if requiredOpenshiftVersions != "" {
 		for _, requiredOpenshiftVersion := range strings.Split(requiredOpenshiftVersions, versionRangeSeparator) {


### PR DESCRIPTION
Openshift >= v3.7.0 we don't need to specify the port number `443` for registry route.