### PR TITLE
Issue #2337 Add test step to delete the minishift home dir

### DIFF
--- a/test/integration/testsuite/minishift.go
+++ b/test/integration/testsuite/minishift.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/minishift/minishift/test/integration/util"
+
+	"os"
 )
 
 var commandOutputs []CommandOutput
@@ -335,4 +337,16 @@ func (m *Minishift) rolloutServicesSuccessfullyBeforeTimeout(servicesToCheck str
 	}
 
 	return nil
+}
+
+func (m *Minishift) deletingMinishiftHomeDirectorySucceeds(dir string) error {
+	return os.RemoveAll(dir)
+}
+
+func (m *Minishift) minishiftHomeDirectoryShouldntExist(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil
+	}
+
+	return fmt.Errorf("Directory %s exists", dir)
 }

--- a/test/integration/testsuite/testsuite.go
+++ b/test/integration/testsuite/testsuite.go
@@ -227,6 +227,9 @@ func FeatureContext(s *godog.Suite) {
 			return nil
 		})
 
+	s.Step(`^deleting minishift home directory "([^"]*)" succeeds$`, MinishiftInstance.deletingMinishiftHomeDirectorySucceeds)
+	s.Step(`^minishift home directory "([^"]*)" shouldn\'t exist$`, MinishiftInstance.minishiftHomeDirectoryShouldntExist)
+
 	s.BeforeSuite(func() {
 		testDir = setUp()
 		testResultDir = filepath.Join(testDir, "..", "test-results")


### PR DESCRIPTION
Fix #2337

Require for https://issues.jboss.org/browse/CDK-271. Also, potential use case for upstream as well.