### PR TITLE
Issue #2717 cache origin-control-plane image if openshift >= 3.10

### DIFF
--- a/pkg/minishift/docker/image/image.go
+++ b/pkg/minishift/docker/image/image.go
@@ -18,6 +18,8 @@ package image
 
 import (
 	"fmt"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	openshiftVersion "github.com/minishift/minishift/pkg/minishift/openshift/version"
 	"github.com/minishift/minishift/pkg/util/os"
 	"github.com/minishift/minishift/pkg/util/os/process"
 	"io"
@@ -40,8 +42,13 @@ type ImageCacheConfig struct {
 
 // GetOpenShiftImageNames returns the full images names for the images requires for a fully functioning OpenShift instance
 func GetOpenShiftImageNames(version string) []string {
+	valid, _ := openshiftVersion.IsGreaterOrEqualToBaseVersion(version, constants.RefactoredOcVersion)
+	imageName := fmt.Sprintf("openshift/origin:%s", version)
+	if valid {
+		imageName = fmt.Sprintf("openshift/origin-control-plane:%s", version)
+	}
 	return []string{
-		fmt.Sprintf("openshift/origin:%s", version),
+		imageName,
 		fmt.Sprintf("openshift/origin-docker-registry:%s", version),
 		fmt.Sprintf("openshift/origin-haproxy-router:%s", version),
 	}

--- a/test/integration/features/cmd-image.feature
+++ b/test/integration/features/cmd-image.feature
@@ -17,7 +17,7 @@ Feature: Basic image caching test
       And image export completes with 3 images within 20 minutes
       And container image "openshift\/origin-haproxy-router:v[0-9]+\.[0-9]+\.[0-9]+" is cached
       And container image "openshift\/origin-docker-registry:v[0-9]+\.[0-9]+\.[0-9]+" is cached
-      And container image "openshift\/origin:v[0-9]+\.[0-9]+\.[0-9]+" is cached
+      And container image "openshift\/origin-control-plane:v[0-9]+\.[0-9]+\.[0-9]+" is cached
       And executing "minishift image export alpine:latest" succeeds
      Then stdout of command "minishift image list" contains "alpine:latest"
 
@@ -40,7 +40,7 @@ Feature: Basic image caching test
      """
 
      When executing "minishift start" succeeds
-     Then stdout should match "Importing 'openshift\/origin:v[0-9]+\.[0-9]+\.[0-9]+' [\.]+ OK"
+     Then stdout should match "Importing 'openshift\/origin-control-plane:v[0-9]+\.[0-9]+\.[0-9]+' [\.]+ OK"
       And stdout should match "Importing 'openshift\/origin-docker-registry:v[0-9]+\.[0-9]+\.[0-9]+' [\.]+ OK"
       And stdout should match "Importing 'openshift\/origin-haproxy-router:v[0-9]+\.[0-9]+\.[0-9]+' [\.]+ OK"
 


### PR DESCRIPTION
Fixes #2717 


Steps to test the pull request

  1.  `minishift start` => this should now cache the `origin-control-plane` image.
  2.  `minishif delete`
  3.  `minishift start` => this should consume the `origin-control-plane` image.

