### PR TITLE
Issue #650 add add-on metadata to express dependencies

### DIFF
--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -104,6 +104,25 @@ If the metadata field *Minishift-Version* is not specified in the add-on header,
 *Minishift-Version* only supports versions in the form of <major>.<minor>.<patch>.
 ====
 
+[[addon-defining-addon-dependencies]]
+== Defining Add-on Dependencies
+
+Add-on dependencies can be defined using the _Depends-On_ metadata field.
+Multiple dependencies may be defined using a comma-separated list of add-on names.
+
+[[example-addon-dependency]]
+.Example: Defining add-on dependency in add-on definition file
+
+----
+# Name: example
+# Description: Shows the use of Depends-On tag
+# Depends-On: anyuid, admin-user
+
+# This add-on depends on anyuid and admin-user add-on
+
+echo Depends on anyuid, admin-user add-on, and requires them to be installed
+----
+
 [[addon-commands]]
 == Add-on Commands
 


### PR DESCRIPTION
Fixes: #650 
### How to test:
Define an add-on as follows in `test-addon/test-addon.addon`

```
# Name: test-addon
# Description: Demo add-on for checking dependency.
# Url: https://minishift.io
# Depends-On: test, anyuid, demo-addon

echo "Minishift"
```

```
$ minishift addons install ~/test-addon/
Add-on installation failed with the error: The add-on depends on: [test, demo-addon]. Please install these first.
```