### PR TITLE
Issue #2331 expand ~ to homedir in source path while adding sshfs hostfolder interactively

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,6 +412,11 @@
   version = "v2.1.1"
 
 [[projects]]
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+
+[[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -696,6 +701,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4eed4d8aa7914116ae7e84f28d65b356f6e87861c60f6bbfaf28bb9637d042af"
+  inputs-digest = "e8be8e80644c208558011b357d8d51528ed4fc7f1fbc5c4c0f16542e312ad14d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -179,3 +179,7 @@ ignored = ["github.com/Sirupsen/logrus"]
   name = "github.com/pkg/sftp"
   version = "1.0.0"
 
+[[constraint]]
+  name = "github.com/mitchellh/go-homedir"
+  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+

--- a/cmd/minishift/cmd/hostfolder/add.go
+++ b/cmd/minishift/cmd/hostfolder/add.go
@@ -27,6 +27,7 @@ import (
 	"github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
@@ -127,6 +128,11 @@ func addHostFolder(cmd *cobra.Command, args []string) {
 
 func addSSHFSInteractive(manager *hostFolderConfig.Manager, name string) error {
 	source := util.ReadInputFromStdin("Source path")
+	source, err := homedir.Expand(source)
+	if err != nil {
+		atexit.ExitWithMessage(1, err.Error())
+	}
+
 	if source == "" {
 		atexit.ExitWithMessage(1, noSource)
 	}


### PR DESCRIPTION
Fiexs: #2331 

Not sure if we want to show it expanded or keep it as `~` in the o/p of command `minishift hostfolder list`
