### PR TITLE
Issue #2792 Add save-start-flags bool option to config

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -152,6 +152,9 @@ var (
 
 	// Hyper-V
 	HypervVirtualSwitch = createConfigSetting("hyperv-virtual-switch", SetString, []setFn{validations.IsValidHypervVirtualSwitch}, nil, true, nil)
+
+	// Save start flags to viper config
+	SaveStartFlags = createConfigSetting("save-start-flags", SetBool, nil, nil, true, true)
 )
 
 func createConfigSetting(name string, set func(validations.ViperConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool, defaultVal interface{}) *Setting {

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -190,7 +190,10 @@ func runStart(cmd *cobra.Command, args []string) {
 		preflightChecksBeforeStartingHost()
 	}
 
-	populateStartFlagsToViperConfig()
+	// Populate start flags to viper config if save-start-flags true in config file
+	if viper.GetBool(configCmd.SaveStartFlags.Name) {
+		populateStartFlagsToViperConfig()
+	}
 
 	// Cache OC binary before starting the VM and perform oc command option check
 	ocPath = cmdUtil.CacheOc(requestedOpenShiftVersion)

--- a/docs/source/using/basic-usage.adoc
+++ b/docs/source/using/basic-usage.adoc
@@ -191,6 +191,11 @@ Persistent configuration can only be applied to the set of supported configurati
 This is different from environment variables, which can be used to replace any option of any command.
 ====
 
+[NOTE]
+====
+By Default minishift persist start flags to peristent configuration, to disable it, use `minishift config set save-start-flags false`.
+====
+
 [[setting-persistent-configuration-values]]
 ==== Setting Persistent Configuration Values
 


### PR DESCRIPTION
Fixes #2792


Steps to test the pull request

  1. ./minishift start --cpus 3 --memory 6GB
  2. ./minishift config view => this will contain cpus and memory value
  3. ./minishift config set save-start-flags false
  4. ./minishift unset cpus
  5. ./minishift unset memory
  6. ./minishift start --cpus 3 --memory 6GB
  7. ./minishift config view => this will now not keep record of start flags.

