### PR TITLE
Issue #2067 Set rawdisk as default for xhyve driver

### DIFF
--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	StorageDisk = "/mnt/sda1"
+	StorageDisk = "/mnt/?da1"
 )
 
 // preflightChecksBeforeStartingHost is executed before the startHost function.

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -65,5 +65,6 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		Boot2DockerURL: config.GetISOFileURI(),
 		DiskSize:       int64(config.DiskSize),
 		QCow2:          false,
+		RawDisk:        true,
 	}
 }


### PR DESCRIPTION
Once we enable rawdisk as true for the driver then mount drive created as `/mnt/vda1` instead `/mnt/sda1`

```
minishift config set skip-check-storage-mount true
```