### PR TITLE
Issue #1326 Enable hyperkit as driver for MacOS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm"
+  ]
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
@@ -15,13 +18,21 @@
 
 [[projects]]
   name = "github.com/DATA-DOG/godog"
-  packages = [".","colors","gherkin"]
+  packages = [
+    ".",
+    "colors",
+    "gherkin"
+  ]
   revision = "4dc98b0e2b130c3c9d06868a050320e5b310d3e7"
   version = "v0.7.4"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
-  packages = [".","archive/tar","backuptar"]
+  packages = [
+    ".",
+    "archive/tar",
+    "backuptar"
+  ]
   revision = "7da180ee92d8bd8bb8c37fc560e673e6557c392f"
   version = "v0.4.7"
 
@@ -44,15 +55,85 @@
   version = "v3.5.0"
 
 [[projects]]
+  name = "github.com/cloudflare/cfssl"
+  packages = ["log"]
+  revision = "4e2dcbde500472449917533851bf4bae9bdff562"
+  version = "1.3.1"
+
+[[projects]]
   name = "github.com/containers/image"
-  packages = ["copy","directory","directory/explicitfilepath","docker","docker/archive","docker/daemon","docker/policyconfiguration","docker/reference","docker/tarfile","image","internal/tmpdir","manifest","oci/archive","oci/internal","oci/layout","openshift","ostree","pkg/compression","pkg/docker/config","pkg/strslice","pkg/tlsclientconfig","signature","storage","tarball","transports","transports/alltransports","types","version"]
+  packages = [
+    "copy",
+    "directory",
+    "directory/explicitfilepath",
+    "docker",
+    "docker/archive",
+    "docker/daemon",
+    "docker/policyconfiguration",
+    "docker/reference",
+    "docker/tarfile",
+    "image",
+    "internal/tmpdir",
+    "manifest",
+    "oci/archive",
+    "oci/internal",
+    "oci/layout",
+    "openshift",
+    "ostree",
+    "pkg/compression",
+    "pkg/docker/config",
+    "pkg/strslice",
+    "pkg/tlsclientconfig",
+    "signature",
+    "storage",
+    "tarball",
+    "transports",
+    "transports/alltransports",
+    "types",
+    "version"
+  ]
   revision = "8b24210344a448e58be6ed53636e2eacaa30be32"
 
 [[projects]]
   branch = "master"
   name = "github.com/containers/storage"
-  packages = [".","drivers","drivers/aufs","drivers/btrfs","drivers/devmapper","drivers/overlay","drivers/overlayutils","drivers/quota","drivers/register","drivers/vfs","drivers/windows","drivers/zfs","pkg/archive","pkg/chrootarchive","pkg/devicemapper","pkg/directory","pkg/dmesg","pkg/fileutils","pkg/fsutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/locker","pkg/longpath","pkg/loopback","pkg/mount","pkg/parsers","pkg/parsers/kernel","pkg/pools","pkg/promise","pkg/reexec","pkg/stringid","pkg/system","pkg/truncindex"]
-  revision = "477e551dd493e5c80999d3690d3a201fd26ba2f1"
+  packages = [
+    ".",
+    "drivers",
+    "drivers/aufs",
+    "drivers/btrfs",
+    "drivers/devmapper",
+    "drivers/overlay",
+    "drivers/overlayutils",
+    "drivers/quota",
+    "drivers/register",
+    "drivers/vfs",
+    "drivers/windows",
+    "drivers/zfs",
+    "pkg/archive",
+    "pkg/chrootarchive",
+    "pkg/devicemapper",
+    "pkg/directory",
+    "pkg/dmesg",
+    "pkg/fileutils",
+    "pkg/fsutils",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/locker",
+    "pkg/longpath",
+    "pkg/loopback",
+    "pkg/mount",
+    "pkg/parsers",
+    "pkg/parsers/kernel",
+    "pkg/pools",
+    "pkg/promise",
+    "pkg/reexec",
+    "pkg/stringid",
+    "pkg/system",
+    "pkg/truncindex"
+  ]
+  revision = "f5dc7fe58d10b581aee6cbf400ab69d2f6b86ab6"
 
 [[projects]]
   name = "github.com/cpuguy83/go-md2man"
@@ -68,23 +149,68 @@
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = [".","digestset","reference","registry/api/errcode","registry/api/v2","registry/client","registry/client/auth/challenge","registry/client/transport","registry/storage/cache","registry/storage/cache/memory"]
+  packages = [
+    ".",
+    "digestset",
+    "reference",
+    "registry/api/errcode",
+    "registry/api/v2",
+    "registry/client",
+    "registry/client/auth/challenge",
+    "registry/client/transport",
+    "registry/storage/cache",
+    "registry/storage/cache/memory"
+  ]
   revision = "5f6282db7d65e6d72ad7c2cc66310724a57be716"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api","api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/image","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/time","api/types/versions","api/types/volume","client","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/longpath","pkg/mount","pkg/system","pkg/term","pkg/term/windows","pkg/tlsconfig"]
+  packages = [
+    "api",
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/image",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/longpath",
+    "pkg/mount",
+    "pkg/system",
+    "pkg/term",
+    "pkg/term/windows",
+    "pkg/tlsconfig"
+  ]
   revision = "30eb4d8cdc422b023d5f11f29a82ecb73554183b"
 
 [[projects]]
   name = "github.com/docker/docker-credential-helpers"
-  packages = ["client","credentials"]
+  packages = [
+    "client",
+    "credentials"
+  ]
   revision = "d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1"
   version = "v0.6.0"
 
 [[projects]]
   name = "github.com/docker/go-connections"
-  packages = ["nat","sockets","tlsconfig"]
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig"
+  ]
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
   version = "v0.3.0"
 
@@ -101,7 +227,42 @@
 
 [[projects]]
   name = "github.com/docker/machine"
-  packages = ["commands/mcndirs","drivers/errdriver","drivers/fakedriver","drivers/hyperv","drivers/none","drivers/virtualbox","drivers/vmwarefusion","libmachine","libmachine/auth","libmachine/cert","libmachine/check","libmachine/drivers","libmachine/drivers/plugin","libmachine/drivers/plugin/localbinary","libmachine/drivers/rpc","libmachine/engine","libmachine/host","libmachine/log","libmachine/mcndockerclient","libmachine/mcnerror","libmachine/mcnflag","libmachine/mcnutils","libmachine/persist","libmachine/provision","libmachine/provision/pkgaction","libmachine/provision/provisiontest","libmachine/provision/serviceaction","libmachine/shell","libmachine/ssh","libmachine/state","libmachine/swarm","libmachine/version","libmachine/versioncmp","version"]
+  packages = [
+    "commands/mcndirs",
+    "drivers/errdriver",
+    "drivers/fakedriver",
+    "drivers/hyperv",
+    "drivers/none",
+    "drivers/virtualbox",
+    "drivers/vmwarefusion",
+    "libmachine",
+    "libmachine/auth",
+    "libmachine/cert",
+    "libmachine/check",
+    "libmachine/drivers",
+    "libmachine/drivers/plugin",
+    "libmachine/drivers/plugin/localbinary",
+    "libmachine/drivers/rpc",
+    "libmachine/engine",
+    "libmachine/host",
+    "libmachine/log",
+    "libmachine/mcndockerclient",
+    "libmachine/mcnerror",
+    "libmachine/mcnflag",
+    "libmachine/mcnutils",
+    "libmachine/persist",
+    "libmachine/provision",
+    "libmachine/provision/pkgaction",
+    "libmachine/provision/provisiontest",
+    "libmachine/provision/serviceaction",
+    "libmachine/shell",
+    "libmachine/ssh",
+    "libmachine/state",
+    "libmachine/swarm",
+    "libmachine/version",
+    "libmachine/versioncmp",
+    "version"
+  ]
   revision = "9ba6da9ebd1140b65eb73e1ce08086ca72764c60"
   version = "v0.13.0"
 
@@ -171,13 +332,27 @@
 
 [[projects]]
   name = "github.com/gorillalabs/go-powershell"
-  packages = [".","backend","utils"]
+  packages = [
+    ".",
+    "backend",
+    "utils"
+  ]
   revision = "3bc7a60b1df80a5766820c4a53d59668f4553f75"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -188,7 +363,11 @@
 
 [[projects]]
   name = "github.com/inconshreveable/go-update"
-  packages = [".","internal/binarydist","internal/osext"]
+  packages = [
+    ".",
+    "internal/binarydist",
+    "internal/osext"
+  ]
   revision = "8152e7eb6ccf8679a64582a66b78519688d156ad"
 
 [[projects]]
@@ -196,6 +375,12 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/johanneswuerbach/nfsexports"
+  packages = ["."]
+  revision = "a9068f3f0daa39616953aec11c3eb1209ebc4086"
 
 [[projects]]
   branch = "master"
@@ -213,6 +398,15 @@
   name = "github.com/kr/fs"
   packages = ["."]
   revision = "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+
+[[projects]]
+  name = "github.com/machine-drivers/docker-machine-driver-hyperkit"
+  packages = [
+    "pkg/drivers",
+    "pkg/hyperkit"
+  ]
+  revision = "88bae774eacefa283ef549f6ea6bc202d97ca07a"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -240,9 +434,21 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/mitchellh/go-ps"
+  packages = ["."]
+  revision = "4fdf99ab29366514c69ccccddab5dc58b8d84062"
+
+[[projects]]
+  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+
+[[projects]]
+  name = "github.com/moby/hyperkit"
+  packages = ["go"]
+  revision = "858492e3d919f8b49a39e1944a49e1d7b4a51e6d"
+  version = "v0.20171204"
 
 [[projects]]
   branch = "master"
@@ -263,26 +469,38 @@
 
 [[projects]]
   name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
+  packages = [
+    "specs-go",
+    "specs-go/v1"
+  ]
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/system","libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user"
+  ]
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
 [[projects]]
   name = "github.com/opencontainers/selinux"
-  packages = ["go-selinux","go-selinux/label"]
+  packages = [
+    "go-selinux",
+    "go-selinux/label"
+  ]
   revision = "ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d"
   version = "v1.0.0-rc1"
 
 [[projects]]
   branch = "master"
   name = "github.com/ostreedev/ostree-go"
-  packages = ["pkg/glibobject","pkg/otbuiltin"]
+  packages = [
+    "pkg/glibobject",
+    "pkg/otbuiltin"
+  ]
   revision = "cb6250d5a6a240b509609915842f763fd87b819d"
 
 [[projects]]
@@ -322,7 +540,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/pquerna/ffjson"
-  packages = ["fflib/v1","fflib/v1/internal"]
+  packages = [
+    "fflib/v1",
+    "fflib/v1/internal"
+  ]
   revision = "d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac"
 
 [[projects]]
@@ -340,12 +561,15 @@
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
-  version = "v1.0.4"
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
   version = "v1.0.2"
 
@@ -357,7 +581,10 @@
 
 [[projects]]
   name = "github.com/spf13/cobra"
-  packages = [".","doc"]
+  packages = [
+    ".",
+    "doc"
+  ]
   revision = "e606913c4ee45fec232e67e70105fb6c866b95d9"
 
 [[projects]]
@@ -390,40 +617,101 @@
 
 [[projects]]
   name = "github.com/vbatts/tar-split"
-  packages = ["archive/tar","tar/asm","tar/storage"]
+  packages = [
+    "archive/tar",
+    "tar/asm",
+    "tar/storage"
+  ]
   revision = "38ec4ddb06dedbea0a895c4848b248eb38af221b"
   version = "v0.10.2"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/zchee/go-vmnet"
+  packages = ["."]
+  revision = "97ebf91740978f1e665defc0a960fb997ebe282b"
+
+[[projects]]
   name = "golang.org/x/crypto"
-  packages = ["cast5","curve25519","ed25519","ed25519/internal/edwards25519","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","ssh","ssh/terminal"]
+  packages = [
+    "cast5",
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "ssh",
+    "ssh/terminal"
+  ]
   revision = "b080dc9a8c480b08e698fb1219160d598526310f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex","proxy"]
-  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex",
+    "proxy"
+  ]
+  revision = "e0c57d8f86c17f0724497efcb3bc617e82834821"
 
 [[projects]]
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal"
+  ]
   revision = "442624c9ec9243441e83b374a9e22ac549b5c51d"
 
 [[projects]]
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry"]
+  packages = [
+    "unix",
+    "windows",
+    "windows/registry"
+  ]
   revision = "43e60d72a8e2bd92ee98319ba9a384a0e9837c08"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -447,6 +735,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "56f18a532b86c7741de018c586555a7e21d193213d341c08dad3a3c296eaaa90"
+  inputs-digest = "334a1635bce7c80047923c6d66f544a330eb0d371956ef56f0fd81b971c44732"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -117,6 +117,11 @@ ignored = ["github.com/Sirupsen/logrus"]
   name = "github.com/docker/go-connections"
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
 
+# Get dependencies for hyperkit
+[[constraint]]
+  name = "github.com/machine-driver/docker-machine-driver-hyperkit"
+  version = "=v1.0.0"
+
 # Use override for docker/docker and docker/distribution to ensure we get the specfied version.
 # In particular we need a version which uses the altest logrus
 [[override]]

--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -29,7 +29,12 @@ macOS::
 ====
 xhyve requires specific installation and configuration steps that are described in the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.
 ====
-
+- link:https://github.com/moby/hyperkit[hyperkit]
++
+[NOTE]
+====
+hyperkit requires specific installation and configuration steps that are described in the xref:../getting-started/setting-up-driver-plugin.adoc#[Setting Up the Driver Plug-in] section.
+====
 - link:https://www.virtualbox.org/wiki/Downloads[VirtualBox]
 
 Linux::

--- a/docs/source/getting-started/setting-up-driver-plugin.adoc
+++ b/docs/source/getting-started/setting-up-driver-plugin.adoc
@@ -183,6 +183,52 @@ $ sudo chmod u+s /usr/local/bin/docker-machine-driver-xhyve
 For more information, see the link:https://github.com/zchee/docker-machine-driver-xhyve#install[xhyve driver] documentation on GitHub.
 ====
 
+[[hyperkit-driver-install]]
+== hyperkit Driver
+
+{project} is currently tested against *docker-machine-driver-hyperkit* version 1.0.0.
+
+
+To install the hyperkit driver, you need to download and install the *docker-machine-driver-hyperkit* binary and place it in a directory which is on your `PATH` environment variable.
+The directory *_/usr/local/bin_* is most likely a good choice, since it is the default installation directory for Docker Machine binaries.
+
+The following steps explain the installation of the *docker-machine-driver-hyperkit* binary to the *_/usr/local/bin/_* directory:
+
+. Download the *docker-machine-driver-hyperkit* binary using:
++
+----
+$ sudo curl -L  https://github.com/machine-drivers/docker-machine-driver-hyperkit/releases/download/v1.0.0/docker-machine-driver-hyperkit -o /usr/local/bin/docker-machine-driver-hyperkit
+----
+
+. Enable root access for the *docker-machine-driver-hyperkit* binary and add it to the default *wheel* group:
++
+----
+$ sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit
+----
+
+. Set owner User ID (SUID) for the binary as follows:
++
+----
+$ sudo chmod u+s,+x /usr/local/bin/docker-machine-driver-hyperkit
+----
+
+[NOTE]
+====
+The downloaded *docker-machine-driver-hyperkit* binary is compiled against a specific version of macOS.
+It is possible that the driver will fail to work after a macOS version upgrade.
+In this case you can try to compile the driver from source:
+
+----
+$ go get -u -d github.com/machine-drivers/docker-machine-driver-hyperkit
+$ cd $GOPATH/src/github.com/machine-drivers/docker-machine-driver-hyperkit
+
+# Install docker-machine-driver-hyperkit binary into /usr/local/bin
+$ make build
+----
+
+For more information, see the link: https://github.com/machine-drivers/docker-machine-driver-hyperkit/blob/master/README.md[hyperkit driver] documentation on GitHub.
+====
+
 == Hyper-V Driver
 To use {project} with Hyper-V:
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -377,6 +377,8 @@ func getDriverOptions(config MachineConfig) interface{} {
 		driver = createXhyveHost(config)
 	case "hyperv":
 		driver = createHypervHost(config)
+	case "hyperkit":
+		driver = createHyperkitHost(config)
 	default:
 		atexit.ExitWithMessage(1, fmt.Sprintf("Unsupported driver: %s", config.VMDriver))
 	}

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -19,7 +19,9 @@ package cluster
 import (
 	"github.com/docker/machine/drivers/vmwarefusion"
 	"github.com/docker/machine/libmachine/drivers"
+	"github.com/machine-drivers/docker-machine-driver-hyperkit/pkg/hyperkit"
 	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/pborman/uuid"
 )
 
 func createVMwareFusionHost(config MachineConfig) drivers.Driver {
@@ -66,5 +68,20 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		DiskSize:       int64(config.DiskSize),
 		QCow2:          false,
 		RawDisk:        true,
+	}
+}
+
+func createHyperkitHost(config MachineConfig) *hyperkit.Driver {
+	return &hyperkit.Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: constants.MachineName,
+			StorePath:   constants.Minipath,
+			SSHUser:     "docker",
+		},
+		Boot2DockerURL: config.GetISOFileURI(),
+		DiskSize:       config.DiskSize,
+		Memory:         config.Memory,
+		CPU:            config.CPUs,
+		UUID:           uuid.NewUUID().String(),
 	}
 }

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -22,6 +22,7 @@ var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"vmwarefusion",
 	"xhyve",
+	"hyperkit",
 }
 
 const DefaultVMDriver = "xhyve"


### PR DESCRIPTION
Following steps need to test current POC.

- Get https://github.com/praveenkumar/docker-machine-driver-hyperkit and `make build`
- Make sure you disable volume mount check because with hyperkit mount driver created as `/mnt/vda1` instead `/mnt/sda1` 
     - `minishift config set skip-check-storage-mount true`

- Get the minishift binary for this PR
- `minishift start --vm-driver hyperkit`