### PR TITLE
Issue #2464 Addon: Specify empty value for Var-Defaults

### DIFF
--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -226,6 +226,13 @@ Multiple default key/value pairs need to be comma separated.
 
 [NOTE]
 ====
+Empty value will be set if NULL, Null or null specified as value for a _Var-Defaults key.
+
+# Var-Defaults: PROJECT_USER=null
+====
+
+[NOTE]
+====
 Variable values specified via the command line using the `--addon-env` or set via `minishift config set addon-env` have precedence over _Var-Defaults_.
 ====
 

--- a/pkg/minishift/addon/addon_meta.go
+++ b/pkg/minishift/addon/addon_meta.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
 	"regexp"
+	"strings"
 )
 
 var requiredMetaTags = []string{NameMetaTagName, DescriptionMetaTagName}
@@ -95,6 +96,10 @@ func (meta *DefaultAddOnMeta) VarDefaults() ([]RequiredVar, error) {
 		defaults := make([]RequiredVar, 0, len(items))
 		for _, item := range items {
 			varDefault, _ := minishiftStrings.SplitAndTrim(item, "=")
+			// In case of value of varDefault is null/Null/NULL then value converted to empty string.
+			if strings.ToLower(varDefault[1]) == "null" {
+				varDefault[1] = ""
+			}
 			defaults = append(defaults, RequiredVar{Key: varDefault[0], Value: varDefault[1]})
 		}
 


### PR DESCRIPTION
How to test
--------------
```
$ cat ~/.minishift/addons/test/test.addon
# Name: test
# Description: Test.
# Required-Vars: FOO
# Var-Defaults: FOO=null

echo Out of 'FOO'
echo #{FOO}

$ ./minishift addon apply test
-- Applying addon 'test':
Out of 'FOO'

```
