### PR TITLE
Issue #2827 Addon: Implement cat as a addon command

### DIFF
--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -161,6 +161,11 @@ sleep::
 If the add-on command starts with `sleep`, it waits for the specified number of seconds.
 This can be useful in cases where you know that a command such as `oc` might take a few seconds before a certain resource can be queried.
 
+cat::
+If the add-on command starts with `cat`, the arguments following the `cat` command should be a valid file path.
+This will print the file content to the console for valid file otherwise displays error message about the non-non-existence of file.
+This can be useful in case you want to use a file content with other command.
+
 [NOTE]
 ====
 Trying to use an undefined command will cause an error when the add-on gets parsed.

--- a/pkg/minishift/addon/command/cat_command.go
+++ b/pkg/minishift/addon/command/cat_command.go
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type CatCommand struct {
+	*defaultCommand
+}
+
+func NewCatCommand(command string, ignoreError bool, outputVariable string) *CatCommand {
+	defaultCommand := &defaultCommand{rawCommand: command, ignoreError: ignoreError, outputVariable: outputVariable}
+	catCommand := &CatCommand{defaultCommand}
+	defaultCommand.fn = catCommand.doExecute
+	return catCommand
+}
+
+func (c *CatCommand) doExecute(ec *ExecutionContext, ignoreError bool, outputVariable string) error {
+	var (
+		err   error
+		f     *os.File
+		fInfo os.FileInfo
+	)
+
+	// split off the actual 'cat' command. As we need to get file name of remaining string.
+	catString := strings.TrimPrefix(c.rawCommand, "cat")
+	fileName := strings.Replace(catString, " ", "", 1)
+
+	if fInfo, err = os.Stat(fileName); os.IsNotExist(err) {
+		return errors.New(fmt.Sprintf("File %s doesn't exist", fileName))
+	}
+
+	f, err = os.Open(fileName)
+	defer f.Close()
+	fileSize := fInfo.Size()
+	buffer := make([]byte, fileSize)
+	_, err = f.Read(buffer)
+
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error executing command '%s':", err.Error()))
+	}
+
+	if outputVariable != "" {
+		ec.AddToContext(outputVariable, strings.TrimSpace(string(buffer)))
+		return nil
+	}
+	fmt.Printf("%s", string(buffer))
+	return nil
+}

--- a/pkg/minishift/addon/command/cat_command_test.go
+++ b/pkg/minishift/addon/command/cat_command_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"io/ioutil"
+	"testing"
+
+	pkgTesting "github.com/minishift/minishift/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"os"
+)
+
+func Test_cat_command_when_file_exist(t *testing.T) {
+
+	// Creating a tmp file with test content.
+	content := []byte("This file to used to test the cat command output.")
+	tmpfile, err := ioutil.TempFile("", "test.txt")
+	assert.NoError(t, err)
+
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	_, err = tmpfile.Write(content)
+	assert.NoError(t, err)
+
+	err = tmpfile.Close()
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		catCommand     string
+		expectedOutput string
+		ignoreError    bool
+	}{
+		{
+			catCommand:     tmpfile.Name(),
+			expectedOutput: "This file to used to test the cat command output.",
+			ignoreError:    false,
+		},
+	}
+
+	for _, test := range testCases {
+		tee, err := pkgTesting.NewTee(true)
+		defer tee.Close()
+		assert.NoError(t, err, "Error getting instance of Tee")
+
+		cat := NewCatCommand(test.catCommand, test.ignoreError, "")
+		context := &FakeInterpolationContext{}
+		err = cat.Execute(&ExecutionContext{interpolationContext: context})
+		assert.NoError(t, err)
+		tee.Close()
+
+		assert.Equal(t, tee.StdoutBuffer.String(), test.expectedOutput)
+	}
+}
+
+func Test_cat_command_when_file_not_exist(t *testing.T) {
+	testCases := []struct {
+		catCommand     string
+		expectedOutput string
+		ignoreError    bool
+		expectedError  string
+	}{
+		{
+			catCommand:     "dummy",
+			expectedOutput: "",
+			ignoreError:    false,
+			expectedError:  "File dummy doesn't exist",
+		},
+	}
+
+	for _, test := range testCases {
+		tee, err := pkgTesting.NewTee(true)
+		defer tee.Close()
+		assert.NoError(t, err, "Error getting instance of Tee")
+
+		cat := NewCatCommand(test.catCommand, test.ignoreError, "")
+		context := &FakeInterpolationContext{}
+		err = cat.Execute(&ExecutionContext{interpolationContext: context})
+		assert.EqualError(t, err, test.expectedError)
+		tee.Close()
+	}
+}

--- a/pkg/minishift/addon/parser/addon_parser.go
+++ b/pkg/minishift/addon/parser/addon_parser.go
@@ -68,6 +68,9 @@ func NewAddOnParser() *AddOnParser {
 	echoHandler := &EchoCommandHandler{&defaultCommandHandler{}}
 	sshHandler.SetNext(echoHandler)
 
+	catHandler := &CatCommandHandler{&defaultCommandHandler{}}
+	echoHandler.SetNext(catHandler)
+
 	parser.handler = ocHandler
 
 	return &parser

--- a/pkg/minishift/addon/parser/command_handler.go
+++ b/pkg/minishift/addon/parser/command_handler.go
@@ -31,6 +31,7 @@ const (
 	sleepCommand     = "sleep"
 	sshCommand       = "ssh"
 	echoCommand      = "echo"
+	catCommand       = "cat"
 )
 
 type CommandHandler interface {
@@ -127,6 +128,17 @@ type EchoCommandHandler struct {
 func (c *EchoCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
 	if strings.HasPrefix(s, echoCommand) {
 		return command.NewEchoCommand(s, ignoreError)
+	}
+	return nil
+}
+
+type CatCommandHandler struct {
+	*defaultCommandHandler
+}
+
+func (c *CatCommandHandler) Parse(s string, ignoreError bool, outputVariable string) command.Command {
+	if strings.HasPrefix(s, catCommand) {
+		return command.NewCatCommand(s, ignoreError, outputVariable)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #2827 


Steps to test the pull request
```
$ cat test/test.addon 
# Name: test
# Description: To test out cat command feature

output := cat dummy.txt

echo "Here is my dummy file content"
echo "#{output}"

$ cat test/dummy.txt 
This file is used to
test the cat command
of the addon

$ ./minishift addon install test

$./minishift apply addon test
-- Applying addon 'test':
"Here is my dummy file content"
"This file is used to
test the cat command
of the addon"
```

