### PR TITLE
Issue #2150 Disk validation fails in cmd-config.feature on MacOS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,8 +23,8 @@
     "colors",
     "gherkin"
   ]
-  revision = "4dc98b0e2b130c3c9d06868a050320e5b310d3e7"
-  version = "v0.7.4"
+  revision = "0371765570d36374bef4ab9f62ed0491f0862a3c"
+  version = "v0.7.6"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
@@ -735,6 +735,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "334a1635bce7c80047923c6d66f544a330eb0d371956ef56f0fd81b971c44732"
+  inputs-digest = "a8b3132400a2b7599e27f66940235f05a28ea77c00039884e03943a10597d38f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@ ignored = ["github.com/Sirupsen/logrus"]
 
 [[constraint]]
   name = "github.com/DATA-DOG/godog"
-  version = "=0.7.4"
+  version = "=0.7.6"
 
 [[constraint]]
   name = "github.com/asaskevich/govalidator"

--- a/test/integration/features/cmd-config.feature
+++ b/test/integration/features/cmd-config.feature
@@ -213,7 +213,7 @@ user defined options which changes default behaviour of Minishift.
 
   Scenario: Checking that disk-size value was applied
      When executing "minishift ssh -- sudo fdisk -l | grep Disk" succeeds
-     Then stdout should match "Disk \/dev\/sda: 2[4-6]\.?[0-9]{0,2} (GB|GiB)"
+     Then stdout should match "Disk \/dev\/.da: 2[4-6]\.?[0-9]{0,2} (GB|GiB)"
 
   Scenario: Checking that cpus value was applied
      When executing "minishift ssh -- cat /proc/cpuinfo" succeeds


### PR DESCRIPTION
Also updating Godog to latest release which fixes incomplete failure report when scenario outlines are used.