### PR TITLE
Issue #2267 adds a flag --skip-startup-checks

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -122,6 +122,7 @@ var (
 	WarnCheckOpenShiftVersion = createConfigSetting("warn-check-openshift-version", SetBool, nil, nil, true, false)
 	SkipCheckOpenShiftRelease = createConfigSetting("skip-check-openshift-release", SetBool, nil, nil, true, nil)
 	WarnCheckOpenShiftRelease = createConfigSetting("warn-check-openshift-release", SetBool, nil, nil, true, false)
+	SkipPreflightChecks       = createConfigSetting("skip-startup-checks", SetBool, nil, nil, true, false)
 
 	// Pre-flight checks for artifacts (before start)
 	SkipCheckClusterUpFlag = createConfigSetting("skip-check-clusterup-flags", SetBool, nil, nil, true, nil)

--- a/cmd/minishift/cmd/preflight_artifacts.go
+++ b/cmd/minishift/cmd/preflight_artifacts.go
@@ -28,6 +28,9 @@ import (
 
 // preflightChecksForArtifacts is executed once artifacts are cached.
 func preflightChecksForArtifacts() {
+	if shouldPreflightChecksBeSkipped() {
+		return
+	}
 	preflightCheckSucceedsOrFails(
 		configCmd.SkipCheckClusterUpFlag.Name,
 		checkOcFlag,

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -575,6 +575,7 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.String(configCmd.Memory.Name, constants.DefaultMemory, "Amount of RAM to allocate to the Minishift VM. Use the format <size><unit>, where unit = MB or GB.")
 	startFlagSet.String(configCmd.DiskSize.Name, constants.DefaultDiskSize, "Disk size to allocate to the Minishift VM. Use the format <size><unit>, where unit = MB or GB.")
 	startFlagSet.String(configCmd.HostOnlyCIDR.Name, "192.168.99.1/24", "The CIDR to be used for the minishift VM. (Only supported with VirtualBox driver.)")
+	startFlagSet.Bool(configCmd.SkipPreflightChecks.Name, false, "Skip the startup checks.")
 	startFlagSet.AddFlag(dockerEnvFlag)
 	startFlagSet.AddFlag(dockerEngineOptFlag)
 	startFlagSet.AddFlag(insecureRegistryFlag)
@@ -729,4 +730,9 @@ func cacheMinishiftISO(config *cluster.MachineConfig) {
 			atexit.ExitWithMessage(1, fmt.Sprintf("Error caching the ISO: %s", err.Error()))
 		}
 	}
+}
+
+// if skip-startup-checks set to true then return true and skip preflight checks
+func shouldPreflightChecksBeSkipped() bool {
+	return viper.GetBool(configCmd.SkipPreflightChecks.Name)
 }

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -49,6 +49,9 @@ const (
 
 // preflightChecksBeforeStartingHost is executed before the startHost function.
 func preflightChecksBeforeStartingHost() {
+	if shouldPreflightChecksBeSkipped() {
+		return
+	}
 	driverErrorMessage := "See the 'Setting Up the Virtualization Environment' topic (https://docs.openshift.org/latest/minishift/getting-started/setting-up-virtualization-environment.html) for more information"
 	prerequisiteErrorMessage := "See the 'Installing Prerequisites for Minishift' topic (https://docs.openshift.org/latest/minishift/getting-started/installing.html#install-prerequisites) for more information"
 
@@ -156,6 +159,9 @@ func preflightChecksBeforeStartingHost() {
 
 // preflightChecksAfterStartingHost is executed after the startHost function.
 func preflightChecksAfterStartingHost(driver drivers.Driver) {
+	if shouldPreflightChecksBeSkipped() {
+		return
+	}
 	preflightCheckSucceedsOrFailsWithDriver(
 		configCmd.SkipInstanceIP.Name,
 		checkInstanceIP, driver,

--- a/docs/source/troubleshooting/troubleshooting-getting-started.adoc
+++ b/docs/source/troubleshooting/troubleshooting-getting-started.adoc
@@ -53,6 +53,12 @@ You can also add this variable in your shell profile so you don't need to manual
 While {project} starts, it runs several startup checks to make sure that the {project} VM and the OpenShift Cluster are able to start without any issues.
 If any configuration is incorrect or missing, the startup checks fail and {project} does not start.
 
+- You can skip the startup checks by executing the following command:
++
+----
+$ minishift config set skip-startup-checks true
+----
+
 The following sections describe the different startup checks.
 
 [[driver-plugin-check]]


### PR DESCRIPTION
Fixes  issue #2267
Adds a flag --skip-startup-checks which is by default false
but when set to true it will skip the preflightchecks