### PR TITLE
Issue #2307 show github api rate limit error for origin check

### DIFF
--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -63,7 +63,7 @@ func preflightChecksBeforeStartingHost() {
 			checkOriginRelease,
 			fmt.Sprintf("Checking if requested OpenShift version '%s' is valid", viper.GetString(configCmd.OpenshiftVersion.Name)),
 			configCmd.WarnCheckOpenShiftRelease.Name,
-			fmt.Sprintf("%s is not a valid OpenShift version", viper.GetString(configCmd.OpenshiftVersion.Name)),
+			"",
 		)
 	} else {
 		fmt.Printf("FAIL\n")
@@ -593,7 +593,13 @@ func validateOpenshiftVersion() bool {
 func checkOriginRelease() bool {
 	client := github.Client()
 	_, _, err := client.Repositories.GetReleaseByTag("openshift", "origin", viper.GetString(configCmd.OpenshiftVersion.Name))
+	if err != nil && github.IsRateLimitError(err) {
+		fmt.Println("\n   Hit github rate limit:", err)
+		return false
+	}
+
 	if err != nil {
+		fmt.Printf("%s is not a valid OpenShift version", viper.GetString(configCmd.OpenshiftVersion.Name))
 		return false
 	}
 	return true


### PR DESCRIPTION
The error does not look nice.. FAIL is printed after the error msg, this is to be fixed in #2327 

```
[minishift]$ minishift start
-- Starting profile 'minishift'
-- Checking if https://github.com is reachable (using proxy: "No") ... OK
-- Checking if requested OpenShift version 'v3.9.0' is valid ... 
   Hit github rate limit: GET https://api.github.com/repos/openshift/origin/releases/tags/v3.9.0: 403 API rate limit exceeded for 125.16.100.118. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.); rate reset in 55m29.059306046s FAIL

```