### PR TITLE
Issue #2720 Separate tests into core and extra to be run in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,22 +202,22 @@ clean_bindata:
 test: $(ADDON_ASSET_FILE)  ## Run unit tests
 	@go test -v -tags "$(BUILD_TAGS)" -ldflags="$(VERSION_VARIABLES)" $(shell $(PACKAGES))
 
-.PHONY: integration
-integration: GODOG_OPTS = --tags=basic ## Run integration tests
+.PHONY: integration ## Run integration tests (quick and minimal)
+integration: GODOG_OPTS = --tags=quick\&\&~disabled
 integration: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
 	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" --copy-oc-from="$(COPY_OC_FROM)" $(GODOG_OPTS)
 
 .PHONY: integration_all ## Run all integration tests
-integration_all: GODOG_OPTS = --tags=~coolstore\&\&~proxy
+integration_all: GODOG_OPTS = --tags=~disabled
 integration_all: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \
 	--run-before-feature="$(RUN_BEFORE_FEATURE)" --test-with-specified-shell="$(TEST_WITH_SPECIFIED_SHELL)" --copy-oc-from="$(COPY_OC_FROM)" $(GODOG_OPTS)
 
-.PHONY: integration_pr ## Run integration tests for pull request
-integration_pr: GODOG_OPTS = --tags=~coolstore\&\&~addon-xpaas\&\&~proxy
+.PHONY: integration_pr ## Run integration tests for pull request (skip more specialized tests)
+integration_pr: GODOG_OPTS = --tags=core\&\&~disabled
 integration_pr: $(MINISHIFT_BINARY)
 	mkdir -p $(INTEGRATION_TEST_DIR)
 	go test -timeout $(TIMEOUT) $(REPOPATH)/test/integration --tags=integration -v -args --test-dir $(INTEGRATION_TEST_DIR) --binary $(MINISHIFT_BINARY) \

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -222,7 +222,7 @@ Features for {project} follow these basic concepts:
 
 User stories::
 Features which follow a happy path of user.
-For example, *basic.feature* or *coolstore.feature*.
+For example, the *coolstore.feature*.
 
 Feature and command coverage::
 Features which focuses on specific fields of {project} functionality or individual commands.
@@ -232,7 +232,7 @@ For example, *proxy.feature* or *cmd-version.feature*.
 ==== Running Integration Tests
 
 By default, tests are run against the binary created by `make build` (*_$GOPATH/bin/minishift_*).
-To run the basic test, use the following command:
+To run the quick test, use the following command:
 
 ----
 $ make integration
@@ -240,10 +240,11 @@ $ make integration
 
 [NOTE]
 ====
-`make integration` only runs tests which are tagged as `@basic` by default.
+By default, `make integration` only runs tests that are tagged as `@quick`.
+These tests contain multiple scenarios, but only start {project} once.
 ====
 
-To run all of the tests, use the following command:
+To run all of the tests (except those tagged as `@disabled`), use the following command:
 
 ----
 $ make integration_all
@@ -251,7 +252,9 @@ $ make integration_all
 
 [NOTE]
 ====
-There is also a `make integration_pr` target which is being run as part of pull request testing.
+There is also a `make integration_pr` target which is run as part of pull request testing.
+This target runs the test on all features tagged as `@core`, which covers the basic functionality of {project}.
+This target is a compromise between total run time and coverage.
 ====
 
 ===== Additional Parameters
@@ -321,11 +324,16 @@ Tags::
 Use `tags` to ensure that scenarios and features containing at least one of the selected tags are executed.
 To select particular feature, you can use its name as a tag.
 For example, the `cmd-config.feature` contains `@cmd-config` tag through which it can be selected and run with the following command: `make integration GODOG_OPTS=--tags=cmd-config`.
-There are also tags covering specific areas and usages of {project}:
+There are also a few special tags used to indicate specific subsets of integration tests.
+These are the following:
 
-- The `@command` tag indicates that the feature file tests commands, for example `cmd-addons.feature`.
-- The `@openshift` tag indicates that the feature file has tests related to OpenShift.
-- The `@addon` tag indicates that the feature file tests particular add-on functionality.
+- `@quick` includes `basic.feature` along with several other features and scenarios which do not require a start of {project}.
+Starting the tests with the `@quick` tag covers a variety of scenarios, but only starts {project} once.
+- `@core` includes feature files which cover all of the essential functionality of {project}.
+This tag is used to test pull requests to the {project} repository.
+- `@disabled` indicates broken feature files.
+Any failures on these features are expected.
+All features, scenarios, and steps tagged as `@disabled` will not be run as part of pull request testing or nightly build testing.
 
 Paths::
 Use `paths` to define paths to different feature files or folders containing feature files.
@@ -350,16 +358,16 @@ Passing any value via `GODOG_OPTS` overrides the default tag definition on each 
 Thus in this case `--tags` must be specified manually, otherwise all features will be run.
 ====
 
-For example, to run integration tests on two specific feature files using only `@basic` and `@openshift` tags and without ANSI colors, the following command can be used:
+For example, to run integration tests on two specific feature files using only the `@basic` and `@cmd-addons` tags and without ANSI colors, the following command can be used:
 
 ----
-$ make integration GODOG_OPTS="-paths ~/tests/custom.feature,~/my.feature -tags basic,openshift -no-colors true"
+$ make integration GODOG_OPTS="-paths ~/tests/custom.feature,~/my.feature -tags basic,cmd-addons -no-colors true"
 ----
 
 [NOTE]
 ====
 Multiple values for a `GODOG_OPTS` option must be separated by a comma without whitespace.
-For example, `-tags basic,openshift` will be parsed properly by `make`, whereas `-tags basic, openshift` will result in only `@basic` being used.
+For example, `-tags basic,cmd-openshift` will be parsed properly by `make`, whereas `-tags basic, cmd-openshift` will result in only `@basic` being used.
 ====
 
 [[viewing-results]]

--- a/test/integration/features/addons/addon-registry-route.feature
+++ b/test/integration/features/addons/addon-registry-route.feature
@@ -1,4 +1,4 @@
-@addon-registry-route @addon
+@addon-registry-route
 Feature: registry-route add-on
 registry-route add-on exposes the route for the OpenShift integrated registry,
 so that user can able to push their container images directly to registry and deploy it.

--- a/test/integration/features/addons/addon-xpaas.feature
+++ b/test/integration/features/addons/addon-xpaas.feature
@@ -1,4 +1,4 @@
-@addon-xpaas @addon
+@addon-xpaas
 Feature: xpaas add-on
 Xpaas add-on imports xPaaS templates and imagestreams,
 which are then available in OpenShift to the user.

--- a/test/integration/features/addons/cmd-addons.feature
+++ b/test/integration/features/addons/cmd-addons.feature
@@ -1,7 +1,7 @@
-@cmd-addons @command
+@cmd-addons @core
 Feature: Addons command and its subcommands
 
-  @minishift-only
+  @minishift-only @quick
   Scenario: Default add-ons are installed but not enabled by default
      Note: default add-ons were installed during previous commands automatically.
      When executing "minishift addons list"
@@ -12,7 +12,7 @@ Feature: Addons command and its subcommands
       And stdout should match "che\s*: disabled\s*P\(0\)"
       And stdout should match "htpasswd-identity-provider\s*: disabled\s*P\(0\)"
 
-@minishift-only
+  @minishift-only @quick
   Scenario: Verbose listing of add-ons installed by default
      When executing "minishift addons list --verbose"
      Then stdout should match "Name\s*: admin-user"
@@ -40,11 +40,13 @@ Feature: Addons command and its subcommands
       And stdout should match "Url\s*:"
       And stdout should match "Openshift Version\s*:"
 
+  @quick
   Scenario: Uninstalling an add-on
      When executing "minishift addons uninstall anyuid" succeeds
      Then executing "minishift addons list" succeeds
       And stdout should not contain "anyuid"
 
+  @quick
   Scenario: Installing add-on from a folder
   Note: working directory when executing Minishift commands is: out/test-run.
      When file from "https://raw.githubusercontent.com/minishift/minishift/master/addons/anyuid/anyuid.addon" is downloaded into location "download/anyuid"
@@ -52,6 +54,7 @@ Feature: Addons command and its subcommands
      Then executing "minishift addons list" succeeds
       And stdout should contain "anyuid"
 
+  @quick
   Scenario: Applying add-on when Minishift is not running
     Given Minishift has state "Does Not Exist"
      When executing "minishift addons apply anyuid" succeeds
@@ -60,6 +63,7 @@ Feature: Addons command and its subcommands
       Running this command requires an existing 'minishift' VM, but no VM is defined.
       """
 
+  @quick
   Scenario: Removing add-on when Minishift is not running
   After issue no. 1377 is resolved, please change the expected stdout to:
   Minishift should return: "Running this command requires an existing 'minishift' VM, but no VM is defined."
@@ -70,6 +74,7 @@ Feature: Addons command and its subcommands
       Unable to remove addon 'anyuid'. No anyuid.addon.remove file is found.
       """
 
+  @quick
   Scenario: Installing default add-ons manually
      When executing "minishift addons install --defaults" succeeds
      Then stdout should contain
@@ -84,7 +89,7 @@ Feature: Addons command and its subcommands
      Then stdout should contain "che"
      Then stdout should contain "htpasswd-identity-provider"
 
-  @minishift-only
+  @minishift-only @quick
   Scenario: Default add-ons are not enabled by default during installation
      When executing "minishift addons list"
      Then stdout should match "admin-user\s*: disabled\s*P\(0\)"
@@ -94,6 +99,7 @@ Feature: Addons command and its subcommands
       And stdout should match "che\s*: disabled\s*P\(0\)"
       And stdout should match "htpasswd-identity-provider\s*: disabled\s*P\(0\)"
 
+  @quick
   Scenario: Enabling not installed add-on
      When executing "minishift addons enable absent-addon"
      Then stdout should contain
@@ -101,12 +107,14 @@ Feature: Addons command and its subcommands
       No add-on with the name 'absent-addon' is installed.
       """
 
+  @quick
   Scenario: Enabling installed add-on
      When executing "minishift addons enable xpaas" succeeds
      Then stdout should contain "Add-on 'xpaas' enabled"
       And executing "minishift addons list" succeeds
       And stdout should match "xpaas\s*: enabled\s*P\(0\)"
 
+  @quick
   Scenario: Enabling installed add-on with priority
      When executing "minishift addons enable anyuid --priority 5" succeeds
      Then stdout should contain "Add-on 'anyuid' enabled"

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -1,4 +1,4 @@
-@basic
+@basic @core @quick
 Feature: Basic
   As a user I can perform basic operations of Minishift and OpenShift
 

--- a/test/integration/features/cmd-config.feature
+++ b/test/integration/features/cmd-config.feature
@@ -1,16 +1,17 @@
-@cmd-config @command
+@cmd-config @core
 Feature: Minishift config subcommands
 Commands `minishift config [sub-command]` are used for storing
 user defined options which changes default behaviour of Minishift.
 
-  @minishift-only
+  @minishift-only @quick
   Scenario: Config is empty
     Given Minishift has state "Does Not Exist"
      Then executing "minishift config view" succeeds
       And stdout should be empty
 
-  Scenario Outline: Setting values in bad range or format
-  Minishift config set should not set a value, if this value is of bad format or in bad range.
+  @quick
+  Scenario Outline: Setting values in wrong range or format
+  Minishift config set should not set a value, if this value is of wrong format or in wrong range.
      When executing "minishift config set <property> <value>" fails
      Then JSON config file ".minishift/config/config.json" does not contain key "<property>" with value matching "<value>"
       And stdout of command "minishift config get <property>" is equal to "<nil>"
@@ -70,6 +71,7 @@ user defined options which changes default behaviour of Minishift.
     | host-only-cidr  | 192.168.1.1                    |
     | host-only-cidr  | notacidr                       |
 
+  @quick
   Scenario Outline: Setting and unsetting with correct values
       When executing "minishift config set <property> "<value>"" succeeds
       Then JSON config file ".minishift/config/config.json" contains key "<property>" with value matching "<expected>"
@@ -158,7 +160,7 @@ user defined options which changes default behaviour of Minishift.
     | host-only-cidr  | 192.168.0.1/0                                                                                   | 192.168.0.1/0                                                                                   |
     | host-only-cidr  | 192.168.0.1/16                                                                                  | 192.168.0.1/16                                                                                  |
 
-  @minishift-only
+  @minishift-only @quick
   Scenario Outline: Setting and unsetting values for iso-url key
      When executing "minishift config set <property> "<value>"" succeeds
      Then JSON config file ".minishift/config/config.json" contains key "<property>" with value matching "<expected>"
@@ -176,14 +178,17 @@ user defined options which changes default behaviour of Minishift.
     | iso-url         | b2d                                                                                              | b2d                                                                                             |
     | iso-url         | centos                                                                                           | centos                                                                                          |
 
+  @quick
   Scenario: Unsetting non-existing key
      When executing "minishift config unset i-do-not-exist" succeeds
      Then exitcode should equal "0"
 
+  @quick
   Scenario: Getting non-existing key
      When executing "minishift config get does-not-exist"
      Then stdout should contain "<nil>"
 
+  @quick
   Scenario Outline: Setting values, getting values and keeping them
   Setting values, not unsetting them so they will be used on next Minishift start.
   Not every key possible is being tested only those which are less complicated,
@@ -198,7 +203,7 @@ user defined options which changes default behaviour of Minishift.
     | docker-env        | FOO=BAR,hello=hi   | [FOO=BAR hello=hi]   |
     | docker-opt        | dns=8.8.8.8        | [dns=8.8.8.8]        |
 
-
+  @quick
   Scenario Outline: Globally Setting values, getting values and keeping them
   Setting values, not unsetting them so they will be used on next Minishift start.
   Not every key possible is being tested only those which are less complicated,

--- a/test/integration/features/cmd-docker-env.feature
+++ b/test/integration/features/cmd-docker-env.feature
@@ -1,4 +1,4 @@
-@cmd-docker-env @command
+@cmd-docker-env @core
 Feature: Command docker-env
 Command docker-env sets docker environment variables for supported shells.
 INFO: This feature runs against a shell instance. To use a non-default shell, please select

--- a/test/integration/features/cmd-image.feature
+++ b/test/integration/features/cmd-image.feature
@@ -1,4 +1,4 @@
-@cmd-image @command
+@cmd-image @core
 Feature: Basic image caching test
   As a user I am able to import and export container images from a local OCI repository
   located in the $MINISHIFT_HOME/cache directory

--- a/test/integration/features/cmd-oc-env.feature
+++ b/test/integration/features/cmd-oc-env.feature
@@ -1,4 +1,4 @@
-@cmd-oc-env @command
+@cmd-oc-env @core
 Feature: Command oc-env
 Command oc-env sets the path to oc binary.
 INFO: This feature runs against a shell instance. To use a non-default shell, please select

--- a/test/integration/features/cmd-openshift.feature
+++ b/test/integration/features/cmd-openshift.feature
@@ -1,8 +1,9 @@
-@cmd-openshift @command @openshift
+@cmd-openshift @core
 Feature: Openshift commands
 Commands "minishift openshift [sub-command]" are used for interaction with Openshift
 cluster in VM provided by Minishift.
 
+  @quick
   Scenario: Trying service command when Minishift is not running
      Given Minishift has state "Does Not Exist"
       When executing "minishift openshift service list" succeeds

--- a/test/integration/features/cmd-profile.feature
+++ b/test/integration/features/cmd-profile.feature
@@ -1,7 +1,8 @@
-@cmd-profile @command
+@cmd-profile @core
 Feature: Profile commands
   As a user I can perform basic operations of Minishift with profile feature
 
+  @quick
   Scenario Outline: As user, I cannot create profile with blank profile name
      When executing "minishift profile set <profilename>" fails
      Then stderr should contain
@@ -14,7 +15,7 @@ Feature: Profile commands
     |             |
     | ''          |
 
-    
+  @quick
   Scenario Outline: As user, I cannot create profile with special character in profile name
      When executing "minishift profile set <profilename>" fails
      Then stderr should contain
@@ -42,6 +43,7 @@ Feature: Profile commands
     | 'foo_bar'   |
     | '_'         |
 
+  @quick
   Scenario Outline: As user, I can create profile with alphanumeric character including '_' and '-' in profile name
      When executing "minishift profile set <profilename>" succeeds
      Then profile <profilename> should have state "Does Not Exist"
@@ -59,6 +61,7 @@ Feature: Profile commands
     | 123profile  |
     | foo         |
 
+  @quick
   Scenario: As user, I can switch between existing profiles
      When executing "minishift profile set Test-123" succeeds
      Then profile "Test-123" should be the active profile

--- a/test/integration/features/cmd-version.feature
+++ b/test/integration/features/cmd-version.feature
@@ -1,4 +1,4 @@
-@cmd-version @command
+@cmd-version @core @quick
 Feature: Version command
 Command "minishift version" shows version of minishift binary.
 

--- a/test/integration/features/experimental-flags.feature
+++ b/test/integration/features/experimental-flags.feature
@@ -3,6 +3,7 @@ Feature: Experimental Flags
   Experimental flag --extra-clusterup-flags will be enabled by setting MINISHIFT_ENABLE_EXPERIMENTAL environment variable,
   this flag will provide access to some of upcoming feature and experiments.
 
+  @quick
   Scenario: User cannot start minishift experimental feature directly
     Given Minishift has state "Does Not Exist"
      Then executing "minishift start --service-catalog" fails
@@ -11,6 +12,7 @@ Feature: Experimental Flags
       Error: unknown flag: --service-catalog
       """
 
+  @quick
   Scenario: User cannot use minishift flag --extra-clusterup-flag directly
     Given Minishift has state "Does Not Exist"
      Then executing "minishift start --extra-clusterup-flags" fails
@@ -19,6 +21,7 @@ Feature: Experimental Flags
       Error: unknown flag: --extra-clusterup-flags
       """
 
+  @quick
   Scenario: User can enable and disable minishift experimental flag --extra-clusterup-flags
     Given Minishift has state "Does Not Exist"
      When setting up environment variable "MINISHIFT_ENABLE_EXPERIMENTAL" with value "y" succeeds
@@ -34,6 +37,7 @@ Feature: Experimental Flags
       --extra-clusterup-flags string
       """
 
+  @quick
   Scenario: User cannot use minishift experimental flag --extra-clusterup-flag without experimental feature name
     Given Minishift has state "Does Not Exist"
      When setting up environment variable "MINISHIFT_ENABLE_EXPERIMENTAL" with value "y" succeeds

--- a/test/integration/features/flags.feature
+++ b/test/integration/features/flags.feature
@@ -1,8 +1,9 @@
-@flags
+@flags @core
 Feature: Flags
   As a user I can perform advanced operations
   such as starting Minishift with optional features
 
+  @quick
   Scenario: Set configuration options for Minishift
     Given Minishift has state "Does Not Exist"
      When executing "minishift config set docker-opt dns=8.8.8.8" succeeds

--- a/test/integration/features/generic-driver.feature
+++ b/test/integration/features/generic-driver.feature
@@ -1,4 +1,4 @@
-@generic-driver
+@generic-driver @core
 Feature: With generic driver Minishift can provision remote unprovisioned VM 
 
   Scenario: User creates an unprovisioned VM

--- a/test/integration/features/provision-various-versions.feature
+++ b/test/integration/features/provision-various-versions.feature
@@ -1,4 +1,4 @@
-@provision-various-versions @openshift
+@provision-various-versions @core
 Feature: Provision all major OpenShift versions
   As a user I can provision major versions of OpenShift
 

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -1,4 +1,4 @@
-@proxy
+@proxy @core @disabled
 Feature: Minishift can run behind proxy
   As a user I can use Minishift behind a proxy.
   INFO: Code behind this feature will start a proxy server in background

--- a/test/integration/features/stories/coolstore.feature
+++ b/test/integration/features/stories/coolstore.feature
@@ -1,4 +1,4 @@
-@coolstore
+@coolstore @disabled
 Feature: Cool Store
   In order to test Minishift under load
   I need to setup a test environment


### PR DESCRIPTION
Fixes #2720 

2. Moves basic.feature and coolstore.feature into directory `stories`
3. Moves addon related features into directory `addons`
4. Adds tag `@quick` to scenarios which does not require a `minishift start` + to elementary.feature
5. Adds tag `@core` to most of the features, except the specialized ones like xpaas.feature. This tags server to PR checks
6. Adds tag `@disabled` to features proxy and coolstore. Any feature, scenario or step tagged as `disabled` will not be run.
 
Steps to test the pull request

  1. run `make integration` - would be quick test containing 184 scenarios and only 1 minishift start
  2. run `make integration_pr` - would run all the tests except some more specialized, for example addon-xpaas.feature containing several app deployments. Usable during PR checks.
  3. run `make integration_all` - would run all the tests. Usable during nightly tests.
  4. all test will not run any feature file tagged as `@disabled` - currently the proxy.feature and coolstore.feature. 

@minishift/minishift-dev WDYT?
