### PR TITLE
Issue #2287 Fix the outdated link in the error message

### DIFF
--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -50,7 +50,7 @@ const (
 
 // preflightChecksBeforeStartingHost is executed before the startHost function.
 func preflightChecksBeforeStartingHost() {
-	driverErrorMessage := "See the 'Setting Up the Virtualization Environment' topic (https://docs.openshift.org/latest/minishift/getting-started/setting-up-virtualization-environment.html) for more information"
+	driverErrorMessage := "See the 'Setting Up the Virtualization Environment' topic (https://docs.openshift.org/latest/minishift/getting-started/setting-up-driver-plugin.html) for more information"
 	prerequisiteErrorMessage := "See the 'Installing Prerequisites for Minishift' topic (https://docs.openshift.org/latest/minishift/getting-started/installing.html#install-prerequisites) for more information"
 
 	proxy := os.Getenv("HTTPS_PROXY")


### PR DESCRIPTION
This commit fixes the link that shows up when the driver is not installed or rightly configured.

Signed-off-by: Farhaan Bukhsh <farhaan.bukhsh@gmail.com>