### PR TITLE
Issue #2854 Add timezone flag to start and a timezone command

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -58,6 +58,7 @@ var (
 	RemoteIPAddress       = createConfigSetting("remote-ipaddress", SetString, nil, nil, true, nil)
 	RemoteSSHUser         = createConfigSetting("remote-ssh-user", SetString, nil, nil, true, nil)
 	SSHKeyToConnectRemote = createConfigSetting("remote-ssh-key", SetString, nil, nil, true, nil)
+	TimeZone              = createConfigSetting("timezone", SetString, []setFn{validations.IsValidTimezone}, nil, true, nil)
 
 	// cluster up
 	SkipRegistryCheck = createConfigSetting("skip-registry-check", SetBool, nil, nil, true, nil)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/minishift/minishift/pkg/minishift/timezone"
 	"os"
 	"runtime"
 	"strings"
@@ -199,6 +200,11 @@ func runStart(cmd *cobra.Command, args []string) {
 	fmt.Print("-- Starting the OpenShift cluster")
 
 	hostVm := startHost(libMachineClient)
+	if !isRestart {
+		minishiftConfig.InstanceStateConfig.TimeZone = viper.GetString(configCmd.TimeZone.Name)
+		minishiftConfig.InstanceStateConfig.Write()
+	}
+	timezone.SetTimeZone(hostVm)
 	registrationUtil.RegisterHost(libMachineClient)
 
 	// Forcibly set nameservers when configured
@@ -685,6 +691,7 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.String(configCmd.RemoteSSHUser.Name, "", "The username of the remote machine to provision OpenShift on")
 	startFlagSet.String(configCmd.SSHKeyToConnectRemote.Name, "", "SSH private key location on the host to connect remote machine")
 	startFlagSet.String(configCmd.ISOUrl.Name, minishiftConstants.CentOsIsoAlias, "Location of the minishift ISO. Can be a URL, file URI or one of the following short names: [centos b2d].")
+	startFlagSet.String(configCmd.TimeZone.Name, constants.DefaultTimeZone, "TimeZone for Minishift VM")
 
 	startFlagSet.AddFlag(dockerEnvFlag)
 	startFlagSet.AddFlag(dockerEngineOptFlag)

--- a/cmd/minishift/cmd/timezone.go
+++ b/cmd/minishift/cmd/timezone.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/minishift/minishift/pkg/minishift/timezone"
+	"time"
+
+	"github.com/docker/machine/libmachine"
+	"github.com/minishift/minishift/cmd/minishift/cmd/util"
+	"github.com/minishift/minishift/cmd/minishift/state"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	"github.com/spf13/cobra"
+)
+
+// stopCmd represents the stop command
+var (
+	timezoneCmd = &cobra.Command{
+		Use:    "timezone",
+		Short:  "Set timezone for running Minishift Instance",
+		Long:   `Set timezone for running Minishift Instance, provided timezone should be valid.`,
+		Run:    runTimezone,
+		Hidden: true,
+	}
+	set  string
+	list bool
+)
+
+func runTimezone(cmd *cobra.Command, args []string) {
+	api := libmachine.NewClient(state.InstanceDirs.Home, state.InstanceDirs.Certs)
+	defer api.Close()
+
+	// if VM does not exist, exit with error
+	util.ExitIfUndefined(api, constants.MachineName)
+
+	hostVm, err := api.Load(constants.MachineName)
+	if err != nil {
+		atexit.ExitWithMessage(1, err.Error())
+	}
+
+	if list {
+		out, err := timezone.GetTimeZoneList(hostVm)
+		if err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		}
+		fmt.Println(out)
+		return
+	}
+
+	if set == "" {
+		out, err := timezone.GetTimeZone(hostVm)
+		if err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		}
+		fmt.Println(out)
+		return
+	}
+	_, err = time.LoadLocation(set)
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("%s is not a vaild timezone: %s", set, err.Error()))
+	}
+
+	fmt.Printf("Setting timezone for Instance ... ")
+	if err := timezone.UpdateTimeZoneInConfig(set); err != nil {
+		atexit.ExitWithMessage(1, err.Error())
+	}
+	if err := timezone.SetTimeZone(hostVm); err != nil {
+		atexit.ExitWithMessage(1, err.Error())
+	}
+	fmt.Println("OK")
+}
+
+func init() {
+	timezoneCmd.Flags().StringVarP(&set, "set", "s", "", "Set the provided timezone.")
+	timezoneCmd.Flags().BoolVarP(&list, "list", "l", false, "List of the available timezone to Minishift Instance")
+	RootCmd.AddCommand(timezoneCmd)
+}

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -324,3 +324,23 @@ the following command:
 $ minishift config set auto-start-tray false
 ----
 
+[[timezone]]
+== Timezone Setup
+
+If you want to set a different timezone from the default one, use the following command:
+
+----
+$ minishift timezone --set <Valid_Timezome>
+----
+
+To check the available timezone, use the following command:
+
+----
+$ minishift timezone --list
+----
+
+To check current timezone of {project} instance, use the following command:
+
+----
+$ minishift timezone
+----

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -36,6 +36,7 @@ const (
 	UpdateMarkerFileName             = "updated"
 	DefaultMachineName               = "minishift"
 	DefaultProfileName               = "minishift"
+	DefaultTimeZone                  = "UTC" // This is what we have in our ISO kickstart template.
 )
 
 var (

--- a/pkg/minishift/config/instance_state_config.go
+++ b/pkg/minishift/config/instance_state_config.go
@@ -34,6 +34,7 @@ type InstanceStateConfigType struct {
 	SupportsNetworkAssignment bool                      // minishift state
 	SupportsDnsmasqServer     bool                      // minishift state
 	OpenshiftVersion          string                    // minishift state
+	TimeZone                  string                    // minishift state
 	HostFolders               []config.HostFolderConfig // This is temporary and should be removed after 2-3 release.
 
 	VMDriver string // general config

--- a/pkg/minishift/config/validations.go
+++ b/pkg/minishift/config/validations.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	units "github.com/docker/go-units"
 	"github.com/minishift/minishift/pkg/util/filehelper"
@@ -228,6 +229,14 @@ func IsValidPort(name string, p string) error {
 func IsSystemTrayAvailable(_ string, _ string) error {
 	if runtime.GOOS == "linux" {
 		return fmt.Errorf("System tray is not available in linux.")
+	}
+	return nil
+}
+
+func IsValidTimezone(_ string, timezone string) error {
+	_, err := time.LoadLocation(timezone)
+	if err != nil {
+		return fmt.Errorf("%s is not a vaild timezone: %s", timezone, err.Error())
 	}
 	return nil
 }

--- a/pkg/minishift/config/validations_test.go
+++ b/pkg/minishift/config/validations_test.go
@@ -289,3 +289,26 @@ func TestValidPort(t *testing.T) {
 	}
 	runValidations(t, tests, "hostfolders-sftp-port", IsValidPort)
 }
+
+func TestValidTimezone(t *testing.T) {
+
+	var tests = []validationTest{
+		{
+			value:     "Europe/Berli",
+			shouldErr: true,
+		},
+		{
+			value:     "APAC",
+			shouldErr: true,
+		},
+		{
+			value:     "Europe/Berlin",
+			shouldErr: false,
+		},
+		{
+			value:     "UTC",
+			shouldErr: false,
+		},
+	}
+	runValidations(t, tests, "timezone", IsValidTimezone)
+}

--- a/pkg/minishift/timezone/timezone.go
+++ b/pkg/minishift/timezone/timezone.go
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timezone
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/provision"
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
+)
+
+func SetTimeZone(host *host.Host) error {
+	if minishiftConfig.InstanceStateConfig != nil {
+		cmd := fmt.Sprintf("sudo timedatectl set-timezone '%s'", minishiftConfig.InstanceStateConfig.TimeZone)
+		sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+		if _, err := sshCommander.SSHCommand(cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func UpdateTimeZoneInConfig(timezone string) error {
+	if minishiftConfig.InstanceStateConfig == nil {
+		minishiftConfig.InstanceStateConfig, _ = minishiftConfig.NewInstanceStateConfig(minishiftConstants.GetInstanceStateConfigPath())
+	}
+	minishiftConfig.InstanceStateConfig.TimeZone = timezone
+	return minishiftConfig.InstanceStateConfig.Write()
+}
+
+func GetTimeZone(host *host.Host) (string, error) {
+	cmd := "sudo timedatectl status"
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+	output, err := sshCommander.SSHCommand(cmd)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func GetTimeZoneList(host *host.Host) (string, error) {
+	cmd := "sudo timedatectl list-timezones"
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+	output, err := sshCommander.SSHCommand(cmd)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -24,7 +24,7 @@ Feature: Basic
   Scenario: Starting Minishift
     Given Minishift has state "Does Not Exist"
       And image caching is disabled
-     When executing "minishift start --v=5" succeeds
+     When executing "minishift start --v=5 --timezone Asia/Kolkata" succeeds
      Then stdout should contain
       """
       --image 'openshift/origin-${component}
@@ -32,6 +32,11 @@ Feature: Basic
      Then Minishift should have state "Running"
      When executing "minishift image list" succeeds
      Then stdout should be empty
+     When executing "minishift timezone" succeeds
+     Then stdout should contain
+     """
+     Asia/Kolkata
+     """
 
   Scenario: OpenShift is ready after startup
     After startup of Minishift OpenShift instance should respond correctly on its html endpoints


### PR DESCRIPTION
Fixes #2854 


Steps to test the pull request
```
$ minishift start 
$ minishift timezone
      Local time: Fri 2018-10-05 08:55:35 EDT
  Universal time: Fri 2018-10-05 12:55:35 UTC
        RTC time: Fri 2018-10-05 12:55:33
       Time zone: America/New_York (EDT, -0400)
     NTP enabled: n/a
NTP synchronized: no
 RTC in local TZ: no
      DST active: yes
 Last DST change: DST began at
                  Sun 2018-03-11 01:59:59 EST
                  Sun 2018-03-11 03:00:00 EDT
 Next DST change: DST ends (the clock jumps one hour backwards) at
                  Sun 2018-11-04 01:59:59 EDT
                  Sun 2018-11-04 01:00:00 EST

$ minishift delete
$ minishift start --timezone Asia/Kolkata

$ ./minishift ssh -- sudo timedatectl status
      Local time: Fri 2018-10-05 18:47:27 IST
  Universal time: Fri 2018-10-05 13:17:27 UTC
        RTC time: Fri 2018-10-05 13:17:24
       Time zone: Asia/Kolkata (IST, +0530)
     NTP enabled: n/a
NTP synchronized: no
 RTC in local TZ: no
      DST active: n/a

$ ./minishift timezone -s America/New_York
Setting timezone for Instance ...OK

$ ./minishift timezone
      Local time: Fri 2018-10-05 09:18:03 EDT
  Universal time: Fri 2018-10-05 13:18:03 UTC
        RTC time: Fri 2018-10-05 13:18:00
       Time zone: America/New_York (EDT, -0400)
     NTP enabled: n/a
NTP synchronized: no
 RTC in local TZ: no
      DST active: yes
 Last DST change: DST began at
                  Sun 2018-03-11 01:59:59 EST
                  Sun 2018-03-11 03:00:00 EDT
 Next DST change: DST ends (the clock jumps one hour backwards) at
                  Sun 2018-11-04 01:59:59 EDT
                  Sun 2018-11-04 01:00:00 EST
```


