### PR TITLE
[WIP] Issue #2383 add support for docker-machine-driver-vmware

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -376,6 +376,8 @@ func getDriverOptions(config MachineConfig) interface{} {
 		driver = createHyperkitHost(config)
 	case "generic":
 		driver = createGenericDriverConfig(config)
+	case "vmware":
+		driver = createVmwareHost(config)
 	default:
 		atexit.ExitWithMessage(1, fmt.Sprintf("Unsupported driver: %s", config.VMDriver))
 	}

--- a/pkg/minikube/cluster/cluster_common.go
+++ b/pkg/minikube/cluster/cluster_common.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cluster
 
 import (
+	"path/filepath"
+
 	"github.com/docker/machine/drivers/generic"
 	"github.com/docker/machine/drivers/virtualbox"
 	"github.com/docker/machine/libmachine/drivers"
@@ -71,4 +73,37 @@ func createVirtualboxHost(config MachineConfig) drivers.Driver {
 	d.DiskSize = int(config.DiskSize)
 	d.HostOnlyCIDR = config.HostOnlyCIDR
 	return d
+}
+
+type vmwareDriver struct {
+	*drivers.BaseDriver
+
+	Memory         int
+	DiskSize       int
+	CPU            int
+	ISO            string
+	Boot2DockerURL string
+
+	SSHPassword    string
+	ConfigDriveISO string
+	ConfigDriveURL string
+	NoShare        bool
+}
+
+func createVmwareHost(config MachineConfig) *vmwareDriver {
+	return &vmwareDriver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: constants.MachineName,
+			StorePath:   constants.Minipath,
+			SSHUser:     "docker",
+			SSHPort:     22,
+		},
+		Boot2DockerURL: config.GetISOFileURI(),
+		DiskSize:       config.DiskSize,
+		Memory:         config.Memory,
+		CPU:            config.CPUs,
+		ISO:            filepath.Join(constants.Minipath, "machines", constants.MachineName, "boot2docker.iso"),
+		NoShare:        true,
+		SSHPassword:    "tcuser",
+	}
 }

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -24,6 +24,7 @@ var SupportedVMDrivers = [...]string{
 	"xhyve",
 	"hyperkit",
 	"generic",
+	"vmware",
 }
 
 const DefaultVMDriver = "xhyve"

--- a/pkg/minikube/constants/constants_gendocs.go
+++ b/pkg/minikube/constants/constants_gendocs.go
@@ -24,6 +24,7 @@ var SupportedVMDrivers = [...]string{
 	"kvm",
 	"xhyve",
 	"hyperv",
+	"vmware",
 }
 
 const DefaultVMDriver = "kvm"

--- a/pkg/minikube/constants/constants_linux.go
+++ b/pkg/minikube/constants/constants_linux.go
@@ -22,6 +22,7 @@ var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"kvm",
 	"generic",
+	"vmware",
 }
 
 const DefaultVMDriver = "kvm"

--- a/pkg/minikube/constants/constants_windows.go
+++ b/pkg/minikube/constants/constants_windows.go
@@ -22,6 +22,7 @@ var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"hyperv",
 	"generic",
+	"vmware",
 }
 
 const DefaultVMDriver = "hyperv"


### PR DESCRIPTION
1. Build the driver plugin from: https://github.com/machine-drivers/docker-machine-driver-vmware -> put binary in path.
2. Install vmware workstation pro (trail version, obviously!)
3. Check if you can create a VM from the vmware GUI (to make sure no weired permission errors later)
4. `minishift start --vm-driver vmware --iso-url http://artifacts.ci.centos.org/minishift/minishift-centos-iso/master/78/minishift-centos7.iso` (need centos iso from master)

Additional steps for running in windows..
https://kb.vmware.com/s/article/2146361

Fixes: #2383 