### PR TITLE
Issue #2732 Use semver comparisons instead via util.VersionOrdinal

### DIFF
--- a/pkg/minishift/addon/manager/addon_manager.go
+++ b/pkg/minishift/addon/manager/addon_manager.go
@@ -25,13 +25,13 @@ import (
 
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/addon"
 	"github.com/minishift/minishift/pkg/minishift/addon/command"
 	"github.com/minishift/minishift/pkg/minishift/addon/config"
 	"github.com/minishift/minishift/pkg/minishift/addon/parser"
 	instanceState "github.com/minishift/minishift/pkg/minishift/config"
-	"github.com/minishift/minishift/pkg/util"
 	"github.com/minishift/minishift/pkg/util/filehelper"
 	utilStrings "github.com/minishift/minishift/pkg/util/strings"
 	"github.com/minishift/minishift/pkg/version"
@@ -358,33 +358,60 @@ func setStateAndPriority(addOn addon.AddOn, configMap map[string]*config.AddOnCo
 
 func compareComponentVersions(currentVersion, requiredVersion string, componentName string, versionRange string) error {
 	if strings.HasPrefix(requiredVersion, ">=") {
-		// This will work for both upstream and downstream.
-		if util.VersionOrdinal(currentVersion) < util.VersionOrdinal(strings.TrimPrefix(requiredVersion, ">=")) {
+		currentVersion, err := semver.Make(currentVersion)
+		if err != nil {
+			return err
+		}
+		requiredVersion, err := semver.Make(strings.TrimPrefix(requiredVersion, ">="))
+		if err != nil {
+			return err
+		}
+		if currentVersion.GE(requiredVersion) != true {
 			return fmt.Errorf("\nAdd-on does not support %s version %s. "+
 				"You need to use a version %s", componentName, currentVersion, versionRange)
 		}
-		return nil
 	}
 	if strings.HasPrefix(requiredVersion, ">") {
-		if util.VersionOrdinal(currentVersion) <= util.VersionOrdinal(strings.TrimPrefix(requiredVersion, ">")) {
+		currentVersion, err := semver.Make(currentVersion)
+		if err != nil {
+			return err
+		}
+		requiredVersion, err := semver.Make(strings.TrimPrefix(requiredVersion, ">"))
+		if err != nil {
+			return err
+		}
+		if currentVersion.GT(requiredVersion) != true {
 			return fmt.Errorf("\nAdd-on does not support %s version %s. "+
 				"You need to use a version %s", componentName, currentVersion, versionRange)
 		}
-		return nil
 	}
 	if strings.HasPrefix(requiredVersion, "<=") {
-		if util.VersionOrdinal(currentVersion) > util.VersionOrdinal(strings.TrimPrefix(requiredVersion, "<=")) {
+		currentVersion, err := semver.Make(currentVersion)
+		if err != nil {
+			return err
+		}
+		requiredVersion, err := semver.Make(strings.TrimPrefix(requiredVersion, "<="))
+		if err != nil {
+			return err
+		}
+		if currentVersion.LE(requiredVersion) != true {
 			return fmt.Errorf("\nAdd-on does not support %s version %s. "+
 				"You need to use a version %s", componentName, currentVersion, versionRange)
 		}
-		return nil
 	}
 	if strings.HasPrefix(requiredVersion, "<") {
-		if util.VersionOrdinal(currentVersion) >= util.VersionOrdinal(strings.TrimPrefix(requiredVersion, "<")) {
+		currentVersion, err := semver.Make(currentVersion)
+		if err != nil {
+			return err
+		}
+		requiredVersion, err := semver.Make(strings.TrimPrefix(requiredVersion, "<"))
+		if err != nil {
+			return err
+		}
+		if currentVersion.LT(requiredVersion) != true {
 			return fmt.Errorf("\nAdd-on does not support %s version %s. "+
 				"You need to use a version %s", componentName, currentVersion, versionRange)
 		}
-		return nil
 	}
 	if currentVersion != requiredVersion {
 		return fmt.Errorf("\nAddon does not support %s version %s. "+

--- a/pkg/minishift/openshift/version/openshift_versions_test.go
+++ b/pkg/minishift/openshift/version/openshift_versions_test.go
@@ -59,28 +59,6 @@ func EnsureGitHubApiAccessTokenSet(t *testing.T) {
 	}
 }
 
-func TestPrintDownStreamVersions(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "minishift-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(testDir)
-
-	f, err := os.Create(testDir + "out.txt")
-	assert.NoError(t, err)
-	defer f.Close()
-
-	os.Stdout = f
-	err = PrintDownStreamVersions(f, "v3.4.1.10")
-	assert.NoError(t, err)
-	_, err = f.Seek(0, 0)
-	assert.NoError(t, err, "Error setting offset back")
-
-	data, err := ioutil.ReadAll(f)
-	assert.NoError(t, err, "Error reading file")
-
-	actualStdout := string(data)
-	assert.Contains(t, actualStdout, "v3.4.1.10")
-}
-
 func TestIsGreaterOrEqualToBaseVersion(t *testing.T) {
 	var versionTestData = []struct {
 		openshiftVersion     string

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -100,39 +100,6 @@ func (m MultiError) ToError() error {
 	return fmt.Errorf(strings.Join(errStrings, "\n"))
 }
 
-func VersionOrdinal(version string) string {
-	// ISO/IEC 14651:2011
-	// https://www.iso.org/standard/57976.html
-	// This method is applicable for 255 characters string
-	// to determine their collating order in a sorted list.
-	// It create a collating sorted list and return the string.
-	const maxByte = 1<<8 - 1
-	vo := make([]byte, 0, len(version)+8)
-	j := -1
-	for i := 0; i < len(version); i++ {
-		b := version[i]
-		if '0' > b || b > '9' {
-			vo = append(vo, b)
-			j = -1
-			continue
-		}
-		if j == -1 {
-			vo = append(vo, 0x00)
-			j = len(vo) - 1
-		}
-		if vo[j] == 1 && vo[j+1] == '0' {
-			vo[j+1] = b
-			continue
-		}
-		if vo[j]+1 > maxByte {
-			panic("VersionOrdinal: invalid version")
-		}
-		vo = append(vo, b)
-		vo[j]++
-	}
-	return string(vo)
-}
-
 // TimeTrack is used to time the execution of a method. It is passed the start time as well as a output writer for the timing.
 // The usage of TimeTrack is in combination with defer like so:
 //

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -88,28 +88,6 @@ Error 2`
 	assert.NoError(t, err)
 }
 
-func TestVersionOrdinal(t *testing.T) {
-	var versionTestData = []struct {
-		OpenshiftVersion    string
-		MinOpenshiftVersion string
-		expectedResult      bool
-	}{
-		{"v3.6.0", "v3.7.0", true},
-		{"v3.4.1.10", "v3.4.1.2", false},
-		{"v3.6.0-alpha.1", "v3.6.0-alpha.2", true},
-		{"v3.7.1", "v3.7.1", true},
-		{"v3.5.5.31.24", "v3.4.2.1", false},
-		{"v3.6.173.0.21", "v3.5.5.31.24", false},
-		{"v3.6.0-rc1", "v3.6.0-alpha.1", false},
-		{"v3.6.0-alpha.1", "v3.6.0-beta.0", true},
-	}
-
-	for _, versionTest := range versionTestData {
-		actualResult := VersionOrdinal(versionTest.MinOpenshiftVersion) >= VersionOrdinal(versionTest.OpenshiftVersion)
-		assert.Equal(t, versionTest.expectedResult, actualResult, fmt.Sprintf("Expected: %s >= %s", versionTest.MinOpenshiftVersion, versionTest.OpenshiftVersion))
-	}
-}
-
 var durationTests = []struct {
 	in   time.Duration
 	want string


### PR DESCRIPTION
Fixes #2732 


Steps to test the pull request

1. cat demoaddon.adon
```
# Name: demoaddon
# Description: Just a demo addon.
# Url: https://docs.okd.io/
# Minishift-Version: <=1.22.0

echo "Hello world"
```
Now, install and apply.
Note: Expect error here.
  
2. Update ~/.minishift/addons/demoaddon/demoaddon.addon
```
# Name: demoaddon
# Description: Just a demo addon.
# Url: https://docs.okd.io/
# Minishift-Version: >=1.22.0

echo "Hello world"
```

Note: Apply should work.

