### PR TITLE
Issue #2555 Add tail option for minishift logs

### DIFF
--- a/cmd/minishift/cmd/logs.go
+++ b/cmd/minishift/cmd/logs.go
@@ -29,6 +29,7 @@ import (
 
 var (
 	follow bool
+	tail   int64
 )
 
 // logsCmd represents the logs command
@@ -39,7 +40,7 @@ var logsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		api := libmachine.NewClient(state.InstanceDirs.Home, state.InstanceDirs.Certs)
 		defer api.Close()
-		s, err := cluster.GetHostLogs(api, follow)
+		s, err := cluster.GetHostLogs(api, follow, tail)
 		if err != nil {
 			atexit.ExitWithMessage(1, fmt.Sprintf("Error getting logs: %s", err.Error()))
 		}
@@ -48,6 +49,7 @@ var logsCmd = &cobra.Command{
 }
 
 func init() {
-	logsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Continously print the logs entries.")
+	logsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Continuously print the logs entries")
+	logsCmd.Flags().Int64VarP(&tail, "tail", "t", -1, "Number of lines to show from the end of the logs")
 	RootCmd.AddCommand(logsCmd)
 }

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -60,7 +60,7 @@ func TestLocalBoot2DockerURL(t *testing.T) {
 	assert.Equal(t, localISOUrl, url)
 }
 
-func TestFollowLogsFlag(t *testing.T) {
+func TestFollowAndTailLogsFlag(t *testing.T) {
 	api := tests.NewMockAPI()
 
 	s, _ := tests.NewSSHServer()
@@ -79,21 +79,29 @@ func TestFollowLogsFlag(t *testing.T) {
 	testCases := []struct {
 		expectedCommand string
 		follow          bool
+		tail            int64
 	}{
 		{
 			expectedCommand: logsCmd,
 			follow:          false,
+			tail:            -1,
 		},
 		{
 			expectedCommand: logsCmdFollow,
 			follow:          true,
+			tail:            -1,
+		},
+		{
+			expectedCommand: logsCmdFollow,
+			follow:          true,
+			tail:            10,
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.expectedCommand, func(t *testing.T) {
-			_, err := GetHostLogs(api, test.follow)
-			assert.NoError(t, err, "Error gettinglogsof the running OpenShift cluster")
+			_, err := GetHostLogs(api, test.follow, test.tail)
+			assert.NoError(t, err, "Error getting logs of the running OpenShift cluster")
 			_, ok := s.Commands[test.expectedCommand]
 			assert.True(t, ok, "Expected command to run but did not")
 		})


### PR DESCRIPTION
Fix #2555 

**Steps to Test**
- `make` to get binary from this PR
- `minishift start`
- `minishift logs -t 10` or `minishift logs --tail 10`.

**Testing Scenarios**
- `minishift logs`
- `minishift logs -f`
- `minishift logs -t 10` or some number you like
- `minishift logs -t 10 -f`