### PR TITLE
Issue #2850 Add a way to skip integration test for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ ci_release: ## Trigger a release via CentOS CI. Needs API_KEY and RELEASE_VERSIO
 
 	curl -s -H "$(shell curl -s --user 'minishift:$(API_KEY)' 'https://ci.centos.org//crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')" \
 	-X POST https://ci.centos.org/job/minishift-release/build --user 'minishift:$(API_KEY)' \
-	--data-urlencode json='{"parameter": [{"name":"RELEASE_VERSION", "value":'"$(RELEASE_VERSION)"'}]}'
+	--data-urlencode json='{"parameter": [{"name":"RELEASE_VERSION", "value":'"$(RELEASE_VERSION)"'}, {"name":"SKIP_INTEGRATION_TEST", "value":"false"}]}'
 
 .PHONY: cross ## Cross compiles all binaries
 cross: $(BUILD_DIR)/darwin-amd64/minishift $(BUILD_DIR)/linux-amd64/minishift $(BUILD_DIR)/windows-amd64/minishift.exe

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -29,7 +29,7 @@ LATEST="latest"
 function load_jenkins_vars() {
   if [ -e "jenkins-env" ]; then
     cat jenkins-env \
-      | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId|GH_TOKEN|CICO_API_KEY|API_TOKEN|JOB_NAME|RELEASE_VERSION|GITHUB_TOKEN|REPO|BRANCH)=" \
+      | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId|GH_TOKEN|CICO_API_KEY|API_TOKEN|JOB_NAME|RELEASE_VERSION|GITHUB_TOKEN|REPO|BRANCH|SKIP_INTEGRATION_TEST)=" \
       | sed 's/^/export /g' \
       > ~/.jenkins-env
     source ~/.jenkins-env
@@ -313,8 +313,10 @@ function perform_release() {
   make prerelease
   exit_on_failure "$?" "Pre-release tests failed."
 
-  MINISHIFT_VM_DRIVER=kvm make integration_pr
-  exit_on_failure "$?" "Integration tests failed."
+  if [ "$SKIP_INTEGRATION_TEST" = false ]; then
+    MINISHIFT_VM_DRIVER=kvm make integration_pr
+    exit_on_failure "$?" "Integration tests failed."
+  fi
 
   make link_check_docs # Test docs builds and all links are valid
   exit_on_failure "$?" "Documentation build failed."

--- a/docs/source/contributing/releasing.adoc
+++ b/docs/source/contributing/releasing.adoc
@@ -45,6 +45,12 @@ The automated release performs:
 - xref:../contributing/releasing.adoc#trigger-docs-build[Triggering the Documentation Build]
 - xref:../contributing/releasing.adoc#post-release-tasks[Perform Post-Release Tasks]
 
+
+[NOTE]
+====
+If the CI release job is failing for a known reason then you can skip the integration tests by changing the `SKIP_INTEGRATION_TEST` value to `true` in Makefile.
+====
+
 [[manaul-release]]
 == Manual Release
 


### PR DESCRIPTION
Fixes #2850 


Steps to test the pull request

  1. Change in the Makefile set `SKIP_INTEGRATION_TEST` value as `true`
  2. run `make ci_release` should not execute the `integration tests`

