### PR TITLE
Issue #2716 show usage if hostfolder name is empty

### DIFF
--- a/cmd/minishift/cmd/hostfolder/add.go
+++ b/cmd/minishift/cmd/hostfolder/add.go
@@ -100,7 +100,10 @@ func addHostFolder(cmd *cobra.Command, args []string) {
 		if interactive {
 			name, shareType = readNameAndTypeInteractive()
 		} else {
-			name = args[0]
+			name = strings.TrimSpace(args[0])
+			if len(name) == 0 {
+				atexit.ExitWithMessage(1, usage)
+			}
 		}
 	}
 

--- a/cmd/minishift/cmd/hostfolder/add_test.go
+++ b/cmd/minishift/cmd/hostfolder/add_test.go
@@ -42,6 +42,21 @@ func Test_host_folder_name_required(t *testing.T) {
 	addHostFolder(nil, nil)
 }
 
+func Test_host_folder_name_not_empty(t *testing.T) {
+	var err error
+	tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)
+	config.InstanceConfig, err = config.NewInstanceConfig(filepath.Join(tmpMinishiftHomeDir, "config"))
+	config.AllInstancesConfig, err = config.NewAllInstancesConfig(filepath.Join(tmpMinishiftHomeDir, "config"))
+	assert.NoError(t, err, "Unexpected error setting instance config")
+
+	tee := cli.CreateTee(t, true)
+	defer cli.TearDown(tmpMinishiftHomeDir, tee)
+	defer viper.Reset()
+
+	atexit.RegisterExitHandler(cli.VerifyExitCodeAndMessage(t, tee, 1, usage))
+	addHostFolder(nil, []string{" "})
+}
+
 func Test_source_required(t *testing.T) {
 	var err error
 	tmpMinishiftHomeDir := cli.SetupTmpMinishiftHome(t)


### PR DESCRIPTION
Fixes #2716 


Steps to test the pull request

  1. `minishift hostfolder add --type sshfs --source /tmp/foo --target /mnt/sda1/foo " "`


