### PR TITLE
 Issue #1889 #2039 Update profile test to disable image caching 

### DIFF
--- a/test/integration/features/cmd-profile.feature
+++ b/test/integration/features/cmd-profile.feature
@@ -77,28 +77,26 @@ Feature: Profile commands
   Scenario: As user, I can apply independent settings in profile 'foo'
      When executing "minishift profile set foo" succeeds
      Then profile "foo" should be the active profile
-     When executing "minishift --profile minishift config get memory" succeeds
-     Then stdout should match "<nil>"
+      And executing "minishift --profile minishift config set cpus 4" succeeds
       And executing "minishift --profile minishift addons list" succeeds
       And stdout should match "registry-route\s*: disabled\s*P\(0\)"
       And executing "minishift addons enable registry-route" succeeds
       And executing "minishift config set memory 5120" succeeds
       And executing "minishift config get memory" succeeds
       And stdout should match "5120"
+      And image caching is disabled
      When executing "minishift start" succeeds
-     Then stdout should contain
-      """
-      Add-on 'registry-route' created docker-registry route.
-      """
+     Then stdout should match "vCPUs\s*:\s*2"
       And profile "foo" should have state "Running"
-     When executing "minishift --profile minishift config get memory" succeeds
-     Then stdout should match "<nil>"
+     When executing "minishift --profile minishift config get cpus" succeeds
+     Then stdout should match "4"
       And executing "minishift --profile minishift addons list" succeeds
       And stdout should match "registry-route\s*: disabled\s*P\(0\)"
       And executing "minishift addons list" succeeds
       And stdout should match "registry-route\s*: enabled\s*P\(0\)"
-      And executing "minishift ssh -- cat /proc/meminfo" succeeds
-      And stdout should match "MemTotal:\s*5[0-1][0-9]{5}\s*kB"
+      And executing "minishift ssh -- cat /proc/cpuinfo" succeeds
+      And stdout should match "processor\s*: [0-3]"
+      And stdout should not match "processor\s*: [4-9]"
 
   Scenario: As user, I can execute a command against a non active profile
     Given profile "foo" is the active profile
@@ -107,7 +105,6 @@ Feature: Profile commands
       And executing "minishift --profile minishift stop" succeeds
       And stdout should contain
        """
-       Stopping local OpenShift cluster...
        Cluster stopped.
        """
      When executing "minishift --profile minishift status" succeeds


### PR DESCRIPTION
Fix : #1889 #2039 

I added tag @minishift-tag to the feature files. Some feature files can be restructured without loosing the usecase integrity to run on both upstream and downstream use. Files like ```cmd-image, provision-earlier-version``` are only for upstream integration test as this is very difficult to restructure and keep the usecase integrity intact for both testing.

So this pr is dealing with these feature files, and as a solution to the downstream it avoid merge conflict with same downstream feature file. In the downstream repo same file should be created with name cdk-*.feature and @cdk-only tag. For example 

cdk-cmd-image.feature
```
@cmd-image @command @cdk-only
Feature: Basic image caching test
  As a user I am able to import and export container images from a local OCI repository
  located in the $MINISHIFT_HOME/cache directory

  //Modify the scenarios as per downstream use

[...]
```

For those specific scenario which are tagged @minishift-only in feature file should be kept in separate feature file like ```cdk-specific.feature``` and is modified accordingly for downstream only. @agajdosi i can see a long pending pr [1] in downstream which almost resolves the same. Would you please delete and resend it.

This is how we can avoid merge conflict for our downstream sync job.
[1] https://gitlab.cee.redhat.com/minishift/minishift/merge_requests/295