### PR TITLE
Issue #2742 Change to htpasswd addon for v3.10

### DIFF
--- a/addons/htpasswd-identity-provider/htpasswd-identity-provider.addon
+++ b/addons/htpasswd-identity-provider/htpasswd-identity-provider.addon
@@ -1,30 +1,45 @@
 # Name: htpasswd-identity-provider
 # Description: Configures minishift to use HTPasswdIdentityProvider
 # Url: https://docs.okd.io/3.9/install_config/configuring_authentication.html#HTPasswdPasswordIdentityProvider
-# Var-Defaults: USERNAME=developer,USER_PASSWORD=developer,MINISHIFT_DATA_HOME=/var/lib/minishift,CONFIG_LOCATION=openshift.local.config/master,MASTER_CONFIG_FILE=master-config.yaml,ORIGIN_DATA_HOME=/var/lib/origin
-# Required-Vars: USER_PASSWORD,USERNAME,CONFIG_LOCATION
+# OpenShift-Version: >=3.10.0
+# Var-Defaults: USERNAME=developer,USER_PASSWORD=developer,MINISHIFT_DATA_HOME=/var/lib/minishift,CONFIG_LOCATION_OPENSHIFT_API=base/openshift-apiserver,CONFIG_LOCATION_KUBERNETES_API=base/kube-apiserver,MASTER_CONFIG_FILE=master-config.yaml
+# Required-Vars: USER_PASSWORD,USERNAME,CONFIG_LOCATION_OPENSHIFT_API
 
 # Install htpasswd on the origin container
 docker exec -t origin /usr/bin/bash -c "which htpasswd || yum install -y httpd-tools"
 
 # backup the existing master-config.yaml
-ssh sudo cp -fp #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE} #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-htpasswd.yaml
+ssh sudo cp -fp #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/#{MASTER_CONFIG_FILE} #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/master-config-htpasswd.yaml
+ssh sudo cp -fp #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/#{MASTER_CONFIG_FILE} #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-htpasswd.yaml
 
 # create users.htpasswd file 
-ssh sudo touch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/users.htpasswd
+ssh sudo touch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/users.htpasswd
+ssh sudo touch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/users.htpasswd
 
-# add the default developer user to file
-docker exec -t origin /usr/bin/bash -c "htpasswd -b #{ORIGIN_DATA_HOME}/#{CONFIG_LOCATION}/users.htpasswd #{USERNAME} #{USER_PASSWORD}"
+# copy htpasswd from container to VM
+ssh sudo docker cp origin:/usr/bin/htpasswd /var/lib/minishift/bin/
 
-# Patch the master configuration to use HTPasswdPasswordIdentityProvider
-ssh sudo grep "HTPasswdPasswordIdentityProvider" #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE} > /dev/null || sudo #{MINISHIFT_DATA_HOME}/bin/oc ex config patch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-htpasswd.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "add","name": "htpasswd","provider": {"apiVersion": "v1","kind": "HTPasswdPasswordIdentityProvider","file": "users.htpasswd"}}]}}' > #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE}
+# Add user to users.htpasswd file
+ssh sudo /var/lib/minishift/bin/htpasswd -b #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/users.htpasswd #{USERNAME} #{USER_PASSWORD}
+ssh sudo /var/lib/minishift/bin/htpasswd -b #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/users.htpasswd #{USERNAME} #{USER_PASSWORD}
 
-# restart openshift 
+# Patch the openshift apiserver configuration to use HTPasswdPasswordIdentityProvider
+ssh sudo grep "HTPasswdPasswordIdentityProvider" #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/#{MASTER_CONFIG_FILE} > /dev/null || sudo #{MINISHIFT_DATA_HOME}/bin/oc ex config patch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/master-config-htpasswd.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "add","name": "htpasswd","provider": {"apiVersion": "v1","kind": "HTPasswdPasswordIdentityProvider","file": "users.htpasswd"}}]}}' > #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/#{MASTER_CONFIG_FILE}
 
-docker stop origin 
-docker start origin
+# Patch the kube apiserver configuration to use HTPasswdPasswordIdentityProvider
+ssh sudo grep "HTPasswdPasswordIdentityProvider" #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/#{MASTER_CONFIG_FILE} > /dev/null || sudo #{MINISHIFT_DATA_HOME}/bin/oc ex config patch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-htpasswd.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "add","name": "htpasswd","provider": {"apiVersion": "v1","kind": "HTPasswdPasswordIdentityProvider","file": "users.htpasswd"}}]}}' > #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/#{MASTER_CONFIG_FILE}
+
+
+
+echo -- Restarting Openshift API server ..
+docker stop $(docker ps -l -q --filter "label=io.kubernetes.container.name=apiserver")
+echo -- Restarting Kube API server ..
+docker stop $(docker ps -l -q --filter "label=io.kubernetes.container.name=api")
+
+ssh until curl -f -k https://#{ip}:8443/healthz;do sleep 1;done
 
 # remove the prepatch file
-ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-htpasswd.yaml
+ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/master-config-htpasswd.yaml
+ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-htpasswd.yaml
 
-echo 'Successfully installed addon htpasswd identity provider'
+echo -- Successfully installed addon htpasswd identity provider ... OK

--- a/addons/htpasswd-identity-provider/htpasswd-identity-provider.addon.remove
+++ b/addons/htpasswd-identity-provider/htpasswd-identity-provider.addon.remove
@@ -1,20 +1,34 @@
 # Name: htpasswd-identity-provider
 # Description: Reverts to default minishift authentication configuration
 # Url: https://docs.okd.io/3.9/install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider
-# Var-Defaults: MINISHIFT_DATA_HOME=/var/lib/minishift,CONFIG_LOCATION=openshift.local.config/master,MASTER_CONFIG_FILE=master-config.yaml
-# Required-Vars: CONFIG_LOCATION
+# Var-Defaults: MINISHIFT_DATA_HOME=/var/lib/minishift,CONFIG_LOCATION_OPENSHIFT_API=base/openshift-apiserver,CONFIG_LOCATION_KUBERNETES_API=base/kube-apiserver,MASTER_CONFIG_FILE=master-config.yaml
+# Required-Vars: CONFIG_LOCATION_OPENSHIFT_API
 
-# backup existing configuration
-ssh sudo cp -fp #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE} #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-prepatch.yaml
+# backup the existing master-config.yaml
+ssh sudo cp -fp #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/#{MASTER_CONFIG_FILE} #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/master-config-htpasswd.yaml
+ssh sudo cp -fp #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/#{MASTER_CONFIG_FILE} #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-htpasswd.yaml
+
 # revert to AllowAllPasswordIdentityProvider
-ssh sudo #{MINISHIFT_DATA_HOME}/bin/oc ex config patch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-prepatch.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "claim","name": "anypassword","provider": {"apiVersion": "v1","kind": "AllowAllPasswordIdentityProvider"}}]}}' > #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/master-config.yaml
-# remove the prepatch file
-ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-prepatch.yaml
+ssh sudo #{MINISHIFT_DATA_HOME}/bin/oc ex config patch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/master-config-htpasswd.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "claim","name": "anypassword","provider": {"apiVersion": "v1","kind": "AllowAllPasswordIdentityProvider"}}]}}' > #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/master-config.yaml
+ssh sudo #{MINISHIFT_DATA_HOME}/bin/oc ex config patch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-htpasswd.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "claim","name": "anypassword","provider": {"apiVersion": "v1","kind": "AllowAllPasswordIdentityProvider"}}]}}' > #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config.yaml
+
+
 # remove users.htpasswd file 
-ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION}/users.htpasswd
+ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/users.htpasswd
+ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/users.htpasswd
 
-# restart openshift 
-docker stop origin 
-docker start origin
+# remove htpasswd from filesystem
+ssh sudo rm -f /var/lib/minishift/bin/htpasswd
 
-echo 'Successfully removed addon htpasswd-identity-provider'
+echo -- Restarting Openshift API server ..
+docker stop $(docker ps -l -q --filter "label=io.kubernetes.container.name=apiserver")
+echo -- Restarting Kube API server ..
+docker stop $(docker ps -l -q --filter "label=io.kubernetes.container.name=api")
+
+ssh until curl -f -k https://#{ip}:8443/healthz;do sleep 1;done
+
+# remove the prepatch file
+ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_OPENSHIFT_API}/master-config-htpasswd.yaml
+ssh sudo rm -f #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-htpasswd.yaml
+
+echo -- Successfully removed addon htpasswd-identity-provider ... OK


### PR DESCRIPTION
Fixes  #2742 


Steps to test the pull request

  1. Use this PR and apply htpasswd-identity-provider
  2. Go to web console and try to login with different user => this should fail.
  3. login with same user with the password you provide during the apply of the addon (default: developer) => should successful.

