### PR TITLE
Issue #2318 Fix preflight check for extra-clusterup-flags

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -123,6 +123,10 @@ var (
 	SkipCheckOpenShiftRelease = createConfigSetting("skip-check-openshift-release", SetBool, nil, nil, true, nil)
 	WarnCheckOpenShiftRelease = createConfigSetting("warn-check-openshift-release", SetBool, nil, nil, true, false)
 
+	// Pre-flight checks for artifacts (before start)
+	SkipCheckClusterUpFlag = createConfigSetting("skip-check-clusterup-flags", SetBool, nil, nil, true, nil)
+	WarnCheckClusterUpFlag = createConfigSetting("warn-check-clusterup-flags", SetBool, nil, nil, true, nil)
+
 	// Pre-flight checks (after start)
 	SkipInstanceIP        = createConfigSetting("skip-check-instance-ip", SetBool, nil, nil, true, nil)
 	WarnInstanceIP        = createConfigSetting("warn-check-instance-ip", SetBool, nil, nil, true, false)


### PR DESCRIPTION
Fixes #2318 

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>

Here is the step to test this PR:

Without this PR
```
$ minishift start --extra-clusterup-flags "--service-catalog"
-- Starting profile 'minishift'
-- Checking if https://github.com is reachable (using proxy: "No") ... OK
-- Checking if requested OpenShift version 'v3.9.0' is valid ... OK
-- Checking if requested OpenShift version 'v3.9.0' is supported ... OK
-- Checking if requested hypervisor 'xhyve' is supported on this platform ... OK
-- Checking if xhyve driver is installed ...
   Driver is available at /usr/local/bin/docker-machine-driver-xhyve
   Checking for setuid bit ... OK
-- Checking the ISO URL ... OK
-- Checking if provided oc flags are supported ... Flag 'extra-clusterup-flags' is not supported for oc version v3.9.0. Use 'openshift-version' flag to select a different version of OpenShift.
FAIL
Provided oc flag not supported
```
With this PR, this error will not come. 