### PR TITLE
Issue #1628 Fix Internet connectivity check to honor proxy settings and use HTTP

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -168,6 +168,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	// we need to determine whether this is a restart prior to potentially creating a new VM
 	isRestart := cmdUtil.VMExists(libMachineClient, constants.MachineName)
 
+	proxyConfig := handleProxies()
+
 	// preflight check (before start)
 	preflightChecksBeforeStartingHost()
 
@@ -177,8 +179,6 @@ func runStart(cmd *cobra.Command, args []string) {
 	preflightChecksForArtifacts()
 
 	setSubscriptionManagerParameters()
-
-	proxyConfig := handleProxies()
 
 	fmt.Print("-- Starting local OpenShift cluster")
 

--- a/pkg/minishift/network/settings.go
+++ b/pkg/minishift/network/settings.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"text/template"
@@ -312,7 +312,7 @@ func WriteNetworkSettingsToInstance(driver drivers.Driver, networkSettings Netwo
 
 // CheckInternetConnectivity return false if user is not connected to internet
 func CheckInternetConnectivity(address string) bool {
-	_, err := net.Dial("tcp", address)
+	_, err := http.Get(address)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
`net.Dial("tcp", address)` did not use the proxy settings which led it to wrongly report a faulty Internet connection when in reality it just didn't know about the proxies.