### PR TITLE
Issue #1960 Retreive value from a command execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+docs/?/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -28,13 +28,18 @@ The following example shows the contents of an add-on file, including the name a
 # Required-Vars: ACME_TOKEN                                                             // <3>
 # OpenShift-Version: >3.6.0                                                             // <4>
 
-oc adm policy add-scc-to-group anyuid system:authenticated                              // <5>
+mytoken := oc sa get-token oauth-client                                                 // <5>
+
+oc new-app -p OPENSHIFT_OAUTH_CLIENT_SECRET=#{mytoken}                                  // <6>
+oc adm policy add-scc-to-group anyuid system:authenticated                              // <7>
 ----
 <1> (Required) Name of the add-on.
 <2> (Required) Description of the add-on.
 <3> (Optional) Comma separated list of required interpolation variables. See xref:../using/addons.adoc#addon-variable-interpolation[Variable Interpolation]
 <4> (Optional) OpenShift version required to run a specific add-on. See xref:../using/addons.adoc#addon-openshift-version-semantics[OpenShift Version Semantic]
-<5> Actual add-on command. In this case, the command executes the *oc* binary.
+<5> Run an actual add-on command and store its output in a variable. See xref:../using/addons.adoc#internal-addon-variable[Internal Variable]
+<6> Actual add-on command. In this case, the command executes the *oc* binary using the `mytoken` variable value.
+<7> Actual add-on command. In this case, the command executes the *oc* binary.
 
 [NOTE]
 ====
@@ -220,6 +225,22 @@ Multiple default key/value pairs need to be comma separated.
 ====
 Variable values specified via the command line using the `--addon-env` or set via `minishift config set addon-env` have precedence over _Var-Defaults_.
 ====
+
+
+[[internal-addon-variable]]
+=== Internal Variables
+
+Add-on allows to define variables in an add-on.
+These variables can be used to store output of an xref:../using/addons.adoc#addon-commands[add-on command]
+
+For example, you can save a `oc` command output in a variable `mytoken` and use it in the subsequent add-on commands.
+
+example :
+----
+mytoken := oc sa get-token oauth-client
+oc new-app -p OPENSHIFT_OAUTH_CLIENT_SECRET=#{mytoken}
+----
+
 
 [[default-addons]]
 == Default Add-ons

--- a/pkg/minishift/addon/command/command.go
+++ b/pkg/minishift/addon/command/command.go
@@ -26,18 +26,19 @@ type Command interface {
 	String() string
 }
 
-type doExecute func(ec *ExecutionContext, ignoreError bool) error
+type doExecute func(ec *ExecutionContext, ignoreError bool, outputVariable string) error
 
 type defaultCommand struct {
 	Command
 
-	rawCommand  string
-	fn          doExecute
-	ignoreError bool
+	rawCommand     string
+	fn             doExecute
+	ignoreError    bool
+	outputVariable string
 }
 
 func (c *defaultCommand) Execute(ec *ExecutionContext) error {
-	err := c.fn(ec, c.ignoreError)
+	err := c.fn(ec, c.ignoreError, c.outputVariable)
 	if c.ignoreError {
 		return nil
 	}

--- a/pkg/minishift/addon/command/docker_command.go
+++ b/pkg/minishift/addon/command/docker_command.go
@@ -19,26 +19,32 @@ package command
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 type DockerCommand struct {
 	*defaultCommand
 }
 
-func NewDockerCommand(command string, ignoreError bool) *DockerCommand {
-	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError}
+func NewDockerCommand(command string, ignoreError bool, outputVariable string) *DockerCommand {
+	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError, outputVariable: outputVariable}
 	dockerCommand := &DockerCommand{defaultCommand}
 	defaultCommand.fn = dockerCommand.doExecute
 	return dockerCommand
 }
 
-func (c *DockerCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
+func (c *DockerCommand) doExecute(ec *ExecutionContext, ignoreError bool, outputVariable string) error {
 	commander := ec.GetDockerCommander()
 	cmd := ec.Interpolate(c.rawCommand)
 	fmt.Print(".")
-	_, err := commander.LocalExec(cmd)
+
+	output, err := commander.LocalExec(cmd)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Error executing command '%s':", err.Error()))
+	}
+
+	if outputVariable != "" {
+		ec.AddToContext(outputVariable, strings.TrimSpace(output))
 	}
 
 	return nil

--- a/pkg/minishift/addon/command/echo_command.go
+++ b/pkg/minishift/addon/command/echo_command.go
@@ -33,7 +33,7 @@ func NewEchoCommand(command string, ignoreError bool) *EchoCommand {
 	return echoCommand
 }
 
-func (c *EchoCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
+func (c *EchoCommand) doExecute(ec *ExecutionContext, ignoreError bool, outputVariable string) error {
 	var err error
 
 	// split off the actual 'echo' command. As we need to print rest of the string

--- a/pkg/minishift/addon/command/sleep_command.go
+++ b/pkg/minishift/addon/command/sleep_command.go
@@ -39,7 +39,7 @@ func NewSleepCommand(command string, ignoreError bool) *SleepCommand {
 	return sleepCommand
 }
 
-func (c *SleepCommand) doExecute(ec *ExecutionContext, ignoreError bool) error {
+func (c *SleepCommand) doExecute(ec *ExecutionContext, ignoreError bool, outputVariable string) error {
 	duration, err := c.getSleepTime()
 	if err != nil {
 		return err

--- a/pkg/minishift/addon/parser/command_handler.go
+++ b/pkg/minishift/addon/parser/command_handler.go
@@ -37,11 +37,11 @@ type CommandHandler interface {
 	// Create attempts to parse the given string into a Command instance of its type. In case
 	// s does not represent a command which can be handled by this Command instance, Create of the specified next
 	// Command is called. If there is no next Command, nil is returned.
-	Handle(next CommandHandler, s string, ignoreError bool) (command.Command, error)
+	Handle(next CommandHandler, s string, ignoreError bool, outputVariable string) (command.Command, error)
 
 	// Parse attempts to parse the given string into a Command instance of its type. nil is returned in case
 	// s does not represent a command which can be handled by this Command instance.
-	Parse(s string, ignoreError bool) command.Command
+	Parse(s string, ignoreError bool, outputVariable string) command.Command
 }
 
 type defaultCommandHandler struct {
@@ -54,12 +54,12 @@ func (dc *defaultCommandHandler) SetNext(next CommandHandler) {
 	dc.next = next
 }
 
-func (dc *defaultCommandHandler) Handle(c CommandHandler, s string, ignoreError bool) (command.Command, error) {
-	newCommand := c.Parse(s, ignoreError)
+func (dc *defaultCommandHandler) Handle(c CommandHandler, s string, ignoreError bool, outputVariable string) (command.Command, error) {
+	newCommand := c.Parse(s, ignoreError, outputVariable)
 	if newCommand != nil {
 		return newCommand, nil
 	} else if dc.next != nil {
-		return dc.next.Handle(dc.next, s, ignoreError)
+		return dc.next.Handle(dc.next, s, ignoreError, outputVariable)
 	} else {
 		return nil, errors.New(fmt.Sprintf("Unable to process command: '%s'", s))
 	}
@@ -69,9 +69,9 @@ type DockerCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *DockerCommandHandler) Parse(s string, ignoreError bool) command.Command {
+func (c *DockerCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
 	if strings.HasPrefix(s, dockerCommand) {
-		return command.NewDockerCommand(s, ignoreError)
+		return command.NewDockerCommand(s, ignoreError, outputVariable)
 	}
 	return nil
 }
@@ -80,9 +80,9 @@ type OcCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *OcCommandHandler) Parse(s string, ignoreError bool) command.Command {
+func (c *OcCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
 	if strings.HasPrefix(s, ocCommand) {
-		return command.NewOcCommand(s, ignoreError)
+		return command.NewOcCommand(s, ignoreError, outputVariable)
 	}
 	return nil
 }
@@ -91,9 +91,9 @@ type OpenShiftCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *OpenShiftCommandHandler) Parse(s string, ignoreError bool) command.Command {
+func (c *OpenShiftCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
 	if strings.HasPrefix(s, openShiftCommand) {
-		return command.NewOpenShiftCommand(s, ignoreError)
+		return command.NewOpenShiftCommand(s, ignoreError, outputVariable)
 	}
 	return nil
 }
@@ -102,7 +102,7 @@ type SleepCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *SleepCommandHandler) Parse(s string, ignoreError bool) command.Command {
+func (c *SleepCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
 	if strings.HasPrefix(s, sleepCommand) {
 		return command.NewSleepCommand(s, ignoreError)
 	}
@@ -113,9 +113,9 @@ type SSHCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *SSHCommandHandler) Parse(s string, ignoreError bool) command.Command {
+func (c *SSHCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
 	if strings.HasPrefix(s, sshCommand) {
-		return command.NewSshCommand(s, ignoreError)
+		return command.NewSshCommand(s, ignoreError, outputVariable)
 	}
 	return nil
 }
@@ -124,7 +124,7 @@ type EchoCommandHandler struct {
 	*defaultCommandHandler
 }
 
-func (c *EchoCommandHandler) Parse(s string, ignoreError bool) command.Command {
+func (c *EchoCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
 	if strings.HasPrefix(s, echoCommand) {
 		return command.NewEchoCommand(s, ignoreError)
 	}


### PR DESCRIPTION
How to test.

Create a test addon like below.

```
$ cat ~/.minishift/addons/test/test.addon
# Name: test
# Description: Test

out := oc whoami
echo Output of 'oc whoami'
echo #{out}
echo
out1 := docker images
echo Output of 'docker images'
echo #{out1}
echo
out2 := ssh cat /etc/os-release
echo Output of 'ssh cat /etc/os-release'
echo #{out2}

$ ./minishift addon apply test
-- Applying addon 'test':.
Output of 'oc whoami'
system:admin
.
Output of 'docker images'
REPOSITORY                                   TAG                 IMAGE ID            CREATED             SIZE
docker.io/openshift/origin-web-console       v3.9.0              86440d38b67c        3 days ago          495 MB
docker.io/openshift/origin-docker-registry   v3.9.0              ded70e3042e1        3 days ago          465 MB
docker.io/openshift/origin-haproxy-router    v3.9.0              a84ae9f600a4        3 days ago          1.28 GB
docker.io/openshift/origin-deployer          v3.9.0              9e6cf91743f8        3 days ago          1.26 GB
docker.io/openshift/origin                   v3.9.0              f6724f32458d        3 days ago          1.26 GB
docker.io/openshift/origin-pod               v3.9.0              57d7271f57d2        3 days ago          223 MB
.
Output of 'ssh cat /etc/os-release'
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

VARIANT="minishift"
VARIANT_VERSION="1.10.0"
BUILD_ID="48ff9c1-08062018065208-local"
```