### PR TITLE
Issue #1360 Improve help for log level for V logs

### DIFF
--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -214,6 +214,8 @@ func init() {
 	}
 	viper.BindPFlags(RootCmd.PersistentFlags())
 	cobra.OnInitialize(initConfig)
+	verbosity := pflag.Lookup("v")
+	verbosity.Usage += ". Level varies from 1 to 5 (default 1)."
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Replaces PR #2571.

Fixes issue #1360.

Previously:

> $ minishift start -h
> ...
>   -v, --v Level                          log level for V logs

Now:

> $ minishift start -h
> ...
>  -v, --v Level                          log level for V logs. Level varies from 1 to 5 (default 1).

I'm new to `go`, so if there's a more idiomatic way of doing this, please don't be shy!  I'd rather do this the right way, than just get a fix on the board.