### PR TITLE
Issue #2625 Removed HOMEBREW_GITHUB_API_TOKEN and GH_TOKEN to access api.github.com

### DIFF
--- a/pkg/util/github/github.go
+++ b/pkg/util/github/github.go
@@ -79,7 +79,7 @@ func Client() *github.Client {
 	return client
 }
 
-var tokenEnvVars = []string{"MINISHIFT_GITHUB_API_TOKEN", "HOMEBREW_GITHUB_API_TOKEN", "GH_TOKEN"}
+var tokenEnvVars = []string{"MINISHIFT_GITHUB_API_TOKEN", "GH_TOKEN"}
 
 func GetGitHubApiToken() string {
 	for _, envVar := range tokenEnvVars {


### PR DESCRIPTION
Fix #2625 