### PR TITLE
Issue #2635 Remove Hyper-V fixed IP from experimental, use config

### DIFF
--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -39,59 +39,6 @@ For example, the following command will pass the `--service-catalog` flag to `oc
 $ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--service-catalog"
 ----
 
-[[hyperv-static-ip]]
-== Assign IP Address to Hyper-V
-
-Since the Internal Virtual Switch for Hyper-V does not provide a DHCP offer option, an IP address needs to be provided in a different way.
-For Hyper-V a functionality is provided to assign an IP address on startup using the Data Exchange Service.
-
-[IMPORTANT]
-====
-This only works with the CentOS or RHEL ISO in combination with Hyper-V.
-The B2D image experiences a problem when the values are being sent to the {project} instance and consumed by the B2D iso.
-We are looking into the issue and hope to provide a solution in the future.
-====
-
-To make this work you need to create a link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[Virtual Switch using NAT].
-
-[NOTE]
-====
-WinNAT is limited to one NAT network per host.
-For more details about capabilities, and limitations, please see the link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[WinNAT capabilities and limitations blog].
-====
-
-The following command will attempt to assign an IP address for use on the Internal Virtual Switch 'MyInternal':
-
-----
-PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
-PS> minishift config set hyperv-virtual-switch "MyInternal"
-PS> minishift.exe start `
-  --iso-url centos `
-  --network-ipaddress 192.168.1.10 `
-  --network-gateway 192.168.1.1 `
-  --network-nameserver 8.8.8.8
-----
-
-If you want to use the 'DockerNAT' network, the following commands are needed to setup the correct NAT networking and assign an IP in the range expected:
-
-----
-PS> New-NetNat -Name SharedNAT -InternalIPInterfaceAddressPrefix 10.0.75.1/24
-PS> $env:MINISHIFT_ENABLE_EXPERIMENTAL="y"
-PS> minishift config set hyperv-virtual-switch "DockerNAT"
-PS> minishift.exe start `
-  --iso-url centos `
-  --network-ipaddress 10.0.75.128 `
-  --network-gateway 10.0.75.1 `
-  --network-nameserver 8.8.8.8
-----
-
-[NOTE]
-====
-Be sure to specify a valid gateway and nameserver.
-Failing to do so will result in connectivity issues.
-====
-
-
 [[set-fixed-ip]]
 == Set Fixed IP Address
 

--- a/docs/source/using/static-ip.adoc
+++ b/docs/source/using/static-ip.adoc
@@ -35,7 +35,7 @@ Functionality is provided to assign an IP address on startup using the Data Exch
 
 [IMPORTANT]
 ====
-This only works with the CentOS or RHEL xref:../using/basic-usage.adoc#choosing-iso-image[ISO] in combation with Hyper-V.
+This only works with the CentOS or RHEL xref:../using/basic-usage.adoc#choosing-iso-image[ISO] in combination with Hyper-V.
 The Boot2Docker ISO image experiences a problem when the values are being sent to the {project} instance and consumed by the Boot2Docker ISO.
 We are looking into the issue and hope to provide a solution in the future.
 ====
@@ -51,9 +51,8 @@ For more details about capabilities and limitations, please see the link:https:/
 The following command will attempt to assign an IP address for use on the Internal Virtual Switch 'MyInternal':
 
 ----
-PS> $env:HYPERV_VIRTUAL_SWITCH="MyInternal"
+PS> minishift.exe config set hyperv-virtual-switch "MyInternal"
 PS> minishift.exe start `
-  --iso-url centos `
   --network-ipaddress 192.168.1.10 `
   --network-gateway 192.168.1.1 `
   --network-nameserver 8.8.8.8
@@ -63,9 +62,8 @@ If you want to use the 'DockerNAT' network, the following commands are needed to
 
 ----
 PS> New-NetNat -Name SharedNAT -InternalIPInterfaceAddressPrefix 10.0.75.1/24
-PS> $env:HYPERV_VIRTUAL_SWITCH="DockerNAT"
+PS> minishift.exe config set hyperv-virtual-switch "DockerNAT"
 PS> minishift.exe start `
-  --iso-url centos `
   --network-ipaddress 10.0.75.128 `
   --network-gateway 10.0.75.1 `
   --network-nameserver 8.8.8.8


### PR DESCRIPTION
Note: `minishift.exe config set hyperv-virtual-switch` is used in the documentation here instead of **MINISHIFT_HYPERV_VIRTUAL_SWITCH**.