### PR TITLE
Issue #2355 Steps in addon-registry-route.feature doesn't work in cmd

### DIFF
--- a/test/integration/features/addons/addon-registry-route.feature
+++ b/test/integration/features/addons/addon-registry-route.feature
@@ -1,14 +1,14 @@
 @addon-registry-route
-Feature: registry-route add-on
-registry-route add-on exposes the route for the OpenShift integrated registry,
+Feature: Registry-route add-on
+Registry-route add-on exposes the route for the OpenShift integrated registry,
 so that user can able to push their container images directly to registry and deploy it.
 
-  Scenario: As a user, I can enable the registry-route add-on
+  Scenario: User enables the registry-route add-on
     Given user starts shell instance on host machine
      When executing "minishift addons enable registry-route" succeeds
      Then stdout should contain "Add-on 'registry-route' enabled"
 
-  Scenario: As a user, I can start Minishift with registry-route add-on enabled
+  Scenario: User starts Minishift with registry-route add-on enabled
     Given Minishift has state "Does Not Exist"
       And image caching is disabled
      When executing "minishift start" succeeds
@@ -18,40 +18,56 @@ so that user can able to push their container images directly to registry and de
       Add-on 'registry-route' created docker-registry route.
       """
 
-  Scenario: As a user, I can login to OpenShift integrated docker registry
-    Given Minishift has state "Running"
-      And executing "minishift docker-env" in host shell succeeds
-      And evaluating stdout of the previous command in host shell
-      And executing "minishift oc-env" in host shell succeeds
-      And evaluating stdout of the previous command in host shell
+  Scenario: User waits until registry is fully started and accessible
      Then with up to "20" retries with wait period of "3" seconds container name "registry_docker-registry" should be "running"
-      And with up to "60" retries with wait period of "1" second command "curl -ik https://docker-registry-default.$(minishift ip).nip.io" output should contain "200 OK"
-      And executing "docker login -u developer -p `oc whoami -t` docker-registry-default.$(minishift ip).nip.io" in host shell succeeds
-      And stdout of host shell should contain "Login Succeeded"
+      And with up to "60" retries with wait period of "1000ms" the "status code" of HTTP request to "/" of service "docker-registry" in namespace "default" is equal to "200"
 
-  Scenario: As a user, I can push pulled application image to OpenShift integrated docker registry and deploy it
-     When executing "docker pull bitnami/nginx" in host shell succeeds
-     Then executing "docker tag bitnami/nginx docker-registry-default.$(minishift ip).nip.io/myproject/nginx" in host shell succeeds
-      And executing "docker push docker-registry-default.$(minishift ip).nip.io/myproject/nginx" in host shell succeeds
-      And executing "oc get is" in host shell succeeds
+  Scenario: User sets docker environment variables
+     When executing "minishift docker-env" in host shell succeeds
+     Then evaluating stdout of the previous command in host shell succeeds
+
+  Scenario: User sets oc environment variables
+     When executing "minishift oc-env" in host shell succeeds
+     Then evaluating stdout of the previous command in host shell succeeds
+
+  Scenario: User gets IP of Minishift
+     When setting scenario variable "minishift_ip" to the stdout from executing "minishift ip"
+     Then scenario variable "minishift_ip" should not be empty
+
+  Scenario: User gets user token from OpenShift instance
+     When setting scenario variable "oc_token" to the stdout from executing "oc whoami -t"
+     Then scenario variable "oc_token" should not be empty
+
+  Scenario: User logs into OpenShift integrated docker registry
+     When executing "docker login -u developer -p $(oc_token) docker-registry-default.$(minishift_ip).nip.io" in host shell succeeds
+     Then stdout of host shell should contain "Login Succeeded"
+
+  Scenario: User can push pulled application image to OpenShift integrated docker registry
+    Given executing "docker pull bitnami/nginx" in host shell succeeds
+      And executing "docker tag bitnami/nginx docker-registry-default.$(minishift_ip).nip.io/myproject/nginx" in host shell succeeds
+     When executing "docker push docker-registry-default.$(minishift_ip).nip.io/myproject/nginx" in host shell succeeds
+     Then executing "oc get is" in host shell succeeds
       And stdout of host shell contains "nginx"
-      And executing "oc new-app --image-stream=nginx --name=nginx" in host shell succeeds
-      And stdout of host shell contains "Success"
+
+  Scenario: User can deploy application from integrated docker registry
+     When executing "oc new-app --image-stream=nginx --name=nginx" in host shell succeeds
       And executing "oc expose svc nginx" in host shell succeeds
-     Then executing "oc set probe dc/nginx --readiness --get-url=http://:8080" in host shell succeeds
+      And executing "oc set probe dc/nginx --readiness --get-url=http://:8080" in host shell succeeds
       And service "nginx" rollout successfully within "1200" seconds
-      And with up to "10" retries with wait period of "500ms" the "status code" of HTTP request to "/" of service "nginx" in namespace "myproject" is equal to "200"
+     Then with up to "10" retries with wait period of "500ms" the "status code" of HTTP request to "/" of service "nginx" in namespace "myproject" is equal to "200"
       And with up to "10" retries with wait period of "500ms" the "body" of HTTP request to "/" of service "nginx" in namespace "myproject" contains "Welcome to nginx!"
 
-  Scenario: As a user, I can login to OpenShift integrated docker registry after restart minishift
+  Scenario: User restarts Minishift
     Given Minishift has state "Running"
      When executing "minishift stop" succeeds
      Then executing "minishift start" succeeds
-      And Minishift should have state "Running"
-      And executing "minishift addon apply registry-route" succeeds
+
+  Scenario: User can login to OpenShift integrated docker registry after restart minishift
+    Given Minishift has state "Running"
+     When executing "minishift addon apply registry-route" succeeds
      Then with up to "60" retries with wait period of "3" seconds container name "registry_docker-registry" should be "running"
-      And with up to "60" retries with wait period of "1" second command "curl -ik https://docker-registry-default.$(minishift ip).nip.io" output should contain "200 OK"
-      And executing "docker login -u developer -p `oc whoami -t` docker-registry-default.$(minishift ip).nip.io" in host shell succeeds
+      And with up to "60" retries with wait period of "1000ms" the "status code" of HTTP request to "/" of service "docker-registry" in namespace "default" is equal to "200"
+      And executing "docker login -u developer -p $(oc_token) docker-registry-default.$(minishift_ip).nip.io" in host shell succeeds
       And stdout of host shell should contain "Login Succeeded"
 
   Scenario: User deletes Minishift

--- a/test/integration/features/cmd-docker-env.feature
+++ b/test/integration/features/cmd-docker-env.feature
@@ -19,14 +19,14 @@ one from: bash, cmd, powershell, tcsh, zsh with TEST_WITH_SPECIFIED_SHELL parame
 
   Scenario: Setting Docker client using docker-env command
      When executing "minishift docker-env" in host shell succeeds
-      And evaluating stdout of the previous command in host shell
+      And evaluating stdout of the previous command in host shell succeeds
      Then executing "docker info" in host shell succeeds
       And stdout of host shell should contain "OSType: linux"
       And stdout of host shell should contain "Name: minishift"
 
   Scenario: Unsetting Docker client using --unset flag of docker-env command
      When executing "minishift docker-env --unset" in host shell succeeds
-      And evaluating stdout of the previous command in host shell
+      And evaluating stdout of the previous command in host shell succeeds
      Then executing "docker info" in host shell
       And stdout of host shell should not contain "Name: minishift"
 

--- a/test/integration/features/cmd-oc-env.feature
+++ b/test/integration/features/cmd-oc-env.feature
@@ -17,7 +17,7 @@ one from: bash, cmd, powershell, tcsh, zsh with TEST_WITH_SPECIFIED_SHELL parame
 
   Scenario: Setting oc binary to PATH with oc-env command
      When executing "minishift oc-env" in host shell succeeds
-      And evaluating stdout of the previous command in host shell
+      And evaluating stdout of the previous command in host shell succeeds
      Then executing "oc status" in host shell succeeds
       And stdout of host shell contains "In project My Project (myproject)"
 

--- a/test/integration/testsuite/testsuite.go
+++ b/test/integration/testsuite/testsuite.go
@@ -160,7 +160,7 @@ func FeatureContext(s *godog.Suite) {
 		util.HostShellCommandReturnShouldEqual)
 	s.Step(`^(stdout|stderr) of host shell (?:should equal|equals)$`,
 		util.HostShellCommandReturnShouldEqualContent)
-	s.Step(`^evaluating stdout of the previous command in host shell$`,
+	s.Step(`^evaluating stdout of the previous command in host shell succeeds$`,
 		util.ExecuteInHostShellLineByLine)
 
 	// Scenario variables
@@ -616,7 +616,7 @@ func commandReturnShouldNotBeEmpty(commandField string) error {
 }
 
 func variableShouldNotBeEmpty(variableName string) error {
-	return util.CompareExpectedWithActualNotEquals("", MinishiftInstance.GetVariableByName(variableName).Value)
+	return util.CompareExpectedWithActualNotEquals("", util.GetVariableByName(variableName))
 }
 
 func commandReturnShouldMatchRegex(commandField string, expected string) error {

--- a/test/integration/util/scenario_variables.go
+++ b/test/integration/util/scenario_variables.go
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+var commandVariables []commandVariable
+
+type commandVariable struct {
+	Name  string
+	Value string
+}
+
+func ProcessVariables(command string) string {
+	for _, variable := range commandVariables {
+		command = strings.Replace(command, fmt.Sprintf("$(%s)", variable.Name), variable.Value, -1)
+	}
+
+	return command
+}
+
+func SetVariable(name string, value string) {
+	commandVariables = append(commandVariables,
+		commandVariable{
+			name,
+			value,
+		})
+}
+
+func GetVariableByName(name string) string {
+	for i := range commandVariables {
+		variable := commandVariables[i]
+		if variable.Name == name {
+			return variable.Value
+		}
+	}
+
+	return ""
+}

--- a/test/integration/util/shell.go
+++ b/test/integration/util/shell.go
@@ -205,10 +205,10 @@ func CloseHostShellInstance() error {
 }
 
 func ExecuteInHostShell(command string) error {
-	var err error
+	command = ProcessVariables(command)
 
 	if shell.instance == nil {
-		return errors.New("Shell instance is started.")
+		return errors.New("Shell instance is not started.")
 	}
 
 	shell.outbuf.Reset()
@@ -217,7 +217,7 @@ func ExecuteInHostShell(command string) error {
 
 	LogMessage(shell.name, command)
 
-	_, err = io.WriteString(shell.inPipe, command+"\n")
+	_, err := io.WriteString(shell.inPipe, command+"\n")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #2355 

Steps to test the pull request:

  1. make integration MINISHIFT_BINARY=/home/agajdosi/minishift/minishift GODOG_OPTS=-tags=addon-registry-route

Changes in the PR:
- replaced checks using `curl`
- replaced steps using backticks
- moved scenario variables functionality to `util` package of integration tests
- added scenario variables functionality to steps executing commands in shell instance
