### PR TITLE
Issue #2163 Fix minishift ip command in case instance doesn't exist

### DIFF
--- a/cmd/minishift/cmd/ip.go
+++ b/cmd/minishift/cmd/ip.go
@@ -42,6 +42,8 @@ var ipCmd = &cobra.Command{
 		api := libmachine.NewClient(state.InstanceDirs.Home, state.InstanceDirs.Certs)
 		defer api.Close()
 
+		cmdUtil.ExitIfUndefined(api, constants.MachineName)
+
 		if configureAsStatic && configureAsDynamic {
 			atexit.ExitWithMessage(1, "Invalid options specified")
 		}

--- a/test/integration/features/cmd-profile.feature
+++ b/test/integration/features/cmd-profile.feature
@@ -164,7 +164,7 @@ Feature: Profile commands
      When executing "minishift delete --force" succeeds
      Then Minishift should have state "Does Not Exist"
      When executing "minishift ip"
-     Then exitcode should equal "1"
+     Then exitcode should equal "0"
 
   Scenario: As user, I cannot create profile when used along with profile <subcommand> --profile name
     Given Minishift has state "Does Not Exist"


### PR DESCRIPTION
Fixes #2163


Steps to test the pull request

  1. ./minishift ip
Running this command requires an existing 'minishift' VM, but no VM is defined.


