### PR TITLE
Issue #1360 Improve help for log level for V logs

### DIFF
--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -398,7 +398,7 @@ type flushSyncWriter interface {
 func init() {
 	flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
 	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
-	flag.Var(&logging.verbosity, "v", "log level for V logs")
+	flag.Var(&logging.verbosity, "v", "log level for V logs. Level varies from 1 to 5 (default 1).")
 	flag.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
 	flag.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")


### PR DESCRIPTION
Fixes Issue #1360

Previously:

> $ minishift start -h
> ...
>   -v, --v Level                          log level for V logs

Now:

> $ minishift start -h
> ...
>  -v, --v Level                          log level for V logs. Level varies from 1 to 5 (default 1).