### PR TITLE
Issue #1803 Ability to overwrite an image during export

### DIFF
--- a/cmd/minishift/cmd/image/export.go
+++ b/cmd/minishift/cmd/image/export.go
@@ -38,6 +38,7 @@ import (
 var (
 	logToFile bool
 	exportAll bool
+	overwrite bool
 
 	imageExportCmd = &cobra.Command{
 		Use:   "export [image ...]",
@@ -97,7 +98,7 @@ func exportImage(cmd *cobra.Command, args []string) {
 		ImageMissStrategy: image.Pull,
 	}
 
-	_, err = handler.ExportImages(imageCacheConfig)
+	_, err = handler.ExportImages(imageCacheConfig, overwrite)
 	if err != nil {
 		msg := fmt.Sprintf("Container image export failed:\n%v", err)
 		if logToFile {
@@ -144,5 +145,6 @@ func createLogFile() *os.File {
 func init() {
 	imageExportCmd.Flags().BoolVar(&exportAll, "all", false, "Exports all images currently available in the Docker daemon.")
 	imageExportCmd.Flags().BoolVar(&logToFile, "log-to-file", false, "Logs export progress to file instead of standard out.")
+	imageExportCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Forces an image exports when image is already available in the Docker daemon.")
 	ImageCmd.AddCommand(imageExportCmd)
 }

--- a/pkg/minishift/docker/image/image_handler.go
+++ b/pkg/minishift/docker/image/image_handler.go
@@ -45,7 +45,7 @@ type ImageHandler interface {
 
 	// ExportImages exports the images specified as part of the ImageCacheConfig from the VM to the host.
 	// The method returns the list of successfully exported images and an error if one occurred.
-	ExportImages(config *ImageCacheConfig) ([]string, error)
+	ExportImages(config *ImageCacheConfig, overwrite bool) ([]string, error)
 
 	// IsImageCached returns true if the specified image is cached, false otherwise.
 	IsImageCached(config *ImageCacheConfig, image string) bool


### PR DESCRIPTION
How to Test
---------------

```
$ cat Dockerfile 
FROM fedora:latest
MAINTAINER Praveen Kumar "kumarpraveen.nitdgp@gmail.com"

RUN echo "VERSION 0.0.1" >> /etc/os-release

$ docker build -t kumarpraveen/fedora-test:1.0.0 .
Sending build context to Docker daemon 2.048 kB
Step 1/3 : FROM fedora:latest
 ---> cc510acfcd70
Step 2/3 : MAINTAINER Praveen Kumar "kumarpraveen.nitdgp@gmail.com"
 ---> Using cache
 ---> 76e091b492f6
Step 3/3 : RUN echo "VERSION 0.0.1" >> /etc/os-release
 ---> Running in f5bc058b2777
 ---> 44c0270f56ba
Removing intermediate container f5bc058b2777
Successfully built 44c0270f56ba

$ docker push kumarpraveen/fedora-test:1.0.0
The push refers to a repository [docker.io/kumarpraveen/fedora-test]
e551e8575d32: Pushed 
891e1e4ef82a: Layer already exists 
1.0.0: digest: sha256:784299f381169095c668767aa1b1cfe800554e2e1e476c880726a91b05c85d57 size: 736

$ MINISHIFT_ENABLE_EXPERIMENTAL=y ./minishift start --no-provision

$ ./minishift image export kumarpraveen/fedora-test:1.0.0 
Exporting 'kumarpraveen/fedora-test:1.0.0'........... OK
$ ./minishift image list
kumarpraveen/fedora-test:1.0.0

$ python -mjson.tool ~/.minishift/cache/images/index.json 
{
    "manifests": [
        {
            "annotations": {
                "org.opencontainers.image.ref.name": "kumarpraveen/fedora-test:1.0.0"
            },
            "digest": "sha256:41e76a70da76dc810cf3614c7fe7e4430620369bfbc9fae1c5ff473be2971ec1",
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            },
            "size": 504
        }
    ],
    "schemaVersion": 2
}

$ cat Dockerfile 
FROM fedora:latest
MAINTAINER Praveen Kumar "kumarpraveen.nitdgp@gmail.com"

RUN echo "VERSION 0.0.2" >> /etc/os-release

$ docker build -t kumarpraveen/fedora-test:1.0.0 .
Sending build context to Docker daemon 2.048 kB
Step 1/3 : FROM fedora:latest
 ---> cc510acfcd70
Step 2/3 : MAINTAINER Praveen Kumar "kumarpraveen.nitdgp@gmail.com"
 ---> Using cache
 ---> 76e091b492f6
Step 3/3 : RUN echo "VERSION 0.0.1" >> /etc/os-release
 ---> Running in f5bc058b2777
 ---> 44c0270f56ba
Removing intermediate container f5bc058b2777
Successfully built 44c0270f56ba

$ docker push kumarpraveen/fedora-test:1.0.0
The push refers to a repository [docker.io/kumarpraveen/fedora-test]
e551e8575d32: Pushed 
891e1e4ef82a: Layer already exists 
1.0.0: digest: sha256:784299f381169095c668767aa1b1cfe800554e2e1e476c880726a91b05c85d57 size: 736

$ ./minishift image export kumarpraveen/fedora-test:1.0.0 --overwrite
Exporting 'kumarpraveen/fedora-test:1.0.0'............. OK

$ python -mjson.tool ~/.minishift/cache/images/index.json 
{
    "manifests": [
        {
            "annotations": {
                "org.opencontainers.image.ref.name": "kumarpraveen/fedora-test:1.0.0"
            },
            "digest": "sha256:9fa243098d333943374444029fa6bd1615a564d4505a5f642ce538d28a915b2c",
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            },
            "size": 504
        }
    ],
    "schemaVersion": 2
}

== Also delete the existing VM and start a fresh one ==
$ minishift delete
$ ./minishift start --no-provision
$ ./minishift image import --all
   Importing 'kumarpraveen/fedora-test:1.0.0' ..... OK
$ ./minishift ssh
$ docker run --rm -it  kumarpraveen/fedora-test:1.0.0 cat /etc/os-release
NAME=Fedora
VERSION="28 (Twenty Eight)"
ID=fedora
VERSION_ID=28
PLATFORM_ID="platform:f28"
PRETTY_NAME="Fedora 28 (Twenty Eight)"
ANSI_COLOR="0;34"
CPE_NAME="cpe:/o:fedoraproject:fedora:28"
HOME_URL="https://fedoraproject.org/"
SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=28
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=28
PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
VERSION 0.0.2  => it have updated one.
```