### PR TITLE
Issue #2102 Add Offine error message for pre-flight check

### DIFF
--- a/pkg/minishift/network/settings.go
+++ b/pkg/minishift/network/settings.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"text/template"
@@ -306,5 +307,14 @@ func WriteNetworkSettingsToInstance(driver drivers.Driver, networkSettings Netwo
 		return false
 	}
 
+	return true
+}
+
+// CheckInternetConnectivity return false if user is not connected to internet
+func CheckInternetConnectivity(address string) bool {
+	_, err := net.Dial("tcp", address)
+	if err != nil {
+		return false
+	}
 	return true
 }


### PR DESCRIPTION
@gbraad Following is the error message now in case of no internet connection to host.

```
 $ ./minishift start --openshift-version v3.7.1
-- Starting profile 'minishift'
-- Checking if requested OpenShift version 'v3.7.1' is valid ... Offline ==>  This one
-- Checking if requested OpenShift version 'v3.7.1' is supported ... OK
-- Checking if requested hypervisor 'xhyve' is supported on this platform ... OK
-- Checking if xhyve driver is installed ... 
   Driver is available at /usr/local/bin/docker-machine-driver-xhyve
   Checking for setuid bit ... OK
```