### PR TITLE
Issue #2611 Populate start flags to viper config

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -113,7 +113,7 @@ var (
 	WarnCheckOpenShiftVersion = createConfigSetting("warn-check-openshift-version", SetBool, nil, nil, true, false)
 	SkipCheckOpenShiftRelease = createConfigSetting("skip-check-openshift-release", SetBool, nil, nil, true, nil)
 	WarnCheckOpenShiftRelease = createConfigSetting("warn-check-openshift-release", SetBool, nil, nil, true, false)
-	SkipPreflightChecks       = createConfigSetting("skip-startup-checks", SetBool, nil, nil, true, false)
+	SkipPreflightChecks       = createConfigSetting("skip-startup-checks", SetBool, nil, nil, true, nil)
 
 	// Pre-flight checks for artifacts (before start)
 	SkipCheckClusterUpFlag = createConfigSetting("skip-check-clusterup-flags", SetBool, nil, nil, true, nil)

--- a/cmd/minishift/cmd/config/set.go
+++ b/cmd/minishift/cmd/config/set.go
@@ -32,7 +32,7 @@ These values can be overwritten by flags or environment variables at runtime.`,
 		if len(args) != 2 {
 			atexit.ExitWithMessage(1, "usage: minishift config set PROPERTY_NAME PROPERTY_VALUE")
 		}
-		err := set(args[0], args[1])
+		err := Set(args[0], args[1], true)
 		if err != nil {
 			atexit.ExitWithMessage(1, err.Error())
 		}
@@ -44,7 +44,7 @@ func init() {
 	configSetCmd.Flags().BoolVar(&global, "global", false, "Sets the value of a configuration property in the global configuration file.")
 }
 
-func set(name string, value string) error {
+func Set(name string, value string, runCallback bool) error {
 	s, err := findSetting(name)
 	if err != nil {
 		return err
@@ -69,10 +69,12 @@ func set(name string, value string) error {
 		return err
 	}
 
-	// Run any callbacks for this property
-	err = run(name, value, s.callbacks)
-	if err != nil {
-		return err
+	if runCallback {
+		// Run any callbacks for this property
+		err = run(name, value, s.callbacks)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Write the value

--- a/cmd/minishift/cmd/config/set_test.go
+++ b/cmd/minishift/cmd/config/set_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestNotFound(t *testing.T) {
-	err := set("nonexistant", "10")
+	err := Set("nonexistant", "10", true)
 	assert.Error(t, err, "Set did not return error for unknown property")
 }
 
@@ -63,6 +63,6 @@ func verifyValueUnset(t *testing.T, key string) {
 }
 
 func persistValue(t *testing.T, key string, value string) {
-	err := set(key, value)
+	err := Set(key, value, true)
 	assert.NoError(t, err, "Error setting value")
 }

--- a/test/integration/features/cmd-config.feature
+++ b/test/integration/features/cmd-config.feature
@@ -244,3 +244,25 @@ user defined options which changes default behaviour of Minishift.
   Scenario: Deleting Minishift instance
      When executing "minishift delete --force" succeeds
      Then Minishift should have state "Does Not Exist"
+
+  Scenario: Minishift should preserve start flags when started with non-defaults parameters.
+    Given Minishift has state "Does Not Exist"
+      And image caching is disabled
+     When executing "minishift start --memory 5000 --disk-size 30g --cpus 2 --docker-env FOO=BAR --docker-opt dns=8.8.8.8 --insecure-registry foo.bar:5000" succeeds
+
+  Scenario Outline: Check the config flag values
+     When Minishift should have state "Running"
+     Then stdout of command "minishift config get <property>" is equal to "<value>"
+
+      Examples: Correct value show in the config
+        | property          | value              |
+        | memory            | 5000               |
+        | disk-size         | 30g                |
+        | cpus              | 2                  |
+        | docker-env        | [FOO=BAR]          |
+        | docker-opt        | [dns=8.8.8.8]      |
+        | insecure-registry | [foo.bar:5000]     |
+
+  Scenario: Deleting Minishift instance
+    When executing "minishift delete --force" succeeds
+    Then Minishift should have state "Does Not Exist"


### PR DESCRIPTION
    - start => stop => start user don't need to remember start flags.

How to test
---------------
```
$ minishift start --vm-driver virtualbox --memory 4GB --cpu 5
$ minishift stop
$ minishift start => this will still be going to start with what user provided the first time
```