### PR TITLE
Issue #2520 Addon: Enable field should have true/false for verbose list

### DIFF
--- a/cmd/minishift/cmd/addon/addons_list.go
+++ b/cmd/minishift/cmd/addon/addons_list.go
@@ -93,7 +93,13 @@ func printAddOnList(manager *manager.AddOnManager, writer io.Writer, template *t
 
 func stringFromStatus(addonStatus bool) string {
 	if addonStatus {
+		if verbose {
+			return "true"
+		}
 		return "enabled"
+	}
+	if verbose {
+		return "false"
 	}
 	return "disabled"
 }


### PR DESCRIPTION
Now it looks like below.

```
$ ./minishift addon list --verbose
Name       : admin-user
Description: Create admin user and assign the cluster-admin role to it.
Enabled    : false
Priority   : 0

Name       : anyuid
Description: Changes the default security context constraints to allow pods to run as any user.
Enabled    : false
Priority   : 0

Name       : registry-route
Description: Create an edge terminated route for the OpenShift registry
Enabled    : false
Priority   : 0

Name       : test
Description: Create admin user and assign the cluster-admin role to it.
Enabled    : false
Priority   : 0

Name       : xpaas
Description: Imports xPaaS templates
Enabled    : false
Priority   : 0

```