### PR TITLE
Issue #2157 pass type specific options for hostfolder add

### DIFF
--- a/cmd/minishift/cmd/hostfolder/add.go
+++ b/cmd/minishift/cmd/hostfolder/add.go
@@ -174,8 +174,9 @@ func addSSHFSNonInteractive(manager *hostFolderConfig.Manager, name string) erro
 		Name: name,
 		Type: hostFolderConfig.SSHFS.String(),
 		Options: map[string]string{
-			config.Source:     source,
-			config.MountPoint: target,
+			config.Source:       source,
+			config.MountPoint:   target,
+			config.ExtraOptions: options,
 		},
 	}
 	hostFolder := hostFolderConfig.NewSSHFSHostFolder(config, minishiftConfig.AllInstancesConfig)
@@ -219,11 +220,12 @@ func addCIFSInteractive(manager *hostFolderConfig.Manager, name string) error {
 		Name: name,
 		Type: hostFolderConfig.CIFS.String(),
 		Options: map[string]string{
-			config.MountPoint: mountPoint,
-			config.UncPath:    minishiftStrings.ConvertSlashes(uncPath),
-			config.UserName:   username,
-			config.Password:   password,
-			config.Domain:     domain,
+			config.MountPoint:   mountPoint,
+			config.UncPath:      minishiftStrings.ConvertSlashes(uncPath),
+			config.UserName:     username,
+			config.Password:     password,
+			config.Domain:       domain,
+			config.ExtraOptions: options,
 		},
 	}
 	hostFolder := hostFolderConfig.NewCifsHostFolder(config)

--- a/docs/source/using/host-folders.adoc
+++ b/docs/source/using/host-folders.adoc
@@ -114,6 +114,15 @@ $ minishift hostfolder add -t sshfs --source /Users/john/myshare --target /mnt/s
 
 For the case of a SSHFS based host folder only the source and target of the host folder need to be specified.
 
+[TIP]
+====
+When adding hostfolders, one can give type specific options to be used while mounting by using the `--options` flag, for example:
+
+----
+$ minishift hostfolder add -t sshfs --source ~/myshare/ --target /mnt/sda1/myshare --options "-o compression=no" myshare
+----
+====
+
 [[instance-host-folders]]
 ==== Instance-Specific Host Folders
 

--- a/pkg/minishift/hostfolder/cifs_hostfolder.go
+++ b/pkg/minishift/hostfolder/cifs_hostfolder.go
@@ -63,11 +63,12 @@ func (h *CifsHostFolder) Mount(driver drivers.Driver) error {
 	}
 
 	cmd := fmt.Sprintf(
-		"sudo mount -t cifs %s %s -o username=%s,password=%s",
-		h.config.Options[config.UncPath],
+		"sudo mount -t cifs %s %s -o username=%s,password=%s,%s",
+		h.config.Option(config.UncPath),
 		h.config.MountPoint(),
-		h.config.Options[config.UserName],
-		password)
+		h.config.Option(config.UserName),
+		password,
+		h.config.Option(config.ExtraOptions))
 
 	if minishiftConfig.InstanceStateConfig.IsRHELBased {
 		cmd = fmt.Sprintf("%s,context=system_u:object_r:svirt_sandbox_file_t:s0", cmd)

--- a/pkg/minishift/hostfolder/config/hostfolder_config.go
+++ b/pkg/minishift/hostfolder/config/hostfolder_config.go
@@ -17,12 +17,13 @@ limitations under the License.
 package config
 
 const (
-	Source     = "source"
-	UncPath    = "uncpath"
-	MountPoint = "mountpoint"
-	UserName   = "username"
-	Password   = "password"
-	Domain     = "domain"
+	Source       = "source"
+	UncPath      = "uncpath"
+	MountPoint   = "mountpoint"
+	UserName     = "username"
+	Password     = "password"
+	Domain       = "domain"
+	ExtraOptions = "extra-options"
 )
 
 type HostFolderConfig struct {

--- a/pkg/minishift/hostfolder/hostfolder_manager.go
+++ b/pkg/minishift/hostfolder/hostfolder_manager.go
@@ -42,7 +42,7 @@ type Manager struct {
 	allInstancesConfig *minishiftConfig.GlobalConfigType
 }
 
-// NewAddOnManager creates a new add-on manager for the specified add-on directory.
+// NewManager creates a new add-on manager for the specified add-on directory.
 func NewManager(instanceConfig *minishiftConfig.InstanceConfigType, allInstancesConfig *minishiftConfig.GlobalConfigType) (*Manager, error) {
 	return &Manager{
 		instanceConfig:     instanceConfig,

--- a/pkg/minishift/hostfolder/sshfs_hostfolder.go
+++ b/pkg/minishift/hostfolder/sshfs_hostfolder.go
@@ -75,11 +75,12 @@ func (h *SSHFSHostFolder) Mount(driver drivers.Driver) error {
 	// Mount command seems to fail occasionally. Give it a couple of attempts
 	mount := func() (err error) {
 		cmd := fmt.Sprintf(
-			"sudo sshfs docker@%s:%s %s -o IdentityFile=%s -o 'StrictHostKeyChecking=no' -o reconnect -o allow_other -o idmap=none -p %d",
+			"sudo sshfs docker@%s:%s %s -o IdentityFile=%s -o 'StrictHostKeyChecking=no' -o reconnect -o allow_other -o idmap=none %s -p %d",
 			ip,
 			h.config.Option(config.Source),
 			h.config.MountPoint(),
 			keyFile,
+			h.config.Option(config.ExtraOptions),
 			SftpPort)
 
 		if glog.V(2) {


### PR DESCRIPTION
      -  implement `--options` flag for hostfolder add command

Need to test for CIFS and on Windows..