### PR TITLE
Issue #2501 Generic: Fix formatting of start command

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -188,7 +188,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	setSubscriptionManagerParameters()
 
-	fmt.Print("-- Starting local OpenShift cluster")
+	fmt.Print("-- Starting the OpenShift cluster")
 
 	hostVm := startHost(libMachineClient)
 	registrationUtil.RegisterHost(libMachineClient)
@@ -405,6 +405,8 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 		cacheMinishiftISO(machineConfig)
 
 		fmt.Print("-- Starting Minishift VM ...")
+	} else {
+		fmt.Print("-- Starting to provision the remote machine ...")
 	}
 	progressDots.Start()
 	start := func() (err error) {


### PR DESCRIPTION
Now it does look like below.

```
-- Starting profile 'minishift'
-- Checking if provided oc flags are supported ... OK
-- Starting local OpenShift cluster using 'generic' hypervisor ...
-- Starting Provision Remote Machine ............................ OK
-- OpenShift cluster will be configured with ...
   Version: v3.9.0
[...]
```