### PR TITLE
Issue #2789 use specific version of image for cluster up

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -64,6 +64,7 @@ var (
 	PublicHostname    = createConfigSetting("public-hostname", SetString, nil, nil, true, nil)
 	RoutingSuffix     = createConfigSetting("routing-suffix", SetString, nil, nil, true, nil)
 	ServerLogLevel    = createConfigSetting("server-loglevel", SetInt, []setFn{validations.IsPositive}, nil, true, nil)
+	ImageName         = createConfigSetting("image", SetString, nil, nil, false, nil)
 
 	// future enabled flags
 	ExtraClusterUpFlags = createConfigSetting("extra-clusterup-flags", SetString, nil, nil, true, nil)

--- a/cmd/minishift/cmd/openshift/component_add.go
+++ b/cmd/minishift/cmd/openshift/component_add.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/provision"
-	cmdUtil "github.com/minishift/minishift/cmd/minishift/cmd/util"
 	"github.com/minishift/minishift/cmd/minishift/state"
 	"github.com/minishift/minishift/pkg/minikube/cluster"
 	"github.com/minishift/minishift/pkg/minikube/constants"
 	"github.com/minishift/minishift/pkg/minishift/clusterup"
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
 	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
 	openshiftVersion "github.com/minishift/minishift/pkg/minishift/openshift/version"
 	"github.com/minishift/minishift/pkg/util/os/atexit"
@@ -72,24 +72,26 @@ func runComponentAdd(cmd *cobra.Command, args []string) {
 	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
 
 	// Get proper OpenShift version
-	requestedOpenShiftVersion, err := cmdUtil.GetOpenShiftReleaseVersion()
+	minishiftConfig.InstanceStateConfig, err = minishiftConfig.NewInstanceStateConfig(minishiftConstants.GetInstanceStateConfigPath())
 	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("Error getting OpenShift version: %v", err))
+		atexit.ExitWithMessage(1, fmt.Sprintf("Error reading config for VM: %s", err.Error()))
 	}
 
+	requestedOpenShiftVersion := minishiftConfig.InstanceStateConfig.OpenshiftVersion
 	valid, err := openshiftVersion.IsGreaterOrEqualToBaseVersion(requestedOpenShiftVersion, constants.RefactoredOcVersion)
 	if err != nil {
 		atexit.ExitWithMessage(1, err.Error())
 	}
-
 	if !valid {
 		atexit.ExitWithMessage(1, fmt.Sprintf("You are using %s but this feature only available for OpenShift >= 3.10.x", requestedOpenShiftVersion))
 	}
 
+	imageToUse := fmt.Sprintf("'%s:%s'", minishiftConstants.ImageNameForClusterUpImageFlag, requestedOpenShiftVersion)
+
 	baseDirectory := minishiftConstants.BaseDirInsideInstance
 	ocPathInsideVM := fmt.Sprintf("%s/oc", minishiftConstants.OcPathInsideVM)
 
-	out, err := clusterup.AddComponent(sshCommander, ocPathInsideVM, baseDirectory, component)
+	out, err := clusterup.AddComponent(sshCommander, ocPathInsideVM, baseDirectory, component, imageToUse)
 	if err != nil {
 		atexit.ExitWithMessage(1, err.Error())
 	}

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -718,8 +718,13 @@ func initClusterUpFlags() *flag.FlagSet {
 	clusterUpFlagSet.String(configCmd.RoutingSuffix.Name, "", "Default suffix for the server routes.")
 	clusterUpFlagSet.Int(configCmd.ServerLogLevel.Name, 0, "Log level for the OpenShift server.")
 	clusterUpFlagSet.String(configCmd.NoProxyList.Name, "", "List of hosts or subnets for which no proxy should be used.")
+	clusterUpFlagSet.String(configCmd.ImageName.Name, "", "Specify the images to use for OpenShift")
 	clusterUpFlagSet.AddFlag(cmdUtil.HttpProxyFlag)
 	clusterUpFlagSet.AddFlag(cmdUtil.HttpsProxyFlag)
+	// This is hidden because we don't want our users to use this flag
+	// we are setting it to openshift/origin-${component}:<user_provided_version> as default
+	// It is used for testing purpose from CDK/minishift QE
+	clusterUpFlagSet.MarkHidden(configCmd.ImageName.Name)
 
 	if minishiftConfig.EnableExperimental {
 		clusterUpFlagSet.String(configCmd.ExtraClusterUpFlags.Name, "", "Specify optional flags for use with 'cluster up' (unsupported)")
@@ -774,6 +779,10 @@ func determineClusterUpParameters(config *clusterup.ClusterUpConfig) map[string]
 	if valid {
 		// Set default value for base config for 3.10
 		clusterUpParams["base-dir"] = baseDirectory
+		if viper.GetString(configCmd.ImageName.Name) == "" {
+			imagetag := fmt.Sprintf("'%s:%s'", minishiftConstants.ImageNameForClusterUpImageFlag, config.OpenShiftVersion)
+			viper.Set(configCmd.ImageName.Name, imagetag)
+		}
 	} else {
 		// This will only required to work with openshift < 3.10
 		for key, value := range dataDirectory {

--- a/pkg/minishift/clusterup/clusterup.go
+++ b/pkg/minishift/clusterup/clusterup.go
@@ -111,8 +111,8 @@ func ClusterUp(config *ClusterUpConfig, clusterUpParams map[string]string) (stri
 }
 
 // AddComponent add a component to running Openshift cluster
-func AddComponent(sshCommander provision.SSHCommander, ocBinaryPathInsideVM string, basedir string, componentName string) (string, error) {
-	cmdArgs := []string{"cluster", "add", fmt.Sprintf("--base-dir=%s", basedir), componentName}
+func AddComponent(sshCommander provision.SSHCommander, ocBinaryPathInsideVM string, basedir string, componentName string, imageToUse string) (string, error) {
+	cmdArgs := []string{"cluster", "add", fmt.Sprintf("--base-dir=%s", basedir), fmt.Sprintf("--image=%s", imageToUse), componentName}
 	if glog.V(2) {
 		fmt.Printf("-- Running 'oc' with: '%s'\n", strings.Join(cmdArgs, " "))
 	}

--- a/pkg/minishift/constants/constants.go
+++ b/pkg/minishift/constants/constants.go
@@ -24,20 +24,21 @@ import (
 )
 
 const (
-	B2dIsoAlias                 = "b2d"
-	CentOsIsoAlias              = "centos"
-	OpenshiftContainerName      = "origin"
-	OpenshiftApiContainerLabel  = "io.kubernetes.container.name=apiserver"
-	KubernetesApiContainerLabel = "io.kubernetes.container.name=api"
-	OpenshiftExec               = "/usr/bin/openshift"
-	OpenshiftOcExec             = "/usr/bin/oc"
-	DefaultProject              = "myproject"
-	DefaultUser                 = "developer"
-	DefaultUserPassword         = "developer"
-	SkipVerifyInsecureTLS       = "insecure-skip-tls-verify=true"
-	BinaryName                  = "minishift"
-	OcPathInsideVM              = "/var/lib/minishift/bin"
-	BaseDirInsideInstance       = "/var/lib/minishift/base"
+	B2dIsoAlias                    = "b2d"
+	CentOsIsoAlias                 = "centos"
+	OpenshiftContainerName         = "origin"
+	OpenshiftApiContainerLabel     = "io.kubernetes.container.name=apiserver"
+	KubernetesApiContainerLabel    = "io.kubernetes.container.name=api"
+	OpenshiftExec                  = "/usr/bin/openshift"
+	OpenshiftOcExec                = "/usr/bin/oc"
+	DefaultProject                 = "myproject"
+	DefaultUser                    = "developer"
+	DefaultUserPassword            = "developer"
+	SkipVerifyInsecureTLS          = "insecure-skip-tls-verify=true"
+	BinaryName                     = "minishift"
+	OcPathInsideVM                 = "/var/lib/minishift/bin"
+	BaseDirInsideInstance          = "/var/lib/minishift/base"
+	ImageNameForClusterUpImageFlag = "openshift/origin-${component}"
 )
 
 var (

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -24,7 +24,11 @@ Feature: Basic
   Scenario: Starting Minishift
     Given Minishift has state "Does Not Exist"
       And image caching is disabled
-     When executing "minishift start" succeeds
+     When executing "minishift start --v=5" succeeds
+     Then stdout should contain
+      """
+      --image 'openshift/origin-${component}
+      """
      Then Minishift should have state "Running"
      When executing "minishift image list" succeeds
      Then stdout should be empty


### PR DESCRIPTION
Fixes #2789 

Steps to test the pull request

  1. minishift start --v=5 should shows
Running 'oc' with: 'cluster up --base-dir /var/lib/minishift/base --image 'openshift/origin-${component}:v3.10.0' ...
  2. minishift start --openshift-version 3.9.0 should also success but not use the `--image` option
  3. image option should not be listed in the start flag.
  4. After minishift start => minishift ssh -- docker images => contain all the images with same tag.

