### PR TITLE
Issue #1517 Config: Create a global config

### DIFF
--- a/cmd/minishift/cmd/addon/util.go
+++ b/cmd/minishift/cmd/addon/util.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/provision"
-	"github.com/minishift/minishift/cmd/minishift/cmd/config"
 	"github.com/minishift/minishift/cmd/minishift/state"
+	"github.com/minishift/minishift/pkg/minikube/constants"
 	addOnConfig "github.com/minishift/minishift/pkg/minishift/addon/config"
 	"github.com/minishift/minishift/pkg/minishift/addon/manager"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
@@ -47,7 +47,7 @@ func GetAddOnManager() *manager.AddOnManager {
 // GetAddOnConfiguration reads the Minishift configuration in $MINISHIFT_HOME/config/config.json related to addons and returns
 // a map of addon names to AddOnConfig
 func GetAddOnConfiguration() map[string]*addOnConfig.AddOnConfig {
-	c, err := config.ReadConfig()
+	c, err := minishiftConfig.ReadViperConfig(constants.ConfigFile)
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Cannot read the Minishift configuration: %s", err.Error()))
 	}

--- a/cmd/minishift/cmd/config/config_test.go
+++ b/cmd/minishift/cmd/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,7 +97,7 @@ var configTestCases = []configTestCase{
 func TestReadConfig(t *testing.T) {
 	for _, tt := range configTestCases {
 		r := bytes.NewBufferString(tt.data)
-		config, err := decode(r)
+		config, err := config.Decode(r)
 		assert.NoError(t, err, "Error Decoding config")
 		assert.ObjectsAreEqualValues(tt.data, config)
 	}
@@ -105,7 +106,7 @@ func TestReadConfig(t *testing.T) {
 func TestWriteConfig(t *testing.T) {
 	var b bytes.Buffer
 	for _, tt := range configTestCases {
-		err := encode(&b, tt.config)
+		err := config.Encode(&b, tt.config)
 		assert.NoError(t, err, "Error Encoding config")
 		assert.Equal(t, b.String(), tt.data)
 		b.Reset()

--- a/cmd/minishift/cmd/config/get.go
+++ b/cmd/minishift/cmd/config/get.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -45,10 +47,15 @@ var configGetCmd = &cobra.Command{
 
 func init() {
 	ConfigCmd.AddCommand(configGetCmd)
+	configGetCmd.Flags().BoolVar(&global, "global", false, "Get the value of a configuration property in the global configuration file.")
 }
 
 func get(name string) (string, error) {
-	m, err := ReadConfig()
+	confFile := constants.ConfigFile
+	if global {
+		confFile = constants.GlobalConfigFile
+	}
+	m, err := config.ReadViperConfig(confFile)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/minishift/cmd/config/set.go
+++ b/cmd/minishift/cmd/config/set.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -39,6 +41,7 @@ These values can be overwritten by flags or environment variables at runtime.`,
 
 func init() {
 	ConfigCmd.AddCommand(configSetCmd)
+	configSetCmd.Flags().BoolVar(&global, "global", false, "Sets the value of a configuration property in the global configuration file.")
 }
 
 func set(name string, value string) error {
@@ -53,11 +56,15 @@ func set(name string, value string) error {
 	}
 
 	// Set the value
-	config, err := ReadConfig()
+	confFile := constants.ConfigFile
+	if global {
+		confFile = constants.GlobalConfigFile
+	}
+	conf, err := config.ReadViperConfig(confFile)
 	if err != nil {
 		return err
 	}
-	err = s.set(config, name, value)
+	err = s.set(conf, name, value)
 	if err != nil {
 		return err
 	}
@@ -69,5 +76,5 @@ func set(name string, value string) error {
 	}
 
 	// Write the value
-	return WriteConfig(config)
+	return config.WriteViperConfig(confFile, conf)
 }

--- a/cmd/minishift/cmd/config/unset.go
+++ b/cmd/minishift/cmd/config/unset.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
 	"github.com/spf13/cobra"
 )
@@ -41,6 +43,7 @@ var configUnsetCmd = &cobra.Command{
 
 func init() {
 	ConfigCmd.AddCommand(configUnsetCmd)
+	configUnsetCmd.Flags().BoolVar(&global, "global", false, "Unset the value of a configuration property in the global configuration file.")
 }
 
 func unset(name string) error {
@@ -48,7 +51,11 @@ func unset(name string) error {
 	if err != nil {
 		return err
 	}
-	m, err := ReadConfig()
+	confFile := constants.ConfigFile
+	if global {
+		confFile = constants.GlobalConfigFile
+	}
+	m, err := config.ReadViperConfig(confFile)
 	if err != nil {
 		return err
 	}
@@ -57,5 +64,5 @@ func unset(name string) error {
 	}
 	delete(m, name)
 	fmt.Printf("Property name '%s' successfully unset\n", name)
-	return WriteConfig(m)
+	return config.WriteViperConfig(confFile, m)
 }

--- a/cmd/minishift/cmd/config/util.go
+++ b/cmd/minishift/cmd/config/util.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
+	viperConfig "github.com/minishift/minishift/pkg/minishift/config"
 )
 
 // Runs all the validation or callback functions and collects errors
@@ -55,12 +56,12 @@ func findSetting(name string) (Setting, error) {
 
 // Set Functions
 
-func SetString(m MinishiftConfig, name string, val string) error {
+func SetString(m viperConfig.ViperConfig, name string, val string) error {
 	m[name] = val
 	return nil
 }
 
-func SetInt(m MinishiftConfig, name string, val string) error {
+func SetInt(m viperConfig.ViperConfig, name string, val string) error {
 	i, err := strconv.Atoi(val)
 	if err != nil {
 		return err
@@ -69,7 +70,7 @@ func SetInt(m MinishiftConfig, name string, val string) error {
 	return nil
 }
 
-func SetBool(m MinishiftConfig, name string, val string) error {
+func SetBool(m viperConfig.ViperConfig, name string, val string) error {
 	b, err := strconv.ParseBool(val)
 	if err != nil {
 		return err
@@ -78,7 +79,7 @@ func SetBool(m MinishiftConfig, name string, val string) error {
 	return nil
 }
 
-func SetSlice(m MinishiftConfig, name string, val string) error {
+func SetSlice(m viperConfig.ViperConfig, name string, val string) error {
 	var tmpSlice []string
 	if val != "" {
 		for _, v := range strings.Split(val, ",") {

--- a/cmd/minishift/cmd/config/util_test.go
+++ b/cmd/minishift/cmd/config/util_test.go
@@ -20,10 +20,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/stretchr/testify/assert"
 )
 
-var minikubeConfig = MinishiftConfig{
+var minikubeConfig = config.ViperConfig{
 	"vm-driver":            "kvm",
 	"cpus":                 12,
 	"show-libmachine-logs": true,

--- a/cmd/minishift/cmd/image/util.go
+++ b/cmd/minishift/cmd/image/util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
+	viperConfig "github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/minishift/docker/image"
 	pkgUtil "github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -129,7 +130,7 @@ func toStringSlice(interfaceSlice []interface{}) []string {
 	return slice
 }
 
-func GetConfiguredCachedImages(minishiftConfig config.MinishiftConfig) []string {
+func GetConfiguredCachedImages(minishiftConfig viperConfig.ViperConfig) []string {
 	var cacheImages []string
 	if minishiftConfig[config.CacheImages.Name] == nil {
 		cacheImages = []string{}

--- a/cmd/minishift/cmd/util/shared_flags.go
+++ b/cmd/minishift/cmd/util/shared_flags.go
@@ -17,9 +17,8 @@ limitations under the License.
 package util
 
 import (
-	"strings"
-
 	flag "github.com/spf13/pflag"
+	"strings"
 )
 
 const (

--- a/docs/source/using/basic-usage.adoc
+++ b/docs/source/using/basic-usage.adoc
@@ -177,9 +177,12 @@ This environment variable is currently experimental and semantics might change i
 === Persistent Configuration
 
 Using persistent configuration allows you to control {project} behavior without specifying actual command line flags, similar to the way you use environment variables.
+You can also define global configuration using--global flag. Global configuration is applicable to all profiles.
 
 {project} maintains a configuration file in *_$MINISHIFT_HOME/config/config.json_*.
-This file can be used to set commonly-used command line flags persistently.
+This file can be used to set commonly-used command line flags persistently for individual profiles.
+{The global configuration file is maintained at *_$MINISHIFT_HOME/config/global.json_*.
+
 
 [NOTE]
 ====
@@ -196,6 +199,13 @@ For example:
 ----
 # Set default memory 4096 MB
 $ minishift config set memory 4096
+----
+
+The easiest way to set a persistent configuration option across all profiles is with the xref:../command-ref/minishift_config_set.adoc#[`minishift config set --global`] sub-command.
+
+For example, you can set the default memory to 8192 MB for every profile as follows:
+----
+$ minishift config set --global memory 8192
 ----
 
 Flags which can be used multiple times per command invocation, like `docker-env` or `insecure-registry`, need to be comma-separated when used with the `config set` command.
@@ -218,6 +228,13 @@ $ minishift config view
 - memory: 4096
 ----
 
+To view all persistent configuration values in the global configuration file, you can use the xref:../command-ref/minishift_config_view.adoc#[`minishift config view --global`] sub-command:
+
+----
+$ minishift config view --global
+- memory: 8192
+----
+
 Alternatively, you can display a single value with the xref:../command-ref/minishift_config_get.adoc#[`minishift config get`] sub-command:
 
 ----
@@ -234,6 +251,16 @@ For example:
 ----
 $ minishift config unset memory
 ----
+
+[NOTE]
+====
+The precedence for user-defined values is as follows:
+
+. Command line flags.
+. Environment variable.
+. Instance-specific configuration.
+. Global configuration.
+====
 
 [[persistent-volumes]]
 == Persistent Volumes

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -47,6 +47,7 @@ var (
 
 	KubeConfigPath        = filepath.Join(Minipath, "machines", MachineName+"_kubeconfig")
 	ConfigFile            = MakeMiniPath("config", "config.json")
+	GlobalConfigFile      = filepath.Join(Minipath, "config", "global.json")
 	AllInstanceConfigPath = filepath.Join(Minipath, "config", "allinstances.json")
 
 	DefaultB2dIsoUrl      = "https://github.com/minishift/minishift-b2d-iso/releases/download/" + version.GetB2dIsoVersion() + "/" + "minishift-b2d.iso"

--- a/pkg/minishift/config/viper_config.go
+++ b/pkg/minishift/config/viper_config.go
@@ -1,0 +1,76 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"io"
+	"os"
+)
+
+type ViperConfig map[string]interface{}
+
+// ReadConfig reads the config from $MINISHIFT_HOME/config/config.json file
+func ReadViperConfig(configfile string) (ViperConfig, error) {
+	f, err := os.Open(configfile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]interface{}), nil
+		}
+		return nil, fmt.Errorf("Cannot open file '%s': %s", constants.ConfigFile, err)
+	}
+	var m ViperConfig
+	m, err = Decode(f)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot decode config '%s': %s", constants.ConfigFile, err)
+	}
+
+	return m, nil
+}
+
+// Writes a config to the $MINISHIFT_HOME/config/config.json file
+func WriteViperConfig(configfile string, m ViperConfig) error {
+	f, err := os.Create(configfile)
+	if err != nil {
+		return fmt.Errorf("Cannot create file '%s': %s", constants.ConfigFile, err)
+	}
+	defer f.Close()
+	err = Encode(f, m)
+	if err != nil {
+		return fmt.Errorf("Cannot encode config '%s': %s", constants.ConfigFile, err)
+	}
+	return nil
+}
+
+func Decode(r io.Reader) (ViperConfig, error) {
+	var data ViperConfig
+	err := json.NewDecoder(r).Decode(&data)
+	return data, err
+}
+
+func Encode(w io.Writer, m ViperConfig) error {
+	b, err := json.MarshalIndent(m, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(b)
+
+	return err
+}

--- a/pkg/minishift/network/dns/localdns.go
+++ b/pkg/minishift/network/dns/localdns.go
@@ -24,6 +24,7 @@ import (
 	"github.com/minishift/minishift/pkg/minishift/network"
 
 	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	"github.com/minishift/minishift/pkg/minikube/constants"
 	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
 
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -50,7 +51,7 @@ func checkSupportForDnsmasqServer() bool {
 // isContainerized allows to force containerized deployment
 // Should be using Instance config. See #1796
 func isContainerized() (bool, error) {
-	minishiftConfig, err := configCmd.ReadConfig()
+	minishiftConfig, err := minishiftConfig.ReadViperConfig(constants.ConfigFile)
 	if err != nil || minishiftConfig[configCmd.DnsmasqContainerized.Name] == nil {
 		return false, err
 	}

--- a/pkg/minishift/network/dns/localdns_docker.go
+++ b/pkg/minishift/network/dns/localdns_docker.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"github.com/docker/machine/libmachine/provision"
 
-	"github.com/minishift/minishift/cmd/minishift/cmd/config"
+	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/config"
 	"github.com/minishift/minishift/pkg/minishift/docker"
 )
 
@@ -79,12 +81,12 @@ func (s DockerDnsService) Restart() (bool, error) {
 }
 
 func (s DockerDnsService) getDnsmasqContainerImage() (string, error) {
-	minishiftConfig, err := config.ReadConfig()
+	minishiftConfig, err := config.ReadViperConfig(constants.ConfigFile)
 	if err != nil {
 		return "", err
 	}
 
-	dnsmasqContainerImage := minishiftConfig[config.DnsmasqContainerImage.Name]
+	dnsmasqContainerImage := minishiftConfig[configCmd.DnsmasqContainerImage.Name]
 	if dnsmasqContainerImage != nil {
 		return fmt.Sprintf("%v", dnsmasqContainerImage), nil
 	}

--- a/test/integration/features/cmd-config.feature
+++ b/test/integration/features/cmd-config.feature
@@ -195,10 +195,25 @@ user defined options which changes default behaviour of Minishift.
     | property          | value              | expected             |
     | memory            | 3500               | 3500                 |
     | disk-size         | 25g                | 25g                  |
-    | cpus              | 3                  | 3                    |
     | docker-env        | FOO=BAR,hello=hi   | [FOO=BAR hello=hi]   |
     | docker-opt        | dns=8.8.8.8        | [dns=8.8.8.8]        |
-    | insecure-registry | test-registry:5000 | [test-registry:5000] |
+
+
+  Scenario Outline: Globally Setting values, getting values and keeping them
+  Setting values, not unsetting them so they will be used on next Minishift start.
+  Not every key possible is being tested only those which are less complicated,
+  for example the http-proxy key is being tested in separate feature file.
+    When executing "minishift config set --global <property> "<value>"" succeeds
+    Then stdout of command "minishift config get --global <property>" is equal to "<expected>"
+
+    Examples: Values to be used on next Minishift start
+      | property          | value              | expected             |
+      | memory            | 4200               | 4200                 |
+      | disk-size         | 40g                | 40g                  |
+      | cpus              | 3                  | 3                    |
+      | docker-env        | HI=BYE,hello=hi    | [HI=BYE hello=hi]    |
+      | docker-opt        | dns=1.1.1.1        | [dns=1.1.1.1]        |
+      | insecure-registry | test-registry:5000 | [test-registry:5000] |
 
   Scenario: Minishift informs about starting with correct setup of memory, disk and CPU
   Note: Minishift rounds the values for the report to make it more readable.


### PR DESCRIPTION
How to test
=========

```
11:08 $ ./minishift config view
- memory                             : 8096
- skip-check-openshift-release       : true
- vm-driver                          : virtualbox

11:08 $ ./minishift config view --global
- memory                             : 4096
- skip-check-openshift-release       : true
- vm-driver                          : virtualbox

11:08 $ ./minishift config unset vm-driver
Property name 'vm-driver' successfully unset

11:09 $ ./minishift config view --global
- memory                             : 4096
- skip-check-openshift-release       : true
- vm-driver                          : virtualbox
 
11:09 $ ./minishift config view
- memory                             : 8096
- skip-check-openshift-release       : true

11:09 $ ./minishift start 
-- Starting profile 'minishift'
-- Check if deprecated options are used ... OK
-- Checking if https://github.com is reachable ... OK
-- Checking if requested OpenShift version 'v3.9.0' is valid ... SKIP
-- Checking if requested OpenShift version 'v3.9.0' is supported ... OK
-- Checking if requested hypervisor 'virtualbox' is supported on this platform ... OK
-- Checking if VirtualBox is installed ... OK
-- Checking the ISO URL ... OK
-- Checking if provided oc flags are supported ... OK
-- Starting the OpenShift cluster using 'virtualbox' hypervisor ... => Taken from global config
-- Minishift VM will be configured with ...
   Memory:    7 GB   => take from the instance specific config 
   vCPUs :    2
   Disk size: 20 GB
```

Global flag command structure.
```
$ minishift config set --global
$ minishift config view --global
$ minishift config unset --global
```

Precedence order

```
1. A user-defined flag.
2. Environment variable.
3. Instance-specific config
4. Global config
```

@jorgemoralespou Does this works for you?
