### PR TITLE
Issue #2666 create instance dirs of default profile for global config

### DIFF
--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -92,6 +92,8 @@ var RootCmd = &cobra.Command{
 		// If profile name is 'minishift' then ignore the vaild profile check.
 		if constants.ProfileName != constants.DefaultProfileName {
 			checkForValidProfileOrExit(cmd)
+			//create the default profile dirs for global config
+			createMinishiftDirs(state.NewMinishiftDirs(constants.GetProfileHomeDir(constants.DefaultProfileName)))
 		}
 
 		constants.MachineName = constants.ProfileName


### PR DESCRIPTION
Fixes: #2666 

- create instance dirs of default profile for global config irrespective of the profile in use, to store the global config

How to test : 

1. Make sure no previous minishift configuration should present on the system
2. Make sure no minishift sub command should run which creates the ```.minishift``` dir
3. Then ```minishift profile set Test``` successfully creates the ```Test``` profile