### PR TITLE
Issue #2478 Add / as mount point to get the diskUsage for generic driver

### DIFF
--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -44,6 +44,7 @@ import (
 
 const (
 	StorageDisk                  = "/mnt/?da1"
+	StorageDiskForGeneric        = "/"
 	GithubAddress                = "https://github.com"
 	hypervDefaultVirtualSwitchId = "c08cb7b8-9b3c-408e-8e30-5e16a3aeb444"
 )
@@ -511,7 +512,7 @@ func checkStorageMounted(driver drivers.Driver) bool {
 // checkStorageUsage checks if the persistent storage volume has enough storage
 // space available.
 func checkStorageUsage(driver drivers.Driver) bool {
-	_, usedPercentage := getDiskUsage(driver, StorageDisk)
+	_, usedPercentage, _ := getDiskUsage(driver, StorageDisk)
 	fmt.Printf("%s used ", usedPercentage)
 	usage, err := strconv.Atoi(stringUtils.GetOnlyNumbers(usedPercentage))
 	if err != nil {
@@ -528,20 +529,21 @@ func checkStorageUsage(driver drivers.Driver) bool {
 }
 
 // isMounted checks returns usage of mountpoint known to the VM instance
-func getDiskUsage(driver drivers.Driver, mountpoint string) (string, string) {
+func getDiskUsage(driver drivers.Driver, mountpoint string) (string, string, string) {
 	cmd := fmt.Sprintf(
-		"df -h %s | awk 'FNR > 1 {print $2,$5}'",
+		"df -h %s | awk 'FNR > 1 {print $2,$5,$6}'",
 		mountpoint)
 
 	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
 
 	if err != nil {
-		return "", "ERR"
+		return "", "ERR", ""
 	}
 	diskDetails := strings.Split(strings.Trim(out, "\n"), " ")
 	diskSize := diskDetails[0]
 	diskUsage := diskDetails[1]
-	return diskSize, diskUsage
+	diskMountPoint := diskDetails[2]
+	return diskSize, diskUsage, diskMountPoint
 }
 
 // isMounted checks if mountpoint is mounted to the VM instance

--- a/cmd/minishift/cmd/status.go
+++ b/cmd/minishift/cmd/status.go
@@ -18,11 +18,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/docker/go-units"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/docker/go-units"
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/provision"
@@ -88,8 +89,11 @@ func runStatus(cmd *cobra.Command, args []string) {
 			openshiftStatus = fmt.Sprintf("Running (%s)", strings.Split(openshiftVersion, "\n")[0])
 		}
 
-		diskSize, diskUse := getDiskUsage(host.Driver, StorageDisk)
-		diskUsage = fmt.Sprintf("%s of %s", diskUse, diskSize)
+		diskSize, diskUse, mountpoint := getDiskUsage(host.Driver, StorageDisk)
+		if host.Driver.DriverName() == "generic" {
+			diskSize, diskUse, mountpoint = getDiskUsage(host.Driver, StorageDiskForGeneric)
+		}
+		diskUsage = fmt.Sprintf("%s of %s (Mounted On: %s)", diskUse, diskSize, mountpoint)
 	}
 
 	cacheDir := filepath.Join(constants.GetMinishiftHomeDir(), "cache")


### PR DESCRIPTION
Below is what you get now.

```
$ ./minishift status
Minishift:  Running
Profile:    minishift
OpenShift:  Stopped
DiskUsage:  17% of 40G
CacheUsage: 1.804 GB (used by oc binary, ISO or cached images)
```