### PR TITLE
Issue #2469 Break up copy the oc binary and pulling the image

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -250,18 +250,13 @@ func runStart(cmd *cobra.Command, args []string) {
 		fmt.Println("-- OpenShift cluster will be configured with ...")
 		fmt.Println("   Version:", requestedOpenShiftVersion)
 
-		fmt.Printf("-- Copying oc binary from the OpenShift container image to VM ")
-		progressDots := progressdots.New()
-		progressDots.Start()
-		err = clusterup.CopyOcBinaryFromImageToVM(dockerCommander, minishiftConstants.GetOpenshiftImageName(requestedOpenShiftVersion), minishiftConstants.OcPathInsideVM)
+		err := cmdUtil.PullOpenshiftImageAndCopyOcBinary(dockerCommander, requestedOpenShiftVersion)
 		if err != nil {
-			atexit.ExitWithMessage(1, fmt.Sprintf("Error copying the oc binary to %s: %v", minishiftConstants.OcPathInsideVM, err))
+			atexit.ExitWithMessage(1, err.Error())
 		}
-		progressDots.Stop()
-		fmt.Println(" OK")
 
 		fmt.Printf("-- Starting OpenShift cluster ")
-		progressDots = progressdots.New()
+		progressDots := progressdots.New()
 		progressDots.Start()
 		out, err := clusterup.ClusterUp(clusterUpConfig, clusterUpParams)
 		if err != nil {

--- a/pkg/minishift/docker/docker.go
+++ b/pkg/minishift/docker/docker.go
@@ -35,6 +35,10 @@ type DockerCommander interface {
 	// and exited. See also https://docs.docker.com/engine/api/v1.21/
 	Status(container string) (string, error)
 
+	// Pull the specified container image. Returns output in case the run was successful.
+	// Any occurring error is also returned.
+	Pull(image string) (string, error)
+
 	// Runs the specified container. Returns true in case the run was successful, false otherwise.
 	// Any occurring error is also returned.
 	Run(options string, container string) (bool, error)
@@ -74,6 +78,10 @@ type DockerCommander interface {
 	// Exec runs 'docker exec' with the specified options, against the specified container, using the specified
 	// command and arguments. The output of the command is returned as well as any occurring error.
 	Exec(options string, container string, command string, args string) (string, error)
+
+	// IsImageExist provide a bool value if an image exist.
+	// Any occurring error is also returned.
+	IsImageExist(image string) (bool, error)
 
 	// LocalExec runs the specified command on the Docker host
 	LocalExec(cmd string) (string, error)
@@ -233,4 +241,24 @@ func (c VmDockerCommander) GetID(container string) (string, error) {
 	out, err := c.commander.SSHCommand(cmd)
 	out = strings.TrimSpace(out)
 	return out, err
+}
+
+func (c VmDockerCommander) Pull(image string) (string, error) {
+	cmd := fmt.Sprintf("docker pull %s", image)
+	c.logCommand(cmd)
+	out, err := c.commander.SSHCommand(cmd)
+	out = strings.TrimSpace(out)
+	return out, err
+}
+
+func (c VmDockerCommander) IsImageExist(image string) (bool, error) {
+	cmd := fmt.Sprintf("docker images -q %s", image)
+	var exist bool
+	c.logCommand(cmd)
+	out, err := c.commander.SSHCommand(cmd)
+	out = strings.TrimSpace(out)
+	if out != "" {
+		exist = true
+	}
+	return exist, err
 }


### PR DESCRIPTION
This is how now it looks.

```
$ ./minishift start
[...]
   Importing 'openshift/origin:v3.9.0' ............. OK
   Importing 'openshift/origin-docker-registry:v3.9.0' .. OK
   Importing 'openshift/origin-haproxy-router:v3.9.0' .. OK
-- OpenShift cluster will be configured with ...
   Version: v3.9.0
-- Pulling the Openshift Container Image. OK
-- Copying oc binary from the OpenShift container image to VM ... OK
-- Starting OpenShift cluster ................................

```