### PR TITLE
Issue #2458 Add stop functionality for generic driver

### DIFF
--- a/cmd/minishift/cmd/delete.go
+++ b/cmd/minishift/cmd/delete.go
@@ -29,7 +29,6 @@ import (
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
-	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
 	pkgUtil "github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -76,7 +75,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 	}
 
 	if host.Driver.DriverName() == "generic" {
-		if err := ocClusterDown(host); err != nil {
+		if err := util.OcClusterDown(host); err != nil {
 			atexit.ExitWithMessage(1, err.Error())
 		}
 		if err := deleteExistingDirectory(host); err != nil {
@@ -136,15 +135,6 @@ func removeInstanceAndKubeConfig() {
 			atexit.ExitWithMessage(1, fmt.Sprintf("Error deleting '%s'", constants.KubeConfigPath))
 		}
 	}
-}
-
-// ocClusterDown down the cluster and if there is any issue during the minishift start before even
-// oc binary cached then it just ignore the error [PK]
-func ocClusterDown(hostVm *host.Host) error {
-	sshCommander := provision.GenericSSHCommander{Driver: hostVm.Driver}
-	cmd := fmt.Sprintf("%s/oc cluster down", minishiftConstants.OcPathInsideVM)
-	sshCommander.SSHCommand(cmd)
-	return nil
 }
 
 // deleteExistingDirectory delete the directory which minishift create in case of generic driver.

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -280,7 +280,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		if isRestart {
 			err = cmdUtil.SetOcContext(minishiftConfig.AllInstancesConfig.ActiveProfile)
 			if err != nil {
-				fmt.Println(fmt.Sprintf("Could not set oc CLI context for: '%s'", profileActions.GetActiveProfile()))
+				fmt.Println(fmt.Sprintf("Could not set oc CLI context for '%s' profile: %v", profileActions.GetActiveProfile(), err))
 			}
 		}
 	}
@@ -710,7 +710,7 @@ func ensureNotRunning(client *libmachine.Client, machineName string) {
 		atexit.ExitWithMessage(1, err.Error())
 	}
 
-	if cmdUtil.IsHostRunning(hostVm.Driver) {
+	if cmdUtil.IsHostRunning(hostVm.Driver) && hostVm.DriverName != "generic" {
 		atexit.ExitWithMessage(0, fmt.Sprintf("The '%s' VM is already running.", machineName))
 	}
 }

--- a/cmd/minishift/cmd/stop.go
+++ b/cmd/minishift/cmd/stop.go
@@ -55,13 +55,19 @@ func runStop(cmd *cobra.Command, args []string) {
 		atexit.ExitWithMessage(0, fmt.Sprintf("The '%s' VM is already stopped.", constants.MachineName))
 	}
 
-	fmt.Println("Stopping local OpenShift cluster...")
+	fmt.Println("Stopping the OpenShift cluster...")
 
-	// Unregister, allow to be skipped and force deletion is ignored
-	registrationUtil.UnregisterHost(api, true, false)
+	if hostVm.Driver.DriverName() == "generic" {
+		if err := util.OcClusterDown(hostVm); err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		}
+	} else {
+		// Unregister, allow to be skipped and force deletion is ignored
+		registrationUtil.UnregisterHost(api, true, false)
 
-	if err := cluster.StopHost(api); err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error stopping cluster: %s", err.Error()))
+		if err := cluster.StopHost(api); err != nil {
+			atexit.ExitWithMessage(1, fmt.Sprintf("Error stopping cluster: %s", err.Error()))
+		}
 	}
 	fmt.Println("Cluster stopped.")
 }

--- a/cmd/minishift/cmd/util/util.go
+++ b/cmd/minishift/cmd/util/util.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/provision"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
@@ -32,6 +34,7 @@ import (
 	cmdState "github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/out/bindata"
 	"github.com/minishift/minishift/pkg/minikube/constants"
+	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
 	"github.com/minishift/minishift/pkg/util/shell"
 )
 
@@ -148,4 +151,12 @@ func ValidateGenericDriverFlags(remoteIPAddress, remoteSSHUser, sshKeyToConnectR
 			"--%s string\n--%s string\n--%s string\n", configCmd.RemoteIPAddress.Name, configCmd.RemoteSSHUser.Name, configCmd.SSHKeyToConnectRemote.Name)
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error: %s", msg))
 	}
+}
+
+// OcClusterDown stop Openshift cluster using oc binary inside the remote machine
+func OcClusterDown(hostVm *host.Host) error {
+	sshCommander := provision.GenericSSHCommander{Driver: hostVm.Driver}
+	cmd := fmt.Sprintf("%s/oc cluster down", minishiftConstants.OcPathInsideVM)
+	_, err := sshCommander.SSHCommand(cmd)
+	return err
 }


### PR DESCRIPTION
@gbraad @amitkrout @agajdosi  following is what we can have as part of stop when using generic driver. In case of other drivers we halt the VM as part of stop but that something we shouldn't do for `generic` but stopping the local OpenShift cluster make sense.

```
$ ./minishift status
Minishift:  Running
Profile:    minishift
OpenShift:  Running (openshift v3.9.0+b8265d6-31)
DiskUsage:  ‘/mnt/?da1’: of df:
CacheUsage: 1.481 GB (used by oc binary, ISO or cached images)

$ ./minishift stop
Stopping local OpenShift cluster...

$ ./minishift status
Minishift:  Running
Profile:    minishift
OpenShift:  Stopped
DiskUsage:  ‘/mnt/?da1’: of df:
CacheUsage: 1.481 GB (used by oc binary, ISO or cached images)
```
