### PR TITLE
Issue #2506 Update error message for sshfs hostfolder mount

### DIFF
--- a/pkg/minishift/hostfolder/sshfs_hostfolder.go
+++ b/pkg/minishift/hostfolder/sshfs_hostfolder.go
@@ -95,7 +95,8 @@ func (h *SSHFSHostFolder) Mount(driver drivers.Driver) error {
 
 	err = util.Retry(3, mount)
 	if err != nil {
-		return fmt.Errorf("error occurred while mounting host folder: %s", err)
+		errMsg := fmt.Sprintf("\nNote: Make sure that your network and firewall settings on the host allows port %d to be opened\n\n", SftpPort)
+		return fmt.Errorf("%s%s", errMsg, err)
 	}
 
 	return nil


### PR DESCRIPTION
@gbraad @anjannath this is now error looks like, I am not sure if cifs also need it.

```
$ ./minishift hostfolder mount test

Note: Make sure that your network and firewall settings on the host allows port 2022 to be opened

error occured while mounting host folder: ssh command error:
command : sudo sshfs docker@192.168.42.1:/home/prkumar/Documents /mnt/sda1/test -o IdentityFile=/home/docker/.ssh/id_rsa -o 'StrictHostKeyChecking=no' -o reconnect -o allow_other -o idmap=none -p 2022
err     : exit status 1
output  : read: Connection reset by peer

```