### PR TITLE
Issue #2269 Add --no-proxy flag to oc-env

### DIFF
--- a/cmd/minishift/cmd/oc_env_test.go
+++ b/cmd/minishift/cmd/oc_env_test.go
@@ -21,11 +21,15 @@ package cmd
 import (
 	"testing"
 
+	"github.com/docker/machine/libmachine"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_unix_oc_path(t *testing.T) {
-	shellConfig, err := getOcShellConfig("/Users/john/.minishift/cache/oc/v1.5.0/oc", "bash")
+	api := libmachine.NewClient("foo", "foo")
+	defer api.Close()
+	shellConfig, err := getOcShellConfig(api, "/Users/john/.minishift/cache/oc/v1.5.0/oc", "bash", false)
+
 	assert.NoError(t, err)
 	expectedOcDirPath := "/Users/john/.minishift/cache/oc/v1.5.0"
 	assert.Equal(t, shellConfig.OcDirPath, expectedOcDirPath)

--- a/cmd/minishift/cmd/oc_env_test_windows.go
+++ b/cmd/minishift/cmd/oc_env_test_windows.go
@@ -19,11 +19,15 @@ package cmd
 import (
 	"testing"
 
+	"github.com/docker/machine/libmachine"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_windows_oc_path(t *testing.T) {
-	shellConfig, err := getOcShellConfig("C:\\Users\\john\\.minishift\\cache\\oc\\v1.5.0\\oc.exe", "")
+	api := libmachine.NewClient("foo", "foo")
+	defer api.Close()
+	shellConfig, err := getOcShellConfig(api, "C:\\Users\\john\\.minishift\\cache\\oc\\v1.5.0\\oc.exe", "", false)
+
 	assert.NoError(t, err)
 	expectedOcDirPath := "C:\\Users\\john\\.minishift\\cache\\oc\\v1.5.0"
 	assert.Equal(t, shellConfig.OcDirPath, expectedOcDirPath)

--- a/pkg/util/shell/shell.go
+++ b/pkg/util/shell/shell.go
@@ -29,9 +29,10 @@ var (
 )
 
 type ShellConfig struct {
-	Prefix    string
-	Delimiter string
-	Suffix    string
+	Prefix     string
+	Delimiter  string
+	Suffix     string
+	PathSuffix string
 }
 
 func GetShell(userShell string) (string, error) {
@@ -88,40 +89,32 @@ func GenerateUsageHint(userShell, cmdLine string) string {
 	return fmt.Sprintf("%s Run this command to configure your shell:\n%s %s\n", comment, comment, cmd)
 }
 
-func GetPrefixSuffixDelimiterForSet(userShell string, pathVar bool) (prefix, suffix, delimiter string) {
+func GetPrefixSuffixDelimiterForSet(userShell string) (prefix, delimiter, suffix, pathSuffix string) {
 	switch userShell {
 	case "fish":
 		prefix = "set -gx "
-		suffix = "\";\n"
 		delimiter = " \""
-		if pathVar {
-			suffix = "\" $PATH;\n"
-		}
+		suffix = "\";\n"
+		pathSuffix = "\" $PATH;\n"
 	case "powershell":
 		prefix = "$Env:"
-		suffix = "\"\n"
-		if pathVar {
-			suffix = ";" + prefix + "PATH" + suffix
-		}
 		delimiter = " = \""
+		suffix = "\"\n"
+		pathSuffix = ";" + prefix + "PATH" + suffix
 	case "cmd":
 		prefix = "SET "
-		suffix = "\n"
-		if pathVar {
-			suffix = ";%PATH%" + suffix
-		}
 		delimiter = "="
+		suffix = "\n"
+		pathSuffix = ";%PATH%" + suffix
 	case "emacs":
 		prefix = "(setenv \""
-		suffix = "\")\n"
 		delimiter = "\" \""
+		suffix = "\")\n"
 	default:
 		prefix = "export "
-		suffix = "\"\n"
-		if pathVar {
-			suffix = ":$PATH" + suffix
-		}
 		delimiter = "=\""
+		suffix = "\"\n"
+		pathSuffix = ":$PATH" + suffix
 	}
 
 	return

--- a/test/integration/features/cmd-oc-env.feature
+++ b/test/integration/features/cmd-oc-env.feature
@@ -7,7 +7,6 @@ one from: bash, cmd, powershell, tcsh, zsh with TEST_WITH_SPECIFIED_SHELL parame
   Scenario: User starts shell instance without oc in PATH
   INFO: This scenario starts interactive shell instance, which will be closed in the end of this feature.
     Given user starts shell instance on host machine
-     When executing "unset PATH" in host shell
      Then executing "oc status" in host shell fails
 
   Scenario: Starting minishift


### PR DESCRIPTION
The test is currently failing because I can't figure out how to get a `libmachine.API` to pass into it. Help appreciated.