### PR TITLE
Issue #2666 Create directory for global config

### DIFF
--- a/cmd/minishift/state/instance_dirs.go
+++ b/cmd/minishift/state/instance_dirs.go
@@ -17,42 +17,46 @@ limitations under the License.
 package state
 
 import (
-	"github.com/minishift/minishift/pkg/minikube/constants"
 	"path/filepath"
+
+	"github.com/minishift/minishift/pkg/minikube/constants"
 )
 
 type MinishiftDirs struct {
-	Home       string
-	Config     string
-	Machines   string
-	Certs      string
-	Cache      string
-	IsoCache   string
-	OcCache    string
-	ImageCache string
-	Addons     string
-	Logs       string
-	Tmp        string
+	Home         string
+	Config       string
+	GlobalConfig string
+	Machines     string
+	Certs        string
+	Cache        string
+	IsoCache     string
+	OcCache      string
+	ImageCache   string
+	Addons       string
+	Logs         string
+	Tmp          string
 }
 
 var InstanceDirs *MinishiftDirs
 
 // Constructor for MinishiftDirs
 func NewMinishiftDirs(baseDir string) *MinishiftDirs {
+	minishiftHomeDir := constants.GetMinishiftHomeDir()
 	// We use a global cache, sharing the cache directory of the default 'minishift' instance
-	cacheDir := filepath.Join(constants.GetMinishiftHomeDir(), "cache")
+	cacheDir := filepath.Join(minishiftHomeDir, "cache")
 
 	return &MinishiftDirs{
-		Home:       baseDir,
-		Certs:      filepath.Join(baseDir, "certs"),
-		Machines:   filepath.Join(baseDir, "machines"),
-		Addons:     filepath.Join(baseDir, "addons"),
-		Logs:       filepath.Join(baseDir, "logs"),
-		Tmp:        filepath.Join(baseDir, "tmp"),
-		Config:     filepath.Join(baseDir, "config"),
-		Cache:      cacheDir,
-		IsoCache:   filepath.Join(cacheDir, "iso"),
-		OcCache:    filepath.Join(cacheDir, "oc"),
-		ImageCache: filepath.Join(cacheDir, "images"),
+		Home:         baseDir,
+		Certs:        filepath.Join(baseDir, "certs"),
+		Machines:     filepath.Join(baseDir, "machines"),
+		Addons:       filepath.Join(baseDir, "addons"),
+		Logs:         filepath.Join(baseDir, "logs"),
+		Tmp:          filepath.Join(baseDir, "tmp"),
+		Config:       filepath.Join(baseDir, "config"),
+		GlobalConfig: filepath.Join(minishiftHomeDir, "config"),
+		Cache:        cacheDir,
+		IsoCache:     filepath.Join(cacheDir, "iso"),
+		OcCache:      filepath.Join(cacheDir, "oc"),
+		ImageCache:   filepath.Join(cacheDir, "images"),
 	}
 }


### PR DESCRIPTION
Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>

The root cause of the issue is that when ~/.minishift/config is not present and user runs `minishift profile set  NON_DEFAULT_PROFILE_NAME` , `createMinishiftDirs(state.InstanceDirs)` only created the directory structure in `~./minishift/profiles`  and not the `~/.minishift/config` . Hence `ensureConfigFileExists(constants.GlobalConfigFile)` gives error as it expects that `~/.minishift/config` would be present.

```
$ tree ~/.minishift
/Users/lmohanty/.minishift
├── cache
│   ├── images
│   ├── iso
│   └── oc
└── profiles
    └── Test
        ├── addons
        ├── certs
        ├── config
        ├── logs
        ├── machines
        └── tmp
```