### PR TITLE
Issue #2712 Fixing the exit code for oc context set during restart

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -282,7 +282,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		if isRestart {
 			err = cmdUtil.SetOcContext(minishiftConfig.AllInstancesConfig.ActiveProfile)
 			if err != nil {
-				fmt.Println(fmt.Sprintf("Could not set oc CLI context for '%s' profile: %v", profileActions.GetActiveProfile(), err))
+				atexit.ExitWithMessage(1, fmt.Sprintf("Could not set oc CLI context for '%s' profile: %v", profileActions.GetActiveProfile(), err))
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>

Fixes #2712 


Steps to test the pull request

  1.  git revert 6c901e8c31f35d021ee9423312c90b29e0c67040
  2.  make clean; make
  3. minishift start -> stop-> start
  4. echo $?
  