### PR TITLE
Issue #392 Implement ability to run minishift against an existing VM

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -225,6 +225,7 @@
     "commands/mcndirs",
     "drivers/errdriver",
     "drivers/fakedriver",
+    "drivers/generic",
     "drivers/hyperv",
     "drivers/none",
     "drivers/virtualbox",
@@ -701,6 +702,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e8be8e80644c208558011b357d8d51528ed4fc7f1fbc5c4c0f16542e312ad14d"
+  inputs-digest = "f899fbdd9a5e7232dc5570aec2da884bfbdd5ebb4247bf0906670ae1fbaaa0c2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -52,18 +52,21 @@ var settingsList []Setting
 
 var (
 	// minishift
-	ISOUrl           = createConfigSetting("iso-url", SetString, []setFn{validations.IsValidISOUrl}, []setFn{RequiresRestartMsg}, true, nil)
-	CPUs             = createConfigSetting("cpus", SetInt, []setFn{validations.IsPositive}, []setFn{RequiresRestartMsg}, true, nil)
-	Memory           = createConfigSetting("memory", SetString, []setFn{validations.IsValidMemorySize}, []setFn{RequiresRestartMsg}, true, nil)
-	DiskSize         = createConfigSetting("disk-size", SetString, []setFn{validations.IsValidDiskSize}, []setFn{RequiresRestartMsg}, true, nil)
-	VmDriver         = createConfigSetting("vm-driver", SetString, []setFn{validations.IsValidDriver}, []setFn{RequiresRestartMsg}, true, nil)
-	OpenshiftVersion = createConfigSetting("openshift-version", SetString, nil, nil, true, nil)
-	HostOnlyCIDR     = createConfigSetting("host-only-cidr", SetString, []setFn{validations.IsValidCIDR}, nil, true, nil)
-	DockerEnv        = createConfigSetting("docker-env", SetSlice, nil, nil, true, nil)
-	DockerEngineOpt  = createConfigSetting("docker-opt", SetSlice, nil, nil, true, nil)
-	InsecureRegistry = createConfigSetting("insecure-registry", SetSlice, nil, nil, true, nil)
-	RegistryMirror   = createConfigSetting("registry-mirror", SetSlice, nil, nil, true, nil)
-	AddonEnv         = createConfigSetting("addon-env", SetSlice, nil, nil, true, nil)
+	ISOUrl                = createConfigSetting("iso-url", SetString, []setFn{validations.IsValidISOUrl}, []setFn{RequiresRestartMsg}, true, nil)
+	CPUs                  = createConfigSetting("cpus", SetInt, []setFn{validations.IsPositive}, []setFn{RequiresRestartMsg}, true, nil)
+	Memory                = createConfigSetting("memory", SetString, []setFn{validations.IsValidMemorySize}, []setFn{RequiresRestartMsg}, true, nil)
+	DiskSize              = createConfigSetting("disk-size", SetString, []setFn{validations.IsValidDiskSize}, []setFn{RequiresRestartMsg}, true, nil)
+	VmDriver              = createConfigSetting("vm-driver", SetString, []setFn{validations.IsValidDriver}, []setFn{RequiresRestartMsg}, true, nil)
+	OpenshiftVersion      = createConfigSetting("openshift-version", SetString, nil, nil, true, nil)
+	HostOnlyCIDR          = createConfigSetting("host-only-cidr", SetString, []setFn{validations.IsValidCIDR}, nil, true, nil)
+	DockerEnv             = createConfigSetting("docker-env", SetSlice, nil, nil, true, nil)
+	DockerEngineOpt       = createConfigSetting("docker-opt", SetSlice, nil, nil, true, nil)
+	InsecureRegistry      = createConfigSetting("insecure-registry", SetSlice, nil, nil, true, nil)
+	RegistryMirror        = createConfigSetting("registry-mirror", SetSlice, nil, nil, true, nil)
+	AddonEnv              = createConfigSetting("addon-env", SetSlice, nil, nil, true, nil)
+	RemoteIPAddress       = createConfigSetting("remote-ipaddress", SetString, nil, nil, true, nil)
+	RemoteSSHUser         = createConfigSetting("remote-ssh-user", SetString, nil, nil, true, nil)
+	SSHKeyToConnectRemote = createConfigSetting("remote-ssh-key", SetString, nil, nil, true, nil)
 
 	// cluster up
 	SkipRegistryCheck = createConfigSetting("skip-registry-check", SetBool, nil, nil, true, nil)

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -151,3 +151,53 @@ To get the status of the DNS server:
 ----
 $ minishift dns status
 ----
+
+[[run-against-an-existing-machine]]
+== Run against an Existing Machine
+
+{project} can be run against an existing remote machine using `vm-driver` as `generic`.
+To use an existing machine with {project} , it needs to be configured as follows:
+
+[NOTE]
+====
+CentOS7/RHEL7/Fedora(>26) are the suggested Linux distributions for this feature.
+====
+
+Lets assume that 10.1.1.1 is the IP of remote machine which you want to run against {project}.
+
+Establish password-less SSH from the host to existing remote machine:
+
+----
+Host$ ssh-copy-id <user>@10.1.1.1  // Make sure user have sudo access without password or use root
+Host$ ssh <user>@10.1.1.1  // Make sure this login without password
+----
+
+Prerequisite steps for configuring the existing machine:
+
+----
+Remote_Machine$ yum install -y docker net-tools firewalld
+Remote_Machine$ systemctl start docker
+Remote_Machine$ systemctl enable docker
+Remote_Machine$ systemctl start firewalld
+Remote_Machine$ systemctl enable firewalld
+----
+
+You also need to allow `2376`, `8443` port on the machine from firewall to have communication from the host.
+
+----
+firewall-cmd --permanent --add-port 2376/tcp
+firewall-cmd --permanent --add-port 8443/tcp
+firewall-cmd --reload
+----
+
+Use the following to run {project} against a remote machine:
+
+----
+Host$ export MINISHIFT_ENABLE_EXPERIMENTAL=y
+Host$ minishift start --vm-driver generic --remote-ipaddress 10.1.1.1 --remote-ssh-user <username> --remote-ssh-key <private_ssh_key>
+----
+
+[NOTE]
+====
+The value of the `--remote-ssh-key` flag must be the location of a private SSH key on the host machine.
+====

--- a/pkg/minikube/cluster/cluster_common.go
+++ b/pkg/minikube/cluster/cluster_common.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/docker/machine/drivers/generic"
+	"github.com/docker/machine/drivers/virtualbox"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+)
+
+type genericDriverOptions struct {
+	remoteIP              string
+	remoteSSHUser         string
+	sshKeyToConnectRemote string
+}
+
+func (g genericDriverOptions) String(key string) string {
+	genericStringOptions := make(map[string]string)
+	genericStringOptions["generic-ssh-user"] = g.remoteSSHUser
+	genericStringOptions["generic-ip-address"] = g.remoteIP
+	genericStringOptions["generic-ssh-key"] = g.sshKeyToConnectRemote
+	return genericStringOptions[key]
+}
+
+func (g genericDriverOptions) StringSlice(key string) []string {
+	return nil
+}
+
+func (g genericDriverOptions) Int(key string) int {
+	genericIntOptions := make(map[string]int)
+	genericIntOptions["generic-engine-port"] = 2376
+	genericIntOptions["generic-ssh-port"] = 22
+	return genericIntOptions[key]
+}
+
+func (g genericDriverOptions) Bool(key string) bool {
+	return false
+}
+
+func createGenericDriverConfig(config MachineConfig) drivers.Driver {
+	d := generic.NewDriver(constants.MachineName, constants.Minipath)
+	remoteOptions := genericDriverOptions{
+		remoteIP:              config.RemoteIPAddress,
+		remoteSSHUser:         config.RemoteSSHUser,
+		sshKeyToConnectRemote: config.SSHKeyToConnectRemote,
+	}
+	d.SetConfigFromFlags(remoteOptions)
+	return d
+}
+
+func createVirtualboxHost(config MachineConfig) drivers.Driver {
+	d := virtualbox.NewDriver(constants.MachineName, constants.Minipath)
+	d.Boot2DockerURL = config.GetISOFileURI()
+	d.Memory = config.Memory
+	d.CPU = config.CPUs
+	d.DiskSize = int(config.DiskSize)
+	d.HostOnlyCIDR = config.HostOnlyCIDR
+	return d
+}

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -23,6 +23,7 @@ var SupportedVMDrivers = [...]string{
 	"vmwarefusion",
 	"xhyve",
 	"hyperkit",
+	"generic",
 }
 
 const DefaultVMDriver = "xhyve"

--- a/pkg/minikube/constants/constants_linux.go
+++ b/pkg/minikube/constants/constants_linux.go
@@ -21,6 +21,7 @@ package constants
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"kvm",
+	"generic",
 }
 
 const DefaultVMDriver = "kvm"

--- a/pkg/minikube/constants/constants_windows.go
+++ b/pkg/minikube/constants/constants_windows.go
@@ -21,6 +21,7 @@ package constants
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"hyperv",
+	"generic",
 }
 
 const DefaultVMDriver = "hyperv"

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -19,6 +19,7 @@ package machine
 import (
 	"os"
 
+	"github.com/docker/machine/drivers/generic"
 	"github.com/docker/machine/drivers/hyperv"
 	"github.com/docker/machine/drivers/virtualbox"
 	"github.com/docker/machine/drivers/vmwarefusion"
@@ -38,6 +39,8 @@ func StartDriver() {
 			plugin.RegisterDriver(vmwarefusion.NewDriver("", ""))
 		case "hyperv":
 			plugin.RegisterDriver(hyperv.NewDriver("", ""))
+		case "generic":
+			plugin.RegisterDriver(generic.NewDriver("", ""))
 		default:
 			glog.Exitf("Unsupported driver: %s\n", driverName)
 		}

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -135,7 +135,7 @@ func PostClusterUp(clusterUpConfig *ClusterUpConfig, sshCommander provision.SSHC
 
 // EnsureHostDirectoriesExist ensures that the specified directories exist on the VM and creates them if not.
 func EnsureHostDirectoriesExist(host *host.Host, dirs []string) error {
-	cmd := fmt.Sprintf("sudo install -d -o docker -g docker -m 755 %s", strings.Join(dirs, " "))
+	cmd := fmt.Sprintf("sudo install -d -o %s -g %s -m 755 %s", host.Driver.GetSSHUsername(), host.Driver.GetSSHUsername(), strings.Join(dirs, " "))
 	_, err := host.RunSSHCommand(cmd)
 	if err != nil {
 		return err

--- a/pkg/minishift/provisioner/minishift_detector.go
+++ b/pkg/minishift/provisioner/minishift_detector.go
@@ -48,6 +48,11 @@ func (detector *MinishiftProvisionerDetector) DetectProvisioner(driver drivers.D
 		provisioner := NewMinishiftProvisioner("minishift", driver)
 		provisioner.SetOsReleaseInfo(osReleaseInfo)
 		return provisioner, nil
+	} else if detector.isRHELVariantIso(osReleaseInfo) {
+		provisioner := NewMinishiftProvisioner("minishift", driver)
+		provisioner.SetOsReleaseInfo(osReleaseInfo)
+		return provisioner, nil
+
 	} else if detector.isBuildrootIso(osReleaseInfo) {
 		provisioner := NewBuildrootProvisioner("buildroot", driver)
 		provisioner.SetOsReleaseInfo(osReleaseInfo)
@@ -59,6 +64,13 @@ func (detector *MinishiftProvisionerDetector) DetectProvisioner(driver drivers.D
 
 func (detector *MinishiftProvisionerDetector) isMinishiftIso(osReleaseInfo *provision.OsRelease) bool {
 	if osReleaseInfo.Variant == "minishift" {
+		return true
+	}
+	return false
+}
+
+func (detector *MinishiftProvisionerDetector) isRHELVariantIso(osReleaseInfo *provision.OsRelease) bool {
+	if osReleaseInfo.ID == "centos" || osReleaseInfo.ID == "fedora" || osReleaseInfo.ID == "redhat" {
 		return true
 	}
 	return false

--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strings"
 	"text/template"
 
 	"github.com/docker/machine/libmachine/auth"
@@ -78,8 +77,7 @@ func (provisioner *MinishiftProvisioner) GetRedhatRelease() bool {
 	minishiftConfig.InstanceConfig.IsRHELBased = true
 	minishiftConfig.InstanceConfig.Write()
 
-	OsRelease, _ := provisioner.GetOsReleaseInfo()
-	if strings.Contains(OsRelease.Name, "Red Hat Enterprise") {
+	if provisioner.OsReleaseInfo.ID == "redhat" {
 		return true
 	}
 	return false
@@ -163,6 +161,8 @@ func (provisioner *MinishiftProvisioner) GenerateDockerOptions(dockerPort int) (
 	engineConfigTemplate := engineConfigTemplateCentOS
 	if provisioner.GetRedhatRelease() {
 		engineConfigTemplate = engineConfigTemplateRHEL
+	} else if provisioner.OsReleaseInfo.ID == "fedora" {
+		engineConfigTemplate = engineConfigTemplateFedora
 	}
 
 	t, err := template.New("engineConfig").Parse(engineConfigTemplate)

--- a/pkg/minishift/provisioner/minishift_provisioner_test.go
+++ b/pkg/minishift/provisioner/minishift_provisioner_test.go
@@ -56,6 +56,7 @@ func TestRhelImage(t *testing.T) {
 	info := &provision.OsRelease{
 		Name:      "Red Hat Enterprise Linux Server",
 		VersionID: "7.3",
+		ID:        "redhat",
 	}
 	p.SetOsReleaseInfo(info)
 	assert.True(t, p.GetRedhatRelease(), "Provisioner should detect RHEL")
@@ -67,6 +68,7 @@ func TestCentOSImage(t *testing.T) {
 	info := &provision.OsRelease{
 		Name:      "CentOS Linux",
 		VersionID: "7.3",
+		ID:        "centos",
 	}
 	p.SetOsReleaseInfo(info)
 	os, _ := p.GetOsReleaseInfo()
@@ -98,6 +100,7 @@ func TestMinishiftProvisionerGenerateDockerOptionsForRHEL(t *testing.T) {
 	info := &provision.OsRelease{
 		Name:      "Red Hat Enterprise Linux Server",
 		VersionID: "7.3",
+		ID:        "redhat",
 	}
 	p.SetOsReleaseInfo(info)
 
@@ -114,6 +117,7 @@ func TestMinishiftProvisionerGenerateDockerOptionsForCentOS(t *testing.T) {
 	info := &provision.OsRelease{
 		Name:      "CentOS Linux",
 		VersionID: "7.3",
+		ID:        "centos",
 	}
 	p.SetOsReleaseInfo(info)
 

--- a/pkg/minishift/provisioner/utils.go
+++ b/pkg/minishift/provisioner/utils.go
@@ -60,6 +60,24 @@ ExecStart=/usr/bin/dockerd-current -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///v
            {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
 `
+
+	engineConfigTemplateFedora = `[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd-current -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock \
+		  --add-runtime oci=/usr/libexec/docker/docker-runc-current \
+          --default-runtime=oci \
+          --authorization-plugin=rhel-push-plugin \
+          --containerd /run/containerd.sock \
+          --exec-opt native.cgroupdriver=systemd \
+          --userland-proxy-path=/usr/libexec/docker/docker-proxy-current \
+          --init-path=/usr/libexec/docker/docker-init-current \
+          --seccomp-profile=/etc/docker/seccomp.json \
+		  --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} \
+		  --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} \
+           {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
+`
+
 	engineConfigTemplateBuildRoot = `[Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com


### PR DESCRIPTION
@LalatenduMohanty this PR is still work I just rebased it and tested against a minishift profile which I started with `--no-provision`

```
$ minishift profile set foo
$ export MINISHIFT_ENABLE_EXPERIMENTAL=y
$ minishift start --no-provision
$ minishift ip
192.168.64.3

$ minishift profile set minishift
$ minishift start --vm-driver generic --remote-ip-address 192.168.64.3 --remote-ssh-username docker --ssh-key-to-connect-remote ~/.minishift/profiles/foo/machines/foo/id_rsa
```

1. How to test on a remote centos/rhel/fedora box.

- Assume you have a remote host which has IP as `10.1.1.1`

```
Host$ ssh-copy-id <user>@10.1.1.1  "Make sure user have sudo access without password or use root"
Host$ ssh <user>@10.1.1.1 
Remote_VM$ yum install -y docker net-tools
Remote_VM$ systemctl start docker
Remote_VM$ systemctl enable docker
Remote_VM$ Make sure port *2376* is not blocked by firewall

Host$ export MINISHIFT_ENABLE_EXPERIMENTAL=y
Host$ minishift start --vm-driver generic --remote-ip-address 10.1.1.1 --remote-ssh-username <user> --ssh-key-to-connect-remote <Private_key_path_which_used_for_ssh_copy_id>
```

2. If you already tried that patch and failed then make sure you follow below steps first before step-1
```
Host$ ssh <user>@10.1.1.1 
Remote_VM$ rm -fr /etc/systemd/system/docker.service.d/
Remote_VM$ systemctl daemon-reload
Remote_VM$ systemctl restart docker
```