### PR TITLE
Issue #2819 Add codecov.io into make tests and Travis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: new
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: no       # [yes :: must have a head report to post]
+  branches: null

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,13 @@ install:
 - chmod +x /tmp/godep/dep
 - export PATH=$PATH:/tmp/godep/
 
-script:
-- make prerelease
+script: |
+  make prerelease
+  make coverage
+
+after_success: |
+  cd out
+  bash <(curl -s https://codecov.io/bash)
 
 notifications:
   webhooks: http://minibot.19cf262c.svc.dockerapp.io:9009/hubot/travis-ci

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,11 @@ clean_bindata:
 test: $(ADDON_ASSET_FILE)  ## Run unit tests
 	@go test -v -tags "$(BUILD_TAGS_SYSTEMTRAY)" -ldflags="$(VERSION_VARIABLES)" $(shell $(PACKAGES))
 
+.PHONY: coverage
+coverage: $(ADDON_ASSET_FILE)
+	rm -f out/coverage.txt
+	@go test -v -tags "$(BUILD_TAGS_SYSTEMTRAY)" -ldflags="$(VERSION_VARIABLES)" -coverprofile=out/coverage.txt -covermode=atomic $(shell $(PACKAGES))
+
 .PHONY: integration ## Run integration tests (quick and minimal)
 integration: GODOG_OPTS = --tags=quick\&\&~disabled
 integration: $(MINISHIFT_BINARY)

--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -185,6 +185,14 @@ For more {project} commands and flags, see the xref:../command-ref/minishift.ado
 === Unit Tests
 
 Unit tests run on *Travis* before the code is merged.
+Unit test coverage is then reported to *Codecov* which provides coverage information on the pull requests.
+Locally you can generate a HTML code coverage report by following steps:
+
+----
+$ make coverage
+$ go tool cover -html=out/coverage.txt -o out/coverage.html
+----
+
 To run tests during the development cycle:
 
 ----


### PR DESCRIPTION
Fixes #2819

Steps to test the pull request

  1. you can see it working on my fork: https://codecov.io/gh/agajdosi/minishift and https://travis-ci.org/agajdosi/minishift
  2. as admin of Minishift project you can enable Minishift project in codecov.io and then next build of this PR would probably upload the report
