### PR TITLE
Issue #1130 Add placeholder to ignore command exit status for addon

### DIFF
--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -38,7 +38,9 @@ oc adm policy add-scc-to-group anyuid system:authenticated                      
 
 [NOTE]
 ====
-Comment lines, starting with the '#' character, can be inserted anywhere in the file.
+- Comment lines, starting with the '#' character, can be inserted anywhere in the file.
+- Command starting with `!` character ignores the execution failure.
+With the help of this, add-on will be idempotent i.e. a command can be executed multiple times without changing the final behavior of the add-on.
 ====
 
 Enabled add-ons are applied during xref:../command-ref/minishift_start.adoc#[`minishift start`], immediately after the initial cluster provisioning is successfully completed.

--- a/pkg/minishift/addon/command/command.go
+++ b/pkg/minishift/addon/command/command.go
@@ -26,17 +26,21 @@ type Command interface {
 	String() string
 }
 
-type doExecute func(ec *ExecutionContext) error
+type doExecute func(ec *ExecutionContext, ignoreError bool) error
 
 type defaultCommand struct {
 	Command
 
-	rawCommand string
-	fn         doExecute
+	rawCommand  string
+	fn          doExecute
+	ignoreError bool
 }
 
 func (c *defaultCommand) Execute(ec *ExecutionContext) error {
-	err := c.fn(ec)
+	err := c.fn(ec, c.ignoreError)
+	if c.ignoreError {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -45,4 +49,8 @@ func (c *defaultCommand) Execute(ec *ExecutionContext) error {
 
 func (c *defaultCommand) String() string {
 	return c.rawCommand
+}
+
+func (c *defaultCommand) IgnoreError() bool {
+	return c.ignoreError
 }

--- a/pkg/minishift/addon/command/docker_command.go
+++ b/pkg/minishift/addon/command/docker_command.go
@@ -25,14 +25,14 @@ type DockerCommand struct {
 	*defaultCommand
 }
 
-func NewDockerCommand(command string) *DockerCommand {
-	defaultCommand := &defaultCommand{rawCommand: command}
+func NewDockerCommand(command string, ignoreError bool) *DockerCommand {
+	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError}
 	dockerCommand := &DockerCommand{defaultCommand}
 	defaultCommand.fn = dockerCommand.doExecute
 	return dockerCommand
 }
 
-func (c *DockerCommand) doExecute(ec *ExecutionContext) error {
+func (c *DockerCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
 	commander := ec.GetDockerCommander()
 	cmd := ec.Interpolate(c.rawCommand)
 	fmt.Print(".")

--- a/pkg/minishift/addon/command/echo_command.go
+++ b/pkg/minishift/addon/command/echo_command.go
@@ -26,14 +26,14 @@ type EchoCommand struct {
 	*defaultCommand
 }
 
-func NewEchoCommand(command string) *EchoCommand {
-	defaultCommand := &defaultCommand{rawCommand: command}
+func NewEchoCommand(command string, ignoreError bool) *EchoCommand {
+	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError}
 	echoCommand := &EchoCommand{defaultCommand}
 	defaultCommand.fn = echoCommand.doExecute
 	return echoCommand
 }
 
-func (c *EchoCommand) doExecute(ec *ExecutionContext) error {
+func (c *EchoCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
 	var err error
 
 	// split off the actual 'echo' command. As we need to print rest of the string

--- a/pkg/minishift/addon/command/echo_command_test.go
+++ b/pkg/minishift/addon/command/echo_command_test.go
@@ -27,26 +27,32 @@ func Test_echo_command(t *testing.T) {
 	testCases := []struct {
 		echoCommand    string
 		expectedOutput string
+		ignoreError    bool
 	}{
 		{
 			echoCommand:    "echo hello world",
 			expectedOutput: "\nhello world",
+			ignoreError:    false,
 		},
 		{
 			echoCommand:    "echo    good\n bye", // 3 extrace spaces are preserved
 			expectedOutput: "\n   good\n bye",
+			ignoreError:    false,
 		},
 		{
 			echoCommand:    "echo",
 			expectedOutput: "\n",
+			ignoreError:    false,
 		},
 		{
 			echoCommand:    "echo ",
 			expectedOutput: "\n",
+			ignoreError:    false,
 		},
 		{
 			echoCommand:    "echo  ", // single additional space
 			expectedOutput: "\n ",
+			ignoreError:    false,
 		},
 	}
 
@@ -55,7 +61,7 @@ func Test_echo_command(t *testing.T) {
 		defer tee.Close()
 		assert.NoError(t, err, "Error getting instance of Tee")
 
-		echo := NewEchoCommand(test.echoCommand)
+		echo := NewEchoCommand(test.echoCommand, test.ignoreError)
 		context := &FakeInterpolationContext{}
 		echo.Execute(&ExecutionContext{interpolationContext: context})
 		tee.Close()

--- a/pkg/minishift/addon/command/execution_context.go
+++ b/pkg/minishift/addon/command/execution_context.go
@@ -45,12 +45,12 @@ func (ec *ExecutionContext) GetSSHCommander() provision.SSHCommander {
 	return ec.sshCommander
 }
 
-// GetSSHCommander returns a ssh commander to execute ssh commands against the Minishift VM
+// GetOcCommander returns a commander to run oc commands against the Minishift VM
 func (ec *ExecutionContext) GetOcCommander() *oc.OcRunner {
 	return ec.ocRunner
 }
 
-// GetDockerCommander returns a commander to run docker commands against the docker daemon used by Minishift
+// GetDockerCommander returns a commander to run docker commands against the docker daemon used by Minishift VM
 func (ec *ExecutionContext) GetDockerCommander() docker.DockerCommander {
 	return ec.dockerCommander
 }

--- a/pkg/minishift/addon/command/openshift_command.go
+++ b/pkg/minishift/addon/command/openshift_command.go
@@ -28,14 +28,14 @@ type OpenShiftCommand struct {
 	*defaultCommand
 }
 
-func NewOpenShiftCommand(command string) *OpenShiftCommand {
-	defaultCommand := &defaultCommand{rawCommand: command}
+func NewOpenShiftCommand(command string, ignoreError bool) *OpenShiftCommand {
+	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError}
 	openShiftCommand := &OpenShiftCommand{defaultCommand}
 	defaultCommand.fn = openShiftCommand.doExecute
 	return openShiftCommand
 }
 
-func (c *OpenShiftCommand) doExecute(ec *ExecutionContext) error {
+func (c *OpenShiftCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
 	// split off the actual 'oc' command. We are using our cached oc version to run oc commands
 	cmd := strings.Replace(c.rawCommand, "openshift ", "", 1)
 	cmd = ec.Interpolate(cmd)

--- a/pkg/minishift/addon/command/sleep_command.go
+++ b/pkg/minishift/addon/command/sleep_command.go
@@ -32,14 +32,14 @@ type SleepCommand struct {
 	*defaultCommand
 }
 
-func NewSleepCommand(command string) *SleepCommand {
-	defaultCommand := &defaultCommand{rawCommand: command}
+func NewSleepCommand(command string, ignoreError bool) *SleepCommand {
+	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError}
 	sleepCommand := &SleepCommand{defaultCommand}
 	defaultCommand.fn = sleepCommand.doExecute
 	return sleepCommand
 }
 
-func (c *SleepCommand) doExecute(ec *ExecutionContext) error {
+func (c *SleepCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
 	duration, err := c.getSleepTime()
 	if err != nil {
 		return err

--- a/pkg/minishift/addon/command/sleep_command_test.go
+++ b/pkg/minishift/addon/command/sleep_command_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Test_parsing_sleep_time_is_successful(t *testing.T) {
-	sleep := NewSleepCommand("sleep 100")
+	sleep := NewSleepCommand("sleep 100", false)
 
 	duration, err := sleep.getSleepTime()
 
@@ -36,7 +36,7 @@ func Test_parsing_sleep_time_is_successful(t *testing.T) {
 
 func Test_parsing_sleep_time_ignores_text_after_durationb(t *testing.T) {
 	cmd := "sleep 5 foobar"
-	sleep := NewSleepCommand(cmd)
+	sleep := NewSleepCommand(cmd, false)
 
 	duration, err := sleep.getSleepTime()
 
@@ -47,7 +47,7 @@ func Test_parsing_sleep_time_ignores_text_after_durationb(t *testing.T) {
 
 func Test_parsing_sleep_time_fails(t *testing.T) {
 	cmd := "sleep abc"
-	sleep := NewSleepCommand(cmd)
+	sleep := NewSleepCommand(cmd, false)
 
 	_, err := sleep.getSleepTime()
 	assert.Error(t, err, "Error getting sleep time")

--- a/pkg/minishift/addon/command/ssh_command.go
+++ b/pkg/minishift/addon/command/ssh_command.go
@@ -26,14 +26,14 @@ type SSHCommand struct {
 	*defaultCommand
 }
 
-func NewSshCommand(command string) *SSHCommand {
-	defaultCommand := &defaultCommand{rawCommand: command}
+func NewSshCommand(command string, ignoreError bool) *SSHCommand {
+	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError}
 	sshCommand := &SSHCommand{defaultCommand}
 	defaultCommand.fn = sshCommand.doExecute
 	return sshCommand
 }
 
-func (c *SSHCommand) doExecute(ec *ExecutionContext) error {
+func (c *SSHCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
 	cmd := strings.Replace(c.rawCommand, "ssh ", "", 1)
 	cmd = ec.Interpolate(cmd)
 	fmt.Print(".")

--- a/pkg/minishift/addon/parser/addon_parser.go
+++ b/pkg/minishift/addon/parser/addon_parser.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	commentChar = "#"
+	commentChar     = "#"
+	ignoreErrorChar = "!"
 
 	noAddOnDefinitionFoundError         = "There needs to be an addon file per addon directory. Found none in '%s'"
 	multipleAddOnDefinitionsError       = "There can only be one addon file per addon directory. Found '%s'"
@@ -191,6 +192,7 @@ func (parser *AddOnParser) parseHeader(scanner *bufio.Scanner) (addon.AddOnMeta,
 func (parser *AddOnParser) parseCommands(scanner *bufio.Scanner) ([]command.Command, error) {
 	var commands []command.Command
 	for scanner.Scan() {
+		ignoreError := false
 		line := scanner.Text()
 
 		// skip blank and comment lines
@@ -198,8 +200,11 @@ func (parser *AddOnParser) parseCommands(scanner *bufio.Scanner) ([]command.Comm
 		if len(line) == 0 || strings.HasPrefix(line, commentChar) {
 			continue
 		}
-
-		newCommand, err := parser.handler.Handle(parser.handler, line)
+		if strings.HasPrefix(line, ignoreErrorChar) {
+			ignoreError = true
+			line = strings.TrimPrefix(line, ignoreErrorChar)
+		}
+		newCommand, err := parser.handler.Handle(parser.handler, line, ignoreError)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/minishift/addon/parser/command_handler.go
+++ b/pkg/minishift/addon/parser/command_handler.go
@@ -37,11 +37,11 @@ type CommandHandler interface {
 	// Create attempts to parse the given string into a Command instance of its type. In case
 	// s does not represent a command which can be handled by this Command instance, Create of the specified next
 	// Command is called. If there is no next Command, nil is returned.
-	Handle(next CommandHandler, s string) (command.Command, error)
+	Handle(next CommandHandler, s string, ignoreError bool) (command.Command, error)
 
 	// Parse attempts to parse the given string into a Command instance of its type. nil is returned in case
 	// s does not represent a command which can be handled by this Command instance.
-	Parse(s string) command.Command
+	Parse(s string, ignoreError bool) command.Command
 }
 
 type defaultCommandHandler struct {
@@ -54,12 +54,12 @@ func (dc *defaultCommandHandler) SetNext(next CommandHandler) {
 	dc.next = next
 }
 
-func (dc *defaultCommandHandler) Handle(c CommandHandler, s string) (command.Command, error) {
-	newCommand := c.Parse(s)
+func (dc *defaultCommandHandler) Handle(c CommandHandler, s string, ignoreError bool) (command.Command, error) {
+	newCommand := c.Parse(s, ignoreError)
 	if newCommand != nil {
 		return newCommand, nil
 	} else if dc.next != nil {
-		return dc.next.Handle(dc.next, s)
+		return dc.next.Handle(dc.next, s, ignoreError)
 	} else {
 		return nil, errors.New(fmt.Sprintf("Unable to process command: '%s'", s))
 	}
@@ -69,9 +69,9 @@ type DockerCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *DockerCommandHandler) Parse(s string) command.Command {
+func (c *DockerCommandHandler) Parse(s string, ignoreError bool) command.Command {
 	if strings.HasPrefix(s, dockerCommand) {
-		return command.NewDockerCommand(s)
+		return command.NewDockerCommand(s, ignoreError)
 	}
 	return nil
 }
@@ -80,9 +80,9 @@ type OcCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *OcCommandHandler) Parse(s string) command.Command {
+func (c *OcCommandHandler) Parse(s string, ignoreError bool) command.Command {
 	if strings.HasPrefix(s, ocCommand) {
-		return command.NewOcCommand(s)
+		return command.NewOcCommand(s, ignoreError)
 	}
 	return nil
 }
@@ -91,9 +91,9 @@ type OpenShiftCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *OpenShiftCommandHandler) Parse(s string) command.Command {
+func (c *OpenShiftCommandHandler) Parse(s string, ignoreError bool) command.Command {
 	if strings.HasPrefix(s, openShiftCommand) {
-		return command.NewOpenShiftCommand(s)
+		return command.NewOpenShiftCommand(s, ignoreError)
 	}
 	return nil
 }
@@ -102,9 +102,9 @@ type SleepCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *SleepCommandHandler) Parse(s string) command.Command {
+func (c *SleepCommandHandler) Parse(s string, ignoreError bool) command.Command {
 	if strings.HasPrefix(s, sleepCommand) {
-		return command.NewSleepCommand(s)
+		return command.NewSleepCommand(s, ignoreError)
 	}
 	return nil
 }
@@ -113,9 +113,9 @@ type SSHCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *SSHCommandHandler) Parse(s string) command.Command {
+func (c *SSHCommandHandler) Parse(s string, ignoreError bool) command.Command {
 	if strings.HasPrefix(s, sshCommand) {
-		return command.NewSshCommand(s)
+		return command.NewSshCommand(s, ignoreError)
 	}
 	return nil
 }
@@ -124,9 +124,9 @@ type EchoCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *EchoCommandHandler) Parse(s string) command.Command {
+func (c *EchoCommandHandler) Parse(s string, ignoreError bool) command.Command {
 	if strings.HasPrefix(s, echoCommand) {
-		return command.NewEchoCommand(s)
+		return command.NewEchoCommand(s, ignoreError)
 	}
 	return nil
 }


### PR DESCRIPTION
To test this PR.

1. create a test addon or use existing addon (admin-user)

```
$ minishift apply addon admin-user

# Again run same apply command to make this admin-user addon to fail
$ ./minishift addon apply admin-user 
-- Applying addon 'admin-user':.Error from server (AlreadyExists): users.user.openshift.io "admin" already exists
Error applying the add-on: Error executing command 'oc create user admin --full-name=admin'.
$ echo $?
1

# Now add ignore error placeholder to command
$ cat ~/.minishift/addons/admin-user/admin-user.addon
# Name: admin-user
# Description: Create admin user and assign the cluster-admin role to it.
# Maintainer: kumarpraveen.nitdgp@gmail.com

!oc create user admin --full-name=admin
oc adm policy add-cluster-role-to-user cluster-admin admin

echo "Hello world"

$ ./minishift addon apply admin-user 
-- Applying addon 'admin-user':.Error from server (AlreadyExists): users.user.openshift.io "admin" already exists
.
"Hello world"
$ echo $?
0
```
