### PR TITLE
Issue #2768 Use origin-cli image if openshift >= 3.10.x

### DIFF
--- a/pkg/minishift/constants/constants.go
+++ b/pkg/minishift/constants/constants.go
@@ -53,7 +53,10 @@ func ProfilePrivateKeyPath() string {
 	return filepath.Join(constants.Minipath, "certs", "id_rsa")
 }
 
-func GetOpenshiftImageName(openshiftVersion string) string {
+func GetOpenshiftImageToFetchOC(openshiftVersion string, isGreaterOrEqualToBaseVersion bool) string {
+	if isGreaterOrEqualToBaseVersion {
+		return fmt.Sprintf("openshift/origin-control-plane:%s", openshiftVersion)
+	}
 	return fmt.Sprintf("openshift/origin:%s", openshiftVersion)
 }
 


### PR DESCRIPTION
Fixes #2768 

Steps to test the pull request

  1. minishift start
  2. docker images => this contain origin-cli image instead origin one for v3.10 and origin for v3.9

