### PR TITLE
Issue #2629 set static ip after minishift instance start

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -167,6 +167,9 @@ var (
 
 	// Systemtray
 	AutoStartTray = createConfigSetting("auto-start-tray", SetBool, []setFn{validations.IsSystemTrayAvailable}, nil, true, true)
+
+	// Static-IP
+	StaticIPAutoSet = createConfigSetting("static-ip", SetBool, nil, nil, true, true)
 )
 
 func createConfigSetting(name string, set func(validations.ViperConfig, string, string) error, validations []setFn, callbacks []setFn, isApply bool, defaultVal interface{}) *Setting {

--- a/cmd/minishift/cmd/ip.go
+++ b/cmd/minishift/cmd/ip.go
@@ -57,7 +57,11 @@ var ipCmd = &cobra.Command{
 		if configureAsDynamic {
 			minishiftNetwork.ConfigureDynamicAssignment(host.Driver)
 		} else if configureAsStatic {
-			minishiftNetwork.ConfigureStaticAssignment(host.Driver)
+			msg, err := minishiftNetwork.ConfigureStaticAssignment(host.Driver)
+			if err != nil {
+				atexit.ExitWithMessage(1, err.Error())
+			}
+			fmt.Println(msg)
 		} else {
 			ip, err := minishiftNetwork.GetIP(host.Driver)
 			if err != nil {

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -235,9 +235,12 @@ func runStart(cmd *cobra.Command, args []string) {
 		proxyConfig.ApplyToEnvironment()
 	}
 
-	// preflight checks (after start)
+	// preflight checks and set static-ip (after start)
 	if viper.GetString(configCmd.VmDriver.Name) != genericDriver {
 		preflightChecksAfterStartingHost(hostVm.Driver)
+		if viper.GetBool(configCmd.StaticIPAutoSet.Name) {
+			setStaticIP(hostVm)
+		}
 	}
 
 	// Adding active profile information to all instance config
@@ -891,4 +894,17 @@ func startTray() error {
 		}
 	}
 	return nil
+}
+
+func setStaticIP(hostVm *host.Host) {
+	fmt.Print("-- Writing current configuration for static assignment of IP address ... ")
+	_, err := minishiftNetwork.ConfigureStaticAssignment(hostVm.Driver)
+	if err != nil {
+		fmt.Println("WARN")
+		if glog.V(2) {
+			fmt.Println(err)
+		}
+	} else {
+		fmt.Println("OK")
+	}
 }

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -45,34 +45,6 @@ For OKD 3.10.0 or later the command is:
 $ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--enable=*,service-catalog'"
 ----
 
-[[set-fixed-ip]]
-== Set Fixed IP Address
-
-[IMPORTANT]
-====
-This only works with the CentOS or RHEL xref:../using/basic-usage.adoc#choosing-iso-image[ISO] and is currently not supported on KVM as the driver plug-in relies on the DHCP offer to determine the IP address.
-====
-
-Most hypervisors do not support extending the lease time when the IP is assigned using DHCP.
-This might lead to a new IP being assigned to the VM after a restart as it will conflict with the security certificates generated for the old IP.
-This will make {project} completely unusable until a new instance is set up by running `minishift delete` followed by `minishift start`.
-
-To prevent this, {project} includes the functionality to set a static IP address to the VM.
-This will prevent the IP address from changing between restarts.
-However, it will not work on all of the driver plug-ins at the moment due to the way the IP address is resolved.
-
-The following command will set the IP address that was assigned as fixed:
-
-----
-$ minishift ip --set-static 
-----
-
-If you prefer to use dynamic assignment, you can use:
-
-----
-$ minishift ip --set-dhcp
-----
-
 [[local-proxy-server]]
 == Local Proxy Server
 

--- a/docs/source/using/static-ip.adoc
+++ b/docs/source/using/static-ip.adoc
@@ -23,8 +23,6 @@ However, it will not work on all of the driver plug-ins at the moment due to the
 ====
 - Assigning a static IP address to the {project} VM is only officially supported for Hyper-V.
 - The {project} VM cannot be assigned a static IP address when using the KVM driver plug-in.
-- An experimental `--set-static` flag is available for the `minishift ip` command for other hypervisors.
-See xref:../using/experimental-features.adoc#set-fixed-ip[Set Fixed IP Address] for more information.
 ====
 
 [[static-ip-hyperv]]
@@ -73,4 +71,29 @@ PS> minishift.exe start `
 ====
 Be sure to specify a valid gateway and nameserver.
 Failing to do so will result in connectivity issues.
+====
+
+[[set-fixed-ip]]
+== Set Fixed IP Address
+
+[IMPORTANT]
+====
+This only works with the CentOS or RHEL xref:../using/basic-usage.adoc#choosing-iso-image[ISO] and is currently not supported on KVM as the driver plug-in relies on the DHCP offer to determine the IP address.
+====
+
+The following command will set the IP address that was assigned as fixed:
+
+----
+$ minishift ip --set-static
+----
+
+If you prefer to use dynamic assignment, you can use:
+
+----
+$ minishift ip --set-dhcp
+----
+
+[NOTE]
+====
+Use `minishift config set static-ip false` to stop assign the static ip automatically for supported hypervsiors.
 ====

--- a/pkg/minishift/network/settings_windows.go
+++ b/pkg/minishift/network/settings_windows.go
@@ -131,7 +131,8 @@ func ConfigureNetworking(machineName string, networkSettings NetworkSettings) {
 
 	}
 
-	printNetworkSettings(networkSettings)
+	msg := printNetworkSettings(networkSettings)
+	fmt.Println(msg)
 
 	networkScript := fillNetworkSettingsScript(networkSettings)
 	record := hvkvp.NewMachineKVPRecord(machineName,


### PR DESCRIPTION
Fixes #2629 

Steps to test the pull request

```
$ minishift start 
-- Writing current configuration for static assignment of IP address ... OK => on supported platform
-- Writing current configuration for static assignment of IP address ... FAIL => on unsupported platform or in case any othere issue.
$ minishift ssh -- cat /var/lib/minishift/networking-eth0  => should be present with required data.
```

