### PR TITLE
Issue #2657 Move Che add-on tests to Minishift repository

### DIFF
--- a/test/integration/che/che-steps.go
+++ b/test/integration/che/che-steps.go
@@ -1,0 +1,54 @@
+// +build integration
+
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package che
+
+import (
+	"github.com/DATA-DOG/godog"
+)
+
+type CheRunner struct {
+	runner CheAPI
+}
+
+func FeatureContext(s *godog.Suite) {
+	cheAPI := CheAPI{
+		CheAPIEndpoint: "",
+	}
+
+	cheAPIRunner := &CheRunner{
+		runner: cheAPI,
+	}
+
+	s.Step(`^applying che addon with openshift token succeeds$`, applyingCheWithOpenshiftTokenSucceeds)
+
+	// steps for testing che addon
+	s.Step(`^user tries to get the che api endpoint$`, cheAPIRunner.weTryToGetTheCheApiEndpoint)
+	s.Step(`^che api endpoint should not be empty$`, cheAPIRunner.cheApiEndpointShouldNotBeEmpty)
+	s.Step(`^user tries to get the stacks information$`, cheAPIRunner.weTryToGetTheStacksInformation)
+	s.Step(`^the stacks should not be empty$`, cheAPIRunner.theStacksShouldNotBeEmpty)
+	s.Step(`^starting a workspace with stack "([^"]*)" succeeds$`, cheAPIRunner.startingWorkspaceWithStackSucceeds)
+	s.Step(`^workspace should have state "([^"]*)"$`, cheAPIRunner.workspaceShouldHaveState)
+	s.Step(`^importing the sample project "([^"]*)" succeeds$`, cheAPIRunner.importingTheSampleProjectSucceeds)
+	s.Step(`^workspace should have (\d+) project$`, cheAPIRunner.workspaceShouldHaveProject)
+	s.Step(`^user runs command on sample "([^"]*)"$`, cheAPIRunner.userRunsCommandOnSample)
+	s.Step(`^exit code should be (\d+)$`, cheAPIRunner.exitCodeShouldBe)
+	s.Step(`^stopping a workspace succeeds$`, cheAPIRunner.stoppingWorkspaceSucceeds)
+	s.Step(`^workspace is removed$`, cheAPIRunner.workspaceIsRemoved)
+	s.Step(`^workspace removal should be successful$`, cheAPIRunner.workspaceRemovalShouldBeSuccessful)
+}

--- a/test/integration/che/che.go
+++ b/test/integration/che/che.go
@@ -1,0 +1,188 @@
+// +build integration
+
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package che
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/minishift/minishift/test/integration/testsuite"
+)
+
+func applyingCheWithOpenshiftTokenSucceeds() error {
+	err := testsuite.MinishiftInstance.ExecutingOcCommand("whoami -t")
+	if err != nil {
+		return err
+	}
+
+	token := testsuite.GetLastCommandOutput().StdOut
+	err = testsuite.MinishiftInstance.ExecutingMinishiftCommand("addons apply --addon-env OPENSHIFT_TOKEN=" + token + " che")
+
+	return err
+}
+
+func (c *CheRunner) weTryToGetTheCheApiEndpoint() error {
+	err := testsuite.MinishiftInstance.ExecutingOcCommand("get routes -n mini-che --template='{{range .items}}{{.spec.host}}{{end}}'")
+	if err != nil {
+		return err
+	}
+
+	commandOutput := testsuite.GetLastCommandOutput()
+	if commandOutput.ExitCode != 0 || commandOutput.StdErr != "" {
+		return fmt.Errorf("Getting route to che service failed. Exit-code: %s, StdErr: %s", commandOutput.ExitCode, commandOutput.StdErr)
+	}
+
+	endpoint := strings.Replace(commandOutput.StdOut, "'", "", -1)
+	if endpoint == "" {
+		return fmt.Errorf("Route to che is empty.")
+	}
+
+	c.runner.CheAPIEndpoint = "http://" + endpoint + "/api"
+
+	return nil
+}
+
+func (c *CheRunner) cheApiEndpointShouldNotBeEmpty() error {
+	if c.runner.CheAPIEndpoint == "" {
+		return fmt.Errorf("Could not detect Eclipse Che Api Endpoint")
+	}
+
+	return nil
+}
+
+func (c *CheRunner) weTryToGetTheStacksInformation() error {
+	workspaces, err := c.runner.GetStackInformation()
+	if err != nil {
+		return err
+	}
+
+	samples, err := c.runner.GetSamplesInformation()
+	if err != nil {
+		return err
+	}
+
+	c.runner.GenerateDataForWorkspaces(workspaces, samples)
+
+	return nil
+}
+
+func (c *CheRunner) theStacksShouldNotBeEmpty() error {
+	if len(c.runner.GetStackConfigMap()) == 0 || len(c.runner.GetSamplesConfigMap()) == 0 {
+		return fmt.Errorf("Could not retrieve samples")
+	}
+
+	return nil
+}
+
+func (c *CheRunner) startingWorkspaceWithStackSucceeds(stackName string) error {
+	stackStartEnvironment, present := c.runner.GetStackConfigMap()[stackName]
+	if present == false {
+		return fmt.Errorf("Could not retrieve '%s' stack information.", stackName)
+	}
+
+	workspace, err := c.runner.StartWorkspace(stackStartEnvironment.Config.EnvironmentConfig, stackStartEnvironment.ID)
+	if err != nil {
+		return err
+	}
+
+	c.runner.SetWorkspaceID(workspace.ID)
+	c.runner.SetStackName(stackName)
+
+	agents, err := c.runner.GetHTTPAgents(workspace.ID)
+	if err != nil {
+		return err
+	}
+	c.runner.SetAgentsURL(agents)
+
+	return nil
+}
+
+func (c *CheRunner) workspaceShouldHaveState(expectedState string) error {
+	currentState, err := c.runner.GetWorkspaceStatusByID(c.runner.WorkspaceID)
+	if err != nil {
+		return err
+	}
+
+	if strings.Compare(strings.ToLower(currentState.WorkspaceStatus), strings.ToLower(expectedState)) != 0 {
+		return fmt.Errorf("Not in expected state. Current state is: %s. Expected state is: %s", currentState.WorkspaceStatus, expectedState)
+	}
+
+	return nil
+}
+
+func (c *CheRunner) importingTheSampleProjectSucceeds(projectURL string) error {
+	sample := c.runner.GetSamplesConfigMap()[projectURL]
+
+	return c.runner.AddSamplesToProject([]Sample{sample})
+}
+
+func (c *CheRunner) workspaceShouldHaveProject(numOfProjects int) error {
+	numOfProjects, err := c.runner.GetNumberOfProjects()
+	if err != nil {
+		return err
+	}
+
+	if numOfProjects == 0 {
+		return fmt.Errorf("No projects were added")
+	}
+
+	return nil
+}
+
+func (c *CheRunner) userRunsCommandOnSample(projectURL string) error {
+	stackConfigMap := c.runner.GetStackConfigMap()[c.runner.StackName]
+	sampleConfigMap := c.runner.GetSamplesConfigMap()[projectURL]
+	if len(sampleConfigMap.Commands) > 0 {
+		commandInfo := sampleConfigMap.Commands[0]
+		commandInfo.CommandLine = strings.Replace(commandInfo.CommandLine, "${current.project.path}", "/projects"+sampleConfigMap.Path, -1)
+		commandInfo.CommandLine = strings.Replace(commandInfo.CommandLine, "${GAE}", "/home/user/google_appengine", -1)
+		commandInfo.CommandLine = strings.Replace(commandInfo.CommandLine, "$TOMCAT_HOME", "/home/user/tomcat8", -1)
+		c.runner.PID, _ = c.runner.PostCommandToWorkspace(commandInfo)
+	} else if len(stackConfigMap.Command) > 0 {
+		commandInfo := stackConfigMap.Command[0]
+		commandInfo.CommandLine = strings.Replace(commandInfo.CommandLine, "${current.project.path}", "/projects"+sampleConfigMap.Path, -1)
+		commandInfo.CommandLine = strings.Replace(commandInfo.CommandLine, "${GAE}", "/home/user/google_appengine", -1)
+		commandInfo.CommandLine = strings.Replace(commandInfo.CommandLine, "$TOMCAT_HOME", "/home/user/tomcat8", -1)
+		c.runner.PID, _ = c.runner.PostCommandToWorkspace(commandInfo)
+	} else {
+		return fmt.Errorf("There are no sample commands give by the stack or the sample")
+	}
+
+	return nil
+}
+
+func (c *CheRunner) exitCodeShouldBe(code int) error {
+	if c.runner.PID != code {
+		return fmt.Errorf("return command was not 0")
+	}
+
+	return nil
+}
+
+func (c *CheRunner) stoppingWorkspaceSucceeds() error {
+	return c.runner.StopWorkspace(c.runner.WorkspaceID)
+}
+
+func (c *CheRunner) workspaceIsRemoved() error {
+	return c.runner.RemoveWorkspace(c.runner.WorkspaceID)
+}
+
+func (c *CheRunner) workspaceRemovalShouldBeSuccessful() error {
+	return c.runner.CheckWorkspaceDeletion(c.runner.WorkspaceID)
+}

--- a/test/integration/che/cheAPI.go
+++ b/test/integration/che/cheAPI.go
@@ -1,0 +1,565 @@
+// +build integration
+
+/*
+Copyright (C) 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package che
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+type Workspace struct {
+	ID      string              `json:"id"`
+	Config  WorkspaceConfig     `json:"workspaceConfig"`
+	Source  WorkspaceSourceType `json:"source"`
+	Tags    []string            `json:"tags"`
+	Command []Command           `json:"commands,omitempty"`
+	Name    string              `json:"name"`
+}
+
+type Workspace2 struct {
+	ID string `json:"id"`
+}
+
+type StackConfigInfo struct {
+	WorkspaceConfig interface{}
+	Project         interface{}
+}
+
+type Project struct {
+	Sample interface{}
+}
+
+type Sample struct {
+	Name        string           `json:"name"`
+	Source      SampleSourceType `json:"source"`
+	Commands    []Command        `json:"commands"`
+	Tags        []string         `json:"tags"`
+	Path        string           `json:"path"`
+	ProjectType string           `json:"projectType"`
+}
+
+type WorkspaceConfig struct {
+	EnvironmentConfig EnvironmentConfig   `json:"environments,omitempty"`
+	Name              string              `json:"name,omitempty"`
+	DefaultEnv        string              `json:"defaultEnv,omitempty"`
+	Description       interface{}         `json:"description,omitempty"`
+	Commands          []Command           `json:"commands,omitempty"`
+	Source            WorkspaceSourceType `json:"source,omitempty"`
+}
+
+type Command struct {
+	CommandLine string `json:"commandLine"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+}
+
+type WorkspaceSourceType struct {
+	Type   string `json:"type"`
+	Origin string `json:"origin"`
+}
+
+type SampleSourceType struct {
+	Type     string `json:"type"`
+	Location string `json:"location"`
+}
+
+type RuntimeStruct struct {
+	Runtime Machine `json:"runtime"`
+}
+
+type Machine struct {
+	Machines map[string]Servers `json:"machines"`
+}
+
+type Che5RuntimeStruct struct {
+	Runtime Che5Machine `json:"runtime"`
+}
+
+type Che5Machine struct {
+	Machines []Che5Runtime `json:"machines"`
+}
+
+type Che5Runtime struct {
+	Runtime Servers `json:"runtime"`
+}
+
+type Servers struct {
+	Servers map[string]ServerURL `json:"servers"`
+}
+
+type ServerURL struct {
+	URL string `json:"url"`
+	Ref string `json:"ref,omitempty"`
+}
+
+type Agent struct {
+	execAgentURL string
+	wsAgentURL   string
+}
+
+type ProcessStruct struct {
+	Pid         int    `json:"pid"`
+	Name        string `json:"name"`
+	CommandLine string `json:"commandLine"`
+	Type        string `json:"type"`
+	Alive       bool   `json:"alive"`
+	NativePid   int    `json:"nativePid"`
+	ExitCode    int    `json:"exitCode"`
+}
+
+type LogArray []struct {
+	Kind int       `json:"kind"`
+	Time time.Time `json:"time"`
+	Text string    `json:"text"`
+}
+
+type LogItem struct {
+	Kind int       `json:"kind"`
+	Time time.Time `json:"time"`
+	Text string    `json:"text"`
+}
+
+type Post struct {
+	Environments interface{}   `json:"environments"`
+	Namespace    string        `json:"namespace"`
+	Name         string        `json:"name"`
+	DefaultEnv   string        `json:"defaultEnv"`
+	Projects     []interface{} `json:"projects"`
+}
+
+type Commands struct {
+	Name        string `json:"name"`
+	CommandLine string `json:"commandLine"`
+	Type        string `json:"type"`
+}
+
+type EnvironmentConfig struct {
+	Default map[string]interface{} `json:"default"`
+}
+
+type WorkspaceStatus struct {
+	WorkspaceStatus string `json:"status"`
+}
+
+type CheAPI struct {
+	CheAPIEndpoint string
+	WorkspaceID    string
+	ExecAgentURL   string
+	WSAgentURL     string
+	PID            int
+	StackName      string
+}
+
+var samples = "https://raw.githubusercontent.com/eclipse/che/master/ide/che-core-ide-templates/src/main/resources/samples.json"
+var stackConfigMap map[string]Workspace
+var sampleConfigMap map[string]Sample
+
+//doRequest does an new request with type requestType on url with data
+func doRequest(requestType, url, data string) ([]byte, int, error) {
+	client := http.Client{
+		Timeout: time.Second * 60,
+	}
+
+	req, err := http.NewRequest(requestType, url, bytes.NewBufferString(data))
+	req.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		return []byte{}, -1, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, res.StatusCode, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, res.StatusCode, err
+	}
+
+	return body, res.StatusCode, nil
+
+}
+
+//GetExecLogs takes in the Process ID of the process you would like to get the logs for
+func (c *CheAPI) GetExecLogs(Pid int) (LogArray, error) {
+	execLogsJSON, _, err := doRequest(http.MethodGet, c.ExecAgentURL+"/"+strconv.Itoa(Pid)+"/logs", "")
+	if err != nil {
+		return LogArray{}, err
+	}
+
+	var execLogData LogArray
+	err = json.Unmarshal(execLogsJSON, &execLogData)
+
+	return execLogData, err
+}
+
+//isLongLivedProcess takes in the Process ID of the process you would like to check if its long running
+func (c *CheAPI) isLongLivedProcess(Pid int) (bool, error) {
+	lastLogData, err := c.GetLastLog(Pid)
+	if err != nil {
+		return false, err
+	}
+
+	commandExitCode, err := c.GetCommandExitCode(Pid)
+	if err != nil {
+		return false, err
+	}
+
+	equalsLastLogCount := 0
+	time.Sleep(15 * time.Second)
+
+	for equalsLastLogCount != 3 && commandExitCode.ExitCode == -1 {
+		newLastLogData, err := c.GetLastLog(Pid)
+		if err != nil {
+			return false, err
+		}
+
+		if newLastLogData.Kind == lastLogData.Kind && newLastLogData.Text == lastLogData.Text && newLastLogData.Time == lastLogData.Time {
+			equalsLastLogCount++
+		} else {
+			equalsLastLogCount = 0
+		}
+
+		lastLogData = newLastLogData
+
+		time.Sleep(15 * time.Second)
+	}
+
+	if equalsLastLogCount == 3 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+//GetLastLog takes in the Process ID of the process you would like to get the logs for
+func (c *CheAPI) GetLastLog(Pid int) (LogItem, error) {
+	execLogData, err := c.GetExecLogs(Pid)
+	if err != nil {
+		return LogItem{}, err
+	}
+
+	if len(execLogData) > 1 {
+		return execLogData[len(execLogData)-1], nil
+	}
+
+	return LogItem{}, nil
+}
+
+//GetCommandExitCode takes in the Process ID of the process you would like to get the Process data for
+func (c *CheAPI) GetCommandExitCode(Pid int) (ProcessStruct, error) {
+	commandExitCodeJSON, _, err := doRequest(http.MethodGet, c.ExecAgentURL+"/"+strconv.Itoa(Pid), "")
+	if err != nil {
+		return ProcessStruct{}, err
+	}
+
+	var processInfo ProcessStruct
+	err = json.Unmarshal(commandExitCodeJSON, &processInfo)
+
+	return processInfo, err
+}
+
+//PostCommandToWorkspace creates and runs sampleCommand using the Exec Agent
+func (c *CheAPI) PostCommandToWorkspace(sampleCommand Command) (int, error) {
+	sampleCommandMarshalled, err := json.MarshalIndent(sampleCommand, "", "    ")
+	if err != nil {
+		return -1, err
+	}
+
+	processJSON, _, err := doRequest(http.MethodPost, c.ExecAgentURL, string(sampleCommandMarshalled))
+	if err != nil {
+		return -1, err
+	}
+
+	var processData ProcessStruct
+	err = json.Unmarshal(processJSON, &processData)
+	if err != nil {
+		return -1, err
+	}
+
+	longLived, err := c.isLongLivedProcess(processData.Pid)
+	if err != nil {
+		return -1, err
+	}
+
+	if longLived {
+		return 0, nil
+	}
+
+	exitCode, _ := c.GetCommandExitCode(processData.Pid)
+	return exitCode.ExitCode, nil
+
+}
+
+//AddSamplesToProject adds an array of samples to the workspace using WS Agent
+func (c *CheAPI) AddSamplesToProject(sample []Sample) error {
+	marshalled, err := json.MarshalIndent(sample, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	_, _, err = doRequest(http.MethodPost, c.WSAgentURL+"/project/batch", string(marshalled))
+
+	return err
+}
+
+//GetNumberOfProjects gets the number of projects in a workspace
+func (c *CheAPI) GetNumberOfProjects() (int, error) {
+	projectData, _, err := doRequest(http.MethodGet, c.WSAgentURL+"/project", "")
+	if err != nil {
+		return -1, err
+	}
+
+	var data []Sample
+	err = json.Unmarshal(projectData, &data)
+	if err != nil {
+		return -1, err
+	}
+
+	return len(data), nil
+}
+
+//BlockWorkspace blocks the given workspaceID until it has started
+func (c *CheAPI) BlockWorkspace(workspaceID, untilStatus string) error {
+	for {
+		workspaceStatus, err := c.GetWorkspaceStatusByID(workspaceID)
+		if err != nil {
+			return err
+		}
+
+		if workspaceStatus.WorkspaceStatus == untilStatus {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	return nil
+}
+
+//GetHTTPAgents gets the Exec Agent and WSAgent from a Che5 or Che6 workspace
+func (c *CheAPI) GetHTTPAgents(workspaceID string) (Agent, error) {
+	//Now we need to get the workspace installers and then unmarshall
+	runtimeData, _, err := doRequest(http.MethodGet, c.CheAPIEndpoint+"/workspace/"+workspaceID, "")
+	if err != nil {
+		return Agent{}, err
+	}
+
+	var Che5Runtime Che5RuntimeStruct
+	json.Unmarshal(runtimeData, &Che5Runtime) //Not checking for unmarshalling errors because we don't know whether its che5 or che6 running
+
+	var Che6Runtime RuntimeStruct
+	json.Unmarshal(runtimeData, &Che6Runtime) //Not checking for unmarshalling errors because we don't know whether its che5 or che6 running
+
+	var agents Agent
+	for index := range Che5Runtime.Runtime.Machines {
+		for _, server := range Che5Runtime.Runtime.Machines[index].Runtime.Servers {
+
+			if server.Ref == "exec-agent" {
+				agents.execAgentURL = server.URL + "/process"
+			}
+
+			if server.Ref == "wsagent" {
+				agents.wsAgentURL = server.URL
+			}
+		}
+	}
+
+	for key := range Che6Runtime.Runtime.Machines {
+		for serverName, installer := range Che6Runtime.Runtime.Machines[key].Servers {
+
+			if serverName == "exec-agent/http" {
+				agents.execAgentURL = installer.URL
+			}
+
+			if serverName == "wsagent/http" {
+				agents.wsAgentURL = installer.URL
+			}
+
+		}
+	}
+
+	return agents, nil
+}
+
+//StartWorkspace POSTs a Workspace configuration to the workspace endpoint, creating a new workspace
+func (c *CheAPI) StartWorkspace(workspaceConfiguration interface{}, stackID string) (Workspace2, error) {
+	a := Post{Environments: workspaceConfiguration, Namespace: "che", Name: stackID + "-stack-test", DefaultEnv: "default"}
+	marshalled, err := json.MarshalIndent(a, "", "    ")
+	if err != nil {
+		return Workspace2{}, err
+	}
+
+	//Get rid of bayesian when you're testing on RH-Che stacks
+	re := regexp.MustCompile(",[\\n|\\s]*\"com.redhat.bayesian.lsp\"")
+	noBayesian := re.ReplaceAllString(string(marshalled), "")
+
+	workspaceDataJSON, _, err := doRequest(http.MethodPost, c.CheAPIEndpoint+"/workspace?start-after-create=true", noBayesian)
+	if err != nil {
+		return Workspace2{}, err
+	}
+
+	var WorkspaceResponse Workspace2
+	err = json.Unmarshal(workspaceDataJSON, &WorkspaceResponse)
+	if err != nil {
+		return Workspace2{}, err
+	}
+
+	c.BlockWorkspace(WorkspaceResponse.ID, "RUNNING")
+
+	return WorkspaceResponse, nil
+}
+
+//GetWorkspaceStatusByID gets the workspace status of the given workspaceID
+func (c *CheAPI) GetWorkspaceStatusByID(workspaceID string) (WorkspaceStatus, error) {
+	workspaceDataJSON, _, err := doRequest(http.MethodGet, c.CheAPIEndpoint+"/workspace/"+workspaceID, "")
+	if err != nil {
+		return WorkspaceStatus{}, err
+	}
+
+	var workspaceStatusObj WorkspaceStatus
+	err = json.Unmarshal(workspaceDataJSON, &workspaceStatusObj)
+
+	return workspaceStatusObj, err
+}
+
+//CheckWorkspaceDeletion checks if the workspace at workspaceID is deleted
+func (c *CheAPI) CheckWorkspaceDeletion(workspaceID string) error {
+	_, statusCode, err := doRequest(http.MethodGet, c.CheAPIEndpoint+"/workspace/"+workspaceID, "")
+	if err != nil {
+		return err
+	}
+
+	if statusCode != 404 {
+		return fmt.Errorf("Workspace was not deleted")
+	}
+
+	return nil
+}
+
+//StopWorkspace stops the workspace with workspaceID
+func (c *CheAPI) StopWorkspace(workspaceID string) error {
+	_, _, err := doRequest(http.MethodDelete, c.CheAPIEndpoint+"/workspace/"+workspaceID+"/runtime", "")
+	if err != nil {
+		return err
+	}
+
+	c.BlockWorkspace(workspaceID, "STOPPED")
+
+	return nil
+}
+
+//RemoveWorkspace removes the workspace with workspaceID
+func (c *CheAPI) RemoveWorkspace(workspaceID string) error {
+	_, _, err := doRequest(http.MethodDelete, c.CheAPIEndpoint+"/workspace/"+workspaceID, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//GetStackInformation gets the stack information
+func (c *CheAPI) GetStackInformation() ([]Workspace, error) {
+	stackData, _, err := doRequest(http.MethodGet, c.CheAPIEndpoint+"/stack?maxItems=200", "")
+	if err != nil {
+		return []Workspace{}, err
+	}
+
+	var workspaceData []Workspace
+	err = json.Unmarshal(stackData, &workspaceData)
+	if err != nil {
+		return workspaceData, err
+	}
+
+	for i, workspace := range workspaceData {
+		if len(workspace.Config.Commands) > 0 {
+			workspaceData[i].Command = append(workspace.Command, workspace.Config.Commands...)
+		}
+	}
+
+	return workspaceData, nil
+}
+
+//GetSamplesInformation gets the samples information
+func (c *CheAPI) GetSamplesInformation() ([]Sample, error) {
+	samplesJSON, _, err := doRequest(http.MethodGet, samples, "")
+	if err != nil {
+		return []Sample{}, err
+	}
+
+	var sampleData []Sample
+	err = json.Unmarshal([]byte(samplesJSON), &sampleData)
+
+	return sampleData, err
+}
+
+//GenerateDataForWorkspaces generates a map of workspaces with the stack name as the key and a map of samples with the project url as the key
+func (c *CheAPI) GenerateDataForWorkspaces(stackData []Workspace, samples []Sample) {
+	stackConfigInfo := make(map[string]Workspace)
+	sampleConfigInfo := make(map[string]Sample)
+	for _, stackElement := range stackData {
+		stackConfigInfo[stackElement.Name] = stackElement
+	}
+
+	for _, sampleElement := range samples {
+		sampleConfigInfo[sampleElement.Source.Location] = sampleElement
+	}
+
+	c.SetStackConfigMap(stackConfigInfo)
+	c.SetSamplesConfigMap(sampleConfigInfo)
+}
+
+//SetAgentsURL sets WSAgent the Exec Agent URL for CheAPI
+func (c *CheAPI) SetAgentsURL(agents Agent) {
+	c.WSAgentURL = agents.wsAgentURL
+	c.ExecAgentURL = agents.execAgentURL
+}
+
+//SetWorkspaceID sets the workspaceID for CheAPI
+func (c *CheAPI) SetWorkspaceID(workspaceID string) {
+	c.WorkspaceID = workspaceID
+}
+
+//SetStackName sets the stackName for CheAPI
+func (c *CheAPI) SetStackName(stackName string) {
+	c.StackName = stackName
+}
+
+func (c *CheAPI) SetStackConfigMap(workspaceConfig map[string]Workspace) {
+	stackConfigMap = workspaceConfig
+}
+
+func (c *CheAPI) SetSamplesConfigMap(sampleConfig map[string]Sample) {
+	sampleConfigMap = sampleConfig
+}
+
+func (c *CheAPI) GetStackConfigMap() map[string]Workspace {
+	return stackConfigMap
+}
+
+func (c *CheAPI) GetSamplesConfigMap() map[string]Sample {
+	return sampleConfigMap
+}

--- a/test/integration/features/addons/addon-che.feature
+++ b/test/integration/features/addons/addon-che.feature
@@ -1,0 +1,64 @@
+@addon-che @addon
+Feature: Che add-on
+  Che addon starts Eclipse Che
+
+  Scenario: Che add-on is part of Minishift
+     When executing "minishift addons list" succeeds
+     Then stdout should contain "che"
+  
+  Scenario: User starts Minishift
+    Given Minishift has state "Does Not Exist"
+     When executing "minishift start --memory=5GB" succeeds
+     Then Minishift should have state "Running"
+
+  Scenario: User applies Che add-on
+     When applying che addon with openshift token succeeds
+     Then stdout should contain "Please wait while the pods all startup!"
+
+  Scenario: Che is ready
+    Given Minishift has state "Running"
+     When executing "oc project mini-che" succeeds
+     Then service "che" rollout successfully within "300" seconds
+
+  Scenario: Che API is accessible
+     When user tries to get the che api endpoint
+     Then che api endpoint should not be empty
+
+  Scenario: Che stacks are accessible
+     When user tries to get the stacks information
+     Then the stacks should not be empty
+
+  Scenario Outline: User starts workspace, imports projects, checks run commands
+     When starting a workspace with stack "<stack>" succeeds
+     Then workspace should have state "RUNNING"
+
+     When importing the sample project "<sample>" succeeds
+     Then workspace should have 1 project
+
+     When user runs command on sample "<sample>"
+     Then exit code should be 0
+
+     When stopping a workspace succeeds
+     Then workspace should have state "STOPPED"
+
+     When workspace is removed
+     Then workspace removal should be successful
+
+    Examples:
+    | stack                 | sample                                                                   |
+    | Eclipse Vert.x        | https://github.com/openshiftio-vertx-boosters/vertx-http-booster         |
+    | Java CentOS           | https://github.com/che-samples/console-java-simple.git                   |
+    | Spring Boot           | https://github.com/snowdrop/spring-boot-http-booster                     |
+    | CentOS WildFly Swarm  | https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http  |
+    | Python                | https://github.com/che-samples/console-python3-simple.git                |
+    | PHP                   | https://github.com/che-samples/web-php-simple.git                        |
+    | C++                   | https://github.com/che-samples/console-cpp-simple.git                    |
+
+  Scenario: Removal of Che addon
+     When executing "minishift addons remove che" succeeds
+      And executing "oc get projects" succeeds
+     Then stdout should not contain "mini-che"
+ 
+  Scenario: User deletes Minishift
+     When executing "minishift delete --force" succeeds
+     Then Minishift should have state "Does Not Exist"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/godog"
+	"github.com/minishift/minishift/test/integration/che"
 	"github.com/minishift/minishift/test/integration/testsuite"
 )
 
@@ -49,8 +50,9 @@ func TestMain(m *testing.M) {
 }
 
 func getFeatureContext(s *godog.Suite) {
-	// loads step definitions from the Minishift integration testsuite
+	// loads step definitions from default Minishift integration tests
 	testsuite.FeatureContext(s)
+	che.FeatureContext(s)
 
 	// here you can load additional step definitions, for example:
 	// mypackage.FeatureContext(s)


### PR DESCRIPTION
Fix #2657.

Moves Che tests from minishift-addons repository here. It keeps them in separate package `Che` to isolate them from the more default steps focused clearly on usage of Minishift. 

How to test:
- `make integration GODOG_OPTS=-tags=addon-che`