### PR TITLE
Issue #2624 Support 'latest' tag in openshift-version flag

### DIFF
--- a/cmd/minishift/cmd/openshift/list_versions.go
+++ b/cmd/minishift/cmd/openshift/list_versions.go
@@ -37,7 +37,7 @@ var getVersionsCmd = &cobra.Command{
 }
 
 func runVersionList(cmd *cobra.Command, args []string) {
-	err := openshiftVersions.PrintUpStreamVersions(os.Stdout, constants.MinimumSupportedOpenShiftVersion, version.GetOpenShiftVersion())
+	err := openshiftVersions.PrintUpstreamVersions(os.Stdout, constants.MinimumSupportedOpenShiftVersion, version.GetOpenShiftVersion())
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error while trying to get list of available Origin versions: %s", err.Error()))
 	}

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -177,13 +177,18 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	proxyConfig := handleProxies()
 
+	// Get proper OpenShift version
+	requestedOpenShiftVersion, err := cmdUtil.GetOpenShiftReleaseVersion()
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting OpenShift version: %v", err))
+	}
+
 	// preflight check (before start)
 	if viper.GetString(configCmd.VmDriver.Name) != genericDriver {
 		preflightChecksBeforeStartingHost()
 	}
 
 	// Cache OC binary before starting the VM and perform oc command option check
-	requestedOpenShiftVersion := viper.GetString(configCmd.OpenshiftVersion.Name)
 	ocPath = cmdUtil.CacheOc(requestedOpenShiftVersion)
 	preflightChecksForArtifacts()
 
@@ -220,7 +225,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	applyDockerEnvToProcessEnv(libMachineClient)
 
-	err := clusterup.EnsureHostDirectoriesExist(hostVm, getRequiredHostDirectories())
+	err = clusterup.EnsureHostDirectoriesExist(hostVm, getRequiredHostDirectories())
 	if err != nil {
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error creating required host directories: %v", err))
 	}
@@ -626,7 +631,7 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.String(configCmd.DiskSize.Name, constants.DefaultDiskSize, "Disk size to allocate to the Minishift VM. Use the format <size><unit>, where unit = MB or GB.")
 	startFlagSet.String(configCmd.HostOnlyCIDR.Name, "192.168.99.1/24", "The CIDR to be used for the minishift VM. (Only supported with VirtualBox driver.)")
 	startFlagSet.Bool(configCmd.SkipPreflightChecks.Name, false, "Skip the startup checks.")
-	startFlagSet.String(configCmd.OpenshiftVersion.Name, version.GetOpenShiftVersion(), fmt.Sprintf("The OpenShift version to run, eg. %s", version.GetOpenShiftVersion()))
+	startFlagSet.String(configCmd.OpenshiftVersion.Name, version.GetOpenShiftVersion(), fmt.Sprintf("The OpenShift version to run, eg. latest or %s", version.GetOpenShiftVersion()))
 
 	startFlagSet.String(configCmd.RemoteIPAddress.Name, "", "IP address of the remote machine to provision OpenShift on")
 	startFlagSet.String(configCmd.RemoteSSHUser.Name, "", "The username of the remote machine to provision OpenShift on")

--- a/pkg/minishift/openshift/openshift.go
+++ b/pkg/minishift/openshift/openshift.go
@@ -25,7 +25,7 @@ import (
 	instanceState "github.com/minishift/minishift/pkg/minishift/config"
 	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
 	"github.com/minishift/minishift/pkg/minishift/docker"
-	openshiftVersionCheck "github.com/minishift/minishift/pkg/minishift/openshift/version"
+	openshiftVersion "github.com/minishift/minishift/pkg/minishift/openshift/version"
 	"github.com/pborman/uuid"
 )
 
@@ -79,8 +79,8 @@ func RestartOpenShift(commander docker.DockerCommander) (bool, error) {
 		ok  bool
 		err error
 	)
-	openshiftVersion := getOpenshiftVersion()
-	valid, _ := openshiftVersionCheck.IsGreaterOrEqualToBaseVersion(openshiftVersion, constants.RefactoredOcVersion)
+	version := getOpenshiftVersion()
+	valid, _ := openshiftVersion.IsGreaterOrEqualToBaseVersion(version, constants.RefactoredOcVersion)
 	if valid {
 		containerID, err := commander.GetID(minishiftConstants.OpenshiftApiContainerName)
 		if err != nil {
@@ -161,8 +161,8 @@ func ViewConfig(target OpenShiftPatchTarget, commander docker.DockerCommander) (
 	if err != nil {
 		return "", err
 	}
-	openshiftVersion := getOpenshiftVersion()
-	valid, _ := openshiftVersionCheck.IsGreaterOrEqualToBaseVersion(openshiftVersion, constants.RefactoredOcVersion)
+	version := getOpenshiftVersion()
+	valid, _ := openshiftVersion.IsGreaterOrEqualToBaseVersion(version, constants.RefactoredOcVersion)
 	if !valid || target.target == "node" {
 		result, err = commander.Exec("-t", minishiftConstants.OpenshiftContainerName, "cat", path)
 		if err != nil {
@@ -256,8 +256,8 @@ func deleteBackup(target OpenShiftPatchTarget, id string, commander docker.Docke
 }
 
 func getLocalConfigFile(target string) string {
-	openshiftVersion := getOpenshiftVersion()
-	valid, _ := openshiftVersionCheck.IsGreaterOrEqualToBaseVersion(openshiftVersion, constants.RefactoredOcVersion)
+	version := getOpenshiftVersion()
+	valid, _ := openshiftVersion.IsGreaterOrEqualToBaseVersion(version, constants.RefactoredOcVersion)
 	switch target {
 	case "master":
 		if !valid {
@@ -274,8 +274,8 @@ func getLocalConfigFile(target string) string {
 }
 
 func getContainerConfigFile(target string) string {
-	openshiftVersion := getOpenshiftVersion()
-	valid, _ := openshiftVersionCheck.IsGreaterOrEqualToBaseVersion(openshiftVersion, constants.RefactoredOcVersion)
+	version := getOpenshiftVersion()
+	valid, _ := openshiftVersion.IsGreaterOrEqualToBaseVersion(version, constants.RefactoredOcVersion)
 	switch target {
 	case "master":
 		if !valid {

--- a/pkg/minishift/openshift/version/openshift_versions.go
+++ b/pkg/minishift/openshift/version/openshift_versions.go
@@ -74,10 +74,10 @@ func PrintDownStreamVersions(output io.Writer, minSupportedVersion string) error
 	return nil
 }
 
-// PrintUpStreamVersions prints the origin versions which satisfies the following conditions:
+// PrintUpstreamVersions prints the origin versions which satisfies the following conditions:
 // 	1. Major versions greater than or equal to the minimum supported and default version
 //	2. Pre-release versions greater than default version
-func PrintUpStreamVersions(output io.Writer, minSupportedVersion string, defaultVersion string) error {
+func PrintUpstreamVersions(output io.Writer, minSupportedVersion string, defaultVersion string) error {
 	tags, err := GetGithubReleases()
 	if err != nil {
 		return err

--- a/pkg/minishift/openshift/version/openshift_versions_test.go
+++ b/pkg/minishift/openshift/version/openshift_versions_test.go
@@ -128,3 +128,10 @@ func TestIsPrerelease(t *testing.T) {
 		assert.Equal(t, versionTest.expectedResult, actualResult)
 	}
 }
+
+func TestOpenShiftTagsByAscending(t *testing.T) {
+	var testTags = []string{"v3.7.0", "v3.10.0", "v3.7.2", "v3.9.0", "v3.7.1"}
+
+	sortTags, _ := OpenShiftTagsByAscending(testTags, "v3.7.0", "v3.9.0")
+	assert.Equal(t, sortTags[len(sortTags)-1], "v3.10.0")
+}

--- a/pkg/minishift/openshift/version/openshift_versions_test.go
+++ b/pkg/minishift/openshift/version/openshift_versions_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPrintUpStreamVersions(t *testing.T) {
+func TestPrintUpstreamVersions(t *testing.T) {
 	EnsureGitHubApiAccessTokenSet(t)
 	testDir, err := ioutil.TempDir("", "minishift-config-")
 	assert.NoError(t, err)
@@ -40,7 +40,7 @@ func TestPrintUpStreamVersions(t *testing.T) {
 
 	os.Stdout = f
 	defaultVersion := version.GetOpenShiftVersion()
-	err = PrintUpStreamVersions(f, constants.MinimumSupportedOpenShiftVersion, defaultVersion)
+	err = PrintUpstreamVersions(f, constants.MinimumSupportedOpenShiftVersion, defaultVersion)
 	assert.NoError(t, err)
 
 	_, err = f.Seek(0, 0)

--- a/test/integration/features/provision-various-versions.feature
+++ b/test/integration/features/provision-various-versions.feature
@@ -30,3 +30,11 @@ Feature: Provision all major OpenShift versions
   Examples:
     | serverVersion | ocVersion |
     | v3.9.0        | v3.9.0    |
+
+  Scenario: Provision latest OpenShift version
+    Given Minishift has state "Does Not Exist"
+      And image caching is disabled
+     When executing "minishift start --openshift-version latest" succeeds
+     Then Minishift should have state "Running"
+     When executing "minishift delete --force" succeeds
+     Then Minishift should have state "Does Not Exist"


### PR DESCRIPTION
Fix #2624 
```
$ minishift start --openshift-version latest
-- Starting profile 'minishift'
-- Check if deprecated options are used ... OK
-- Checking if https://github.com is reachable ... OK
-- Checking if requested OpenShift version 'v3.10.0-rc.0' is valid ... OK
-- Checking if requested OpenShift version 'v3.10.0-rc.0' is supported ... OK
-- Checking if requested hypervisor 'kvm' is supported on this platform ... OK
-- Checking if KVM driver is installed ... 
   Driver is available at /usr/local/bin/docker-machine-driver-kvm ... 
   Checking driver binary is executable ... OK
[...]
-- OpenShift cluster will be configured with ...
   Version: v3.10.0-rc.0
-- Pulling the Openshift Container Image ................ OK
-- Copying oc binary from the OpenShift container image to VM ... OK
-- Starting OpenShift cluster .........................................
[...]
```