### PR TITLE
Issue #1479 Addon: Add required openshift version and url in verbose list

### DIFF
--- a/cmd/minishift/cmd/addon/addons_list.go
+++ b/cmd/minishift/cmd/addon/addons_list.go
@@ -34,19 +34,23 @@ import (
 
 var verbose bool
 
-var verboseAddonListFormat = `Name       : {{.Name}}
-Description: {{.Description}}
-Enabled    : {{.Status}}
-Priority   : {{.Priority}}
+var verboseAddonListFormat = `Name              : {{.Name}}
+Description       : {{.Description}}
+Url               : {{.Url}}
+Openshift Version : {{.RequiredOpenshiftVerison}}
+Enabled           : {{.Status}}
+Priority          : {{.Priority}}
 
 `
 var verboseListTemplate *template.Template
 
 type DisplayAddOn struct {
-	Name        string
-	Description string
-	Status      string
-	Priority    int
+	Name                     string
+	Description              string
+	Status                   string
+	Priority                 int
+	Url                      string
+	RequiredOpenshiftVerison string
 }
 
 var addonsListCmd = &cobra.Command{
@@ -78,7 +82,9 @@ func printAddOnList(manager *manager.AddOnManager, writer io.Writer, template *t
 
 	for _, addon := range addOns {
 		description := strings.Join(addon.MetaData().Description(), fmt.Sprintf("\n%13s", " "))
-		addonInfo := DisplayAddOn{addon.MetaData().Name(), description, stringFromStatus(addon.IsEnabled()), addon.GetPriority()}
+		addonInfo := DisplayAddOn{addon.MetaData().Name(), description,
+			stringFromStatus(addon.IsEnabled()), addon.GetPriority(),
+			addon.MetaData().Url(), addon.MetaData().OpenShiftVersion()}
 		if verbose {
 			err := template.Execute(writer, addonInfo)
 			if err != nil {

--- a/pkg/minishift/addon/addon_meta.go
+++ b/pkg/minishift/addon/addon_meta.go
@@ -47,6 +47,7 @@ type AddOnMeta interface {
 	VarDefaults() ([]RequiredVar, error)
 	GetValue(key string) string
 	OpenShiftVersion() string
+	Url() string
 }
 
 type DefaultAddOnMeta struct {
@@ -78,6 +79,19 @@ func (meta *DefaultAddOnMeta) Name() string {
 
 func (meta *DefaultAddOnMeta) Description() []string {
 	return meta.headers[requiredMetaTags[1]].([]string)
+}
+
+func (meta *DefaultAddOnMeta) Url() string {
+	if meta.headers["url"] != nil {
+		return meta.headers["url"].(string)
+	}
+	if meta.headers["URL"] != nil {
+		return meta.headers["URL"].(string)
+	}
+	if meta.headers["Url"] != nil {
+		return meta.headers["Url"].(string)
+	}
+	return ""
 }
 
 func (meta *DefaultAddOnMeta) RequiredVars() ([]string, error) {


### PR DESCRIPTION
We don't force addon to have url and required openshift version to addon dsl like we have or name and description. So now if an addon contains those details it will be shown in verbose as follow.

```
$ ./minishift addon list --verbose
Name              : admin-user
Description       : Create admin user and assign the cluster-admin role to it.
Url               : 
Openshift Version : >3.9.0
Enabled           : disabled
Priority          : 0

Name              : anyuid
Description       : Changes the default security context constraints to allow pods to run as any user.
Url               : https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines
Openshift Version : 
Enabled           : disabled
Priority          : 0

Name              : che
Description       : Setup and Configure Eclipse Che Template and Image Streams
Url               : https://www.eclipse.org/che/docs/setup/openshift/index.html
Openshift Version : >=3.5.0
Enabled           : disabled
Priority          : 0

Name              : registry-route
Description       : Create an edge terminated route for the OpenShift registry
Url               : 
Openshift Version : 
Enabled           : disabled
Priority          : 0

Name              : test
Description       : Test
Url               : 
Openshift Version : 
Enabled           : disabled
Priority          : 0

Name              : xpaas
Description       : Imports xPaaS templates
Url               : https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_examples/files/examples/v3.7
Openshift Version : 
Enabled           : disabled
Priority          : 0
```