### PR TITLE
[WIP] Issue #2141 Remove vmwarefusion deprecation code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,7 +133,7 @@
     "pkg/system",
     "pkg/truncindex"
   ]
-  revision = "f5dc7fe58d10b581aee6cbf400ab69d2f6b86ab6"
+  revision = "aaa10cba3c246a9186e2160f4e12b21d8cf77c94"
 
 [[projects]]
   name = "github.com/cpuguy83/go-md2man"
@@ -234,7 +234,6 @@
     "drivers/hyperv",
     "drivers/none",
     "drivers/virtualbox",
-    "drivers/vmwarefusion",
     "libmachine",
     "libmachine/auth",
     "libmachine/cert",
@@ -528,8 +527,8 @@
 [[projects]]
   name = "github.com/pkg/sftp"
   packages = ["."]
-  revision = "0159c83e42a88e5c35180f73b84298a6bdde1ec1"
-  version = "1.4.0"
+  revision = "49488377fa2f14143ba3067cf7555f60f6c7b550"
+  version = "1.5.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -661,7 +660,7 @@
     "lex/httplex",
     "proxy"
   ]
-  revision = "e0c57d8f86c17f0724497efcb3bc617e82834821"
+  revision = "24dd3780ca4f75fed9f321890729414a4b5d3f13"
 
 [[projects]]
   name = "golang.org/x/oauth2"
@@ -735,6 +734,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "334a1635bce7c80047923c6d66f544a330eb0d371956ef56f0fd81b971c44732"
+  inputs-digest = "72798011620276f7af8c3e0add3c2e135bd75caf54fc90c7946eb3fa26d4f931"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -368,9 +368,6 @@ func getDriverOptions(config MachineConfig) interface{} {
 	switch config.VMDriver {
 	case "virtualbox":
 		driver = createVirtualboxHost(config)
-	case "vmwarefusion":
-		fmt.Println("VMWare Fusion driver will be deprecated soon. Please consider using other drivers.")
-		driver = createVMwareFusionHost(config)
 	case "kvm":
 		driver = createKVMHost(config)
 	case "xhyve":

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -17,25 +17,11 @@ limitations under the License.
 package cluster
 
 import (
-	"github.com/docker/machine/drivers/vmwarefusion"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/machine-drivers/docker-machine-driver-hyperkit/pkg/hyperkit"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/pborman/uuid"
 )
-
-func createVMwareFusionHost(config MachineConfig) drivers.Driver {
-	d := vmwarefusion.NewDriver(constants.MachineName, constants.Minipath).(*vmwarefusion.Driver)
-	d.Boot2DockerURL = config.GetISOFileURI()
-	d.Memory = config.Memory
-	d.CPU = config.CPUs
-	d.DiskSize = config.DiskSize
-
-	// TODO(philips): push these defaults upstream to fixup this driver
-	d.SSHPort = 22
-	d.ISO = d.ResolveStorePath("boot2docker.iso")
-	return d
-}
 
 type xhyveDriver struct {
 	*drivers.BaseDriver

--- a/pkg/minikube/cluster/cluster_non_darwin_panic.go
+++ b/pkg/minikube/cluster/cluster_non_darwin_panic.go
@@ -20,10 +20,6 @@ package cluster
 
 import "github.com/docker/machine/libmachine/drivers"
 
-func createVMwareFusionHost(config MachineConfig) drivers.Driver {
-	panic("vmwarefusion not supported")
-}
-
 func createXhyveHost(config MachineConfig) drivers.Driver {
 	panic("xhyve not supported")
 }

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -20,7 +20,6 @@ package constants
 
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
-	"vmwarefusion",
 	"xhyve",
 	"hyperkit",
 }

--- a/pkg/minikube/constants/constants_gendocs.go
+++ b/pkg/minikube/constants/constants_gendocs.go
@@ -20,7 +20,6 @@ package constants
 
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
-	"vmwarefusion",
 	"kvm",
 	"xhyve",
 	"hyperv",

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/docker/machine/drivers/hyperv"
 	"github.com/docker/machine/drivers/virtualbox"
-	"github.com/docker/machine/drivers/vmwarefusion"
 	"github.com/docker/machine/libmachine/drivers/plugin"
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
 	"github.com/golang/glog"
@@ -34,8 +33,6 @@ func StartDriver() {
 		switch driverName {
 		case "virtualbox":
 			plugin.RegisterDriver(virtualbox.NewDriver("", ""))
-		case "vmwarefusion":
-			plugin.RegisterDriver(vmwarefusion.NewDriver("", ""))
 		case "hyperv":
 			plugin.RegisterDriver(hyperv.NewDriver("", ""))
 		default:


### PR DESCRIPTION
Fixes #2141 

To cleanup Gopkg.lock, I also ran `dep ensure -update`, which appears to have updated some packages. Let me know if this isn't desired and I can back this out.