### PR TITLE
Issue #2683 use PersistentPreRun for version, completion cmd

### DIFF
--- a/cmd/minishift/cmd/completion.go
+++ b/cmd/minishift/cmd/completion.go
@@ -73,6 +73,9 @@ var completionCmd = &cobra.Command{
 	Use:   "completion SHELL",
 	Short: "Outputs minishift shell completion for the given shell (bash or zsh)",
 	Long:  longDescription,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		//noop
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			fmt.Println("Usage: minishift completion SHELL")

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -44,7 +44,6 @@ import (
 	profileActions "github.com/minishift/minishift/pkg/minishift/profile"
 	"github.com/minishift/minishift/pkg/util/filehelper"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
-	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
 	"github.com/minishift/minishift/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -62,10 +61,6 @@ const (
 	invalidProfileName    = "Profile names must consist of alphanumeric characters only."
 )
 
-var noPersistentPreRunForCmds = []string{
-	"version",
-	"completion",
-}
 var viperWhiteList = []string{
 	"v",
 	"alsologtostderr",
@@ -78,12 +73,6 @@ var RootCmd = &cobra.Command{
 	Short: "Minishift is a tool for application development in local OpenShift clusters.",
 	Long:  `Minishift is a command-line tool that provisions and manages single-node OpenShift clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Return from here for commands included in 'noPersistentPreRunForCmds' and "minishift" as its parent.
-		// This will result in no home dir when executing such commands.
-		if minishiftStrings.Contains(noPersistentPreRunForCmds, cmd.Name()) && cmd.Parent().Name() == minishiftConstants.BinaryName {
-			return
-		}
-
 		var (
 			err                    error
 			isAddonInstallRequired bool

--- a/cmd/minishift/cmd/version.go
+++ b/cmd/minishift/cmd/version.go
@@ -29,7 +29,7 @@ var versionCmd = &cobra.Command{
 	Short: "Gets the version of Minishift.",
 	Long:  `Gets the currently installed version of Minishift and prints it to standard output.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		RootCmd.PersistentPreRun(cmd, args)
+		//noop
 	},
 	Run: runPrintVersion,
 }


### PR DESCRIPTION
Fixes: #2683 

* Use `PersistentPreRun` for `version` and `completion` command to stop them from creating instance dirs