### PR TITLE
Issue #2069 Print origin versions from github releases instead of dockerhub

### DIFF
--- a/pkg/minishift/openshift/version/openshift_versions_test.go
+++ b/pkg/minishift/openshift/version/openshift_versions_test.go
@@ -101,3 +101,21 @@ func TestIsGreaterOrEqualToBaseVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPrerelease(t *testing.T) {
+	var versionTestData = []struct {
+		openshiftVersion string
+		expectedResult   bool
+	}{
+		{"v3.6.0", false},
+		{"v3.6.0-alpha.1", true},
+		{"v3.9.0-alpha.3", true},
+		{"v3.8.0-rc.1", true},
+		{"v3.6.0-beta", true},
+	}
+
+	for _, versionTest := range versionTestData {
+		actualResult := isPrerelease(versionTest.openshiftVersion)
+		assert.Equal(t, versionTest.expectedResult, actualResult)
+	}
+}


### PR DESCRIPTION
Fixes: #2069

```
$ minishift openshift version list
The following OpenShift versions are available: 
	- v1.4.1
	- v1.5.0
	- v1.5.1
	- v3.6.0
	- v3.6.1
	- v3.7.0
	- v3.7.1
	- v3.9.0-alpha.3
``` 