### PR TITLE
Issue #2548 Provisioner: Start docker daemon if not running by default

### DIFF
--- a/pkg/minishift/provisioner/minishift_provisioner.go
+++ b/pkg/minishift/provisioner/minishift_provisioner.go
@@ -91,6 +91,13 @@ func (provisioner *MinishiftProvisioner) Package(name string, action pkgaction.P
 func (provisioner *MinishiftProvisioner) dockerDaemonResponding() bool {
 	log.Debug("checking docker daemon")
 
+	// Start the docker daemon service if not running.
+	if out, err := provisioner.SSHCommand("sudo systemctl -f start docker"); err != nil {
+		log.Warnf("Error getting SSH command to check if the daemon is running: %s", err)
+		log.Debugf("'sudo systemctl docker start' output:\n%s", out)
+		return false
+	}
+
 	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is running: %s", err)
 		log.Debugf("'sudo docker version' output:\n%s", out)


### PR DESCRIPTION
How to test
=========

```
$ minishift start --no-provision
$ minishift ip
$ minishift ssh -- sudo systemctl stop docker
$ minishift start --profile test --vm-driver generic --remote-ipaddress <IP> --remote-ssh-user docker  --remote-ssh-key <ssh_key>
```