### PR TITLE
Issue #1586 Make pre-flight check self-explanatory in case of failure

### DIFF
--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -76,7 +76,8 @@ func preflightChecksBeforeStartingHost() {
 			checkOriginRelease,
 			fmt.Sprintf("Checking if requested OpenShift version '%s' is valid", requestedOpenShiftVersion),
 			configCmd.WarnCheckOpenShiftRelease.Name,
-			"",
+			fmt.Sprintf("To warn this test use 'minishift config set %s true'\nTo skip this test use 'minishift config set %s true'",
+				configCmd.WarnCheckOpenShiftRelease.Name, configCmd.SkipCheckOpenShiftRelease.Name),
 		)
 	} else {
 		fmt.Printf("FAIL\n")


### PR DESCRIPTION
Fixes #1586 

I think instead of document we should proactive tell user to skip the test when we know can be avoided. I am planning to put this logic to all the test which can be skipped without any major blocker in term of starting the VM.

