### PR TITLE
Issue #2767 implement openshift add command to add component in running cluster

### DIFF
--- a/cmd/minishift/cmd/openshift/component.go
+++ b/cmd/minishift/cmd/openshift/component.go
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var componentCmd = &cobra.Command{
+	Use:   "component [command]",
+	Short: "Interacts with the Components to an OpenShift cluster (Only works openshift version >= 3.10.x)",
+	Long:  `Interacts with the Components to an OpenShift cluster (Only works openshift version >= 3.10.x)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	OpenShiftCmd.AddCommand(componentCmd)
+}

--- a/cmd/minishift/cmd/openshift/component_add.go
+++ b/cmd/minishift/cmd/openshift/component_add.go
@@ -1,0 +1,101 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/provision"
+	cmdUtil "github.com/minishift/minishift/cmd/minishift/cmd/util"
+	"github.com/minishift/minishift/cmd/minishift/state"
+	"github.com/minishift/minishift/pkg/minikube/cluster"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/clusterup"
+	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
+	openshiftVersion "github.com/minishift/minishift/pkg/minishift/openshift/version"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+const (
+	nonSpecifiedComponentError = "You need to specify a component name (use 'minishift openshift component list' to find available components)"
+	nonValidComponentError     = "You have specified a non-valid component name, use 'minishift openshift component list' to find valid components"
+)
+
+// version command represent current running openshift version and available one.
+var componentAddCmd = &cobra.Command{
+	Use:   "add [component-name]",
+	Short: "Add component to an OpenShift cluster (Only works openshift version >= 3.10.x)",
+	Long:  `Add component to an OpenShift cluster (Only works openshift version >= 3.10.x)`,
+	Run:   runComponentAdd,
+}
+
+var (
+	component string
+)
+
+func runComponentAdd(cmd *cobra.Command, args []string) {
+	if len(args) <= 0 {
+		atexit.ExitWithMessage(1, nonSpecifiedComponentError)
+	}
+
+	component = args[0]
+
+	if !minishiftStrings.Contains(minishiftConstants.ValidComponents, component) {
+		atexit.ExitWithMessage(1, nonValidComponentError)
+	}
+
+	api := libmachine.NewClient(state.InstanceDirs.Home, state.InstanceDirs.Certs)
+	defer api.Close()
+
+	host, err := cluster.CheckIfApiExistsAndLoad(api)
+	if err != nil {
+		atexit.ExitWithMessage(1, nonExistentMachineError)
+	}
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+
+	// Get proper OpenShift version
+	requestedOpenShiftVersion, err := cmdUtil.GetOpenShiftReleaseVersion()
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting OpenShift version: %v", err))
+	}
+
+	valid, err := openshiftVersion.IsGreaterOrEqualToBaseVersion(requestedOpenShiftVersion, constants.RefactoredOcVersion)
+	if err != nil {
+		atexit.ExitWithMessage(1, err.Error())
+	}
+
+	if !valid {
+		atexit.ExitWithMessage(1, fmt.Sprintf("You are using %s but this feature only available for OpenShift >= 3.10.x", requestedOpenShiftVersion))
+	}
+
+	baseDirectory := minishiftConstants.BaseDirInsideInstance
+	ocPathInsideVM := fmt.Sprintf("%s/oc", minishiftConstants.OcPathInsideVM)
+
+	out, err := clusterup.AddComponent(sshCommander, ocPathInsideVM, baseDirectory, component)
+	if err != nil {
+		atexit.ExitWithMessage(1, err.Error())
+	}
+	fmt.Fprint(os.Stdout, out)
+
+}
+
+func init() {
+	componentCmd.AddCommand(componentAddCmd)
+}

--- a/cmd/minishift/cmd/openshift/component_list.go
+++ b/cmd/minishift/cmd/openshift/component_list.go
@@ -1,0 +1,43 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"fmt"
+	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// version command represent current running openshift version and available one.
+var componentListCmd = &cobra.Command{
+	Use:   "list [component-name]",
+	Short: "Add component to an OpenShift cluster (Only works openshift version >= 3.10.x)",
+	Long:  `Add component to an OpenShift cluster (Only works openshift version >= 3.10.x)`,
+	Run:   runComponentList,
+}
+
+func runComponentList(cmd *cobra.Command, args []string) {
+	fmt.Fprint(os.Stdout, "The following OpenShift components are available: \n")
+	for _, component := range minishiftConstants.ValidComponents {
+		fmt.Fprintf(os.Stdout, "\t- %s\n", component)
+	}
+}
+
+func init() {
+	componentCmd.AddCommand(componentListCmd)
+}

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -120,7 +120,7 @@ var (
 	}
 
 	// Set the base dir for v3.10.0
-	baseDirectory = "/var/lib/minishift/base"
+	baseDirectory = minishiftConstants.BaseDirInsideInstance
 
 	// clusterUpFlagSet contains the command line switches which needs to be passed on to 'cluster up'
 	clusterUpFlagSet *flag.FlagSet

--- a/docs/source/openshift/openshift-client-binary.adoc
+++ b/docs/source/openshift/openshift-client-binary.adoc
@@ -177,3 +177,30 @@ $ minishift openshift config set --patch '{"routingConfig": {"subdomain": "<IP-A
 
 Make sure to replace `IP-ADDRESS` in the above example with the IP address of your {project} VM.
 You can retrieve the IP address by running the xref:../command-ref/minishift_ip.adoc#[`minishift ip`] command.
+
+[[add-component-to-openshift-cluster]]
+== Add component to OpenShift Cluster
+
+To add a component to a running OpenShift Cluster, use the following:
+
+----
+$ minishift openshift component add <component-name>
+----
+
+[[example-add-service-catalog-component]]
+=== Example: Add service-catalog component
+
+In this example, service-catalog component can be added as follows:
+
+----
+$ minishift openshift component add service-catalog
+----
+
+[[list-valid-components-to-add-to-openshift-cluster]]
+== List valid components to add to OpenShift cluster
+
+To list valid components which can be add to running OpenShift cluster, use the following:
+
+----
+$ minishift openshift component list
+----

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -33,7 +33,7 @@ You can set the `MINISHIFT_ENABLE_EXPERIMENTAL` environment variable to enable t
 `extra-clusterup-flags`::
 Enables passing flags directly to `oc cluster up` that are not directly exposed in the {project} CLI.
 
-Using the experimental flag, to enable the Service Catalog in Openshift Origin 3.9, the command is:
+Using the experimental flag, to enable the Service Catalog in OKD 3.9, the command is:
 
 ----
 $ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--service-catalog"

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -110,6 +110,20 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string) (stri
 	return out, nil
 }
 
+// AddComponent add a component to running Openshift cluster
+func AddComponent(sshCommander provision.SSHCommander, ocBinaryPathInsideVM string, basedir string, componentName string) (string, error) {
+	cmdArgs := []string{"cluster", "add", fmt.Sprintf("--base-dir=%s", basedir), componentName}
+	if glog.V(2) {
+		fmt.Printf("-- Running 'oc' with: '%s'\n", strings.Join(cmdArgs, " "))
+	}
+	cmd := fmt.Sprintf("%s %s", ocBinaryPathInsideVM, strings.Join(cmdArgs, " "))
+	out, err := sshCommander.SSHCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("Error adding the component: %v", err)
+	}
+	return out, nil
+}
+
 // PostClusterUp runs the Minishift specific provisioning after 'cluster up' has run
 func PostClusterUp(clusterUpConfig *ClusterUpConfig, sshCommander provision.SSHCommander, addOnManager *manager.AddOnManager, runner util.Runner) error {
 	err := kubeconfig.CacheSystemAdminEntries(clusterUpConfig.KubeConfigPath, clusterUpConfig.OcBinaryPathInsideVM, sshCommander)

--- a/pkg/minishift/constants/constants.go
+++ b/pkg/minishift/constants/constants.go
@@ -37,10 +37,12 @@ const (
 	SkipVerifyInsecureTLS       = "insecure-skip-tls-verify=true"
 	BinaryName                  = "minishift"
 	OcPathInsideVM              = "/var/lib/minishift/bin"
+	BaseDirInsideInstance       = "/var/lib/minishift/base"
 )
 
 var (
 	ValidIsoAliases = []string{B2dIsoAlias, CentOsIsoAlias}
+	ValidComponents = []string{"automation-service-broker", "service-catalog", "template-service-broker"}
 )
 
 // ProfileAuthorizedKeysPath returns the path of authorized_keys file in profile dir used for authentication purpose

--- a/test/integration/features/cmd-openshift.feature
+++ b/test/integration/features/cmd-openshift.feature
@@ -134,6 +134,13 @@ cluster in VM provided by Minishift.
       When executing "minishift openshift config view" succeeds
       Then stdout is YAML which contains key "assetConfig.logoutURL" with value matching "http://www\.minishift\.io"
 
+  Scenario: Add a component to running openshift cluster
+      When executing "minishift openshift component add service-catalog" succeeds
+       And stdout should contain
+       """
+       Finished installing "openshift-service-catalog"
+       """
+
   Scenario: Deleting the Minishift instance
      Given Minishift has state "Running"
       When executing "minishift delete --force" succeeds


### PR DESCRIPTION
Fixes #2767

Steps to test the pull request

  1. minishift start
  2. minishift openshift component add service-catalog => this should success
  3. minishift openshift componet add foobar => this should fail and you will see the component not available and failure
  4. minishift start --openshift-version v3.9.0 => minishift openshift component add service-catalog => this should fail because it not supported and provide the respective error.
 5. minishift openshift component list => this will show valid component list.

