### PR TITLE
Issue #2892 Changing webconsole URL for OpenShift 3.11

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -502,8 +502,7 @@ func GetConsoleURL(api libmachine.API) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	return fmt.Sprintf("https://%s:%d", ip, constants.APIServerPort), nil
+	return fmt.Sprintf("https://%s:%d/console", ip, constants.APIServerPort), nil
 }
 
 func GetHostIP(api libmachine.API) (string, error) {

--- a/test/integration/testsuite/minishift.go
+++ b/test/integration/testsuite/minishift.go
@@ -266,9 +266,11 @@ func (m *Minishift) imageShouldHaveCached(image string) error {
 	return util.CompareExpectedWithActualMatchesRegex(image, strings.TrimRight(cmdOut, "\n"))
 }
 
-func (m *Minishift) getOpenShiftUrl() string {
-	cmdOut, _, _ := m.runner.RunCommand("console --url")
-	return strings.TrimRight(cmdOut, "\n")
+func (m *Minishift) getOpenShiftInstanceUrl() string {
+	cmdOut, _, _ := m.runner.RunCommand("ip")
+	ip := strings.TrimRight(cmdOut, "\n")
+	url := "https://" + ip + ":8443"
+	return url
 }
 
 func (m *Minishift) getRoute(serviceName, nameSpace string) string {

--- a/test/integration/testsuite/testsuite.go
+++ b/test/integration/testsuite/testsuite.go
@@ -689,12 +689,12 @@ func verifyRequestToServiceWithRetry(retryCount int, retryWaitPeriod int, partOf
 }
 
 func verifyRequestToOpenShift(partOfResponse string, urlSuffix string, assertion string, expected string) error {
-	url := MinishiftInstance.getOpenShiftUrl() + urlSuffix
+	url := MinishiftInstance.getOpenShiftInstanceUrl() + urlSuffix
 	return verifyHTTPResponse(partOfResponse, url, assertion, expected)
 }
 
 func verifyRequestToOpenShiftWithRetry(retryCount int, retryWaitPeriod int, partOfResponse string, urlSuffix string, assertion string, expected string) error {
-	url := MinishiftInstance.getOpenShiftUrl() + urlSuffix
+	url := MinishiftInstance.getOpenShiftInstanceUrl() + urlSuffix
 	return verifyHTTPResponseWithRetry(partOfResponse, url, assertion, expected, retryCount, retryWaitPeriod)
 }
 


### PR DESCRIPTION
The url with /console should work with previous versions also.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>

Fixes #2892 


Steps to test the pull request

  1.  `$ minishift  console ` should point to `https://Minishift IP:8443/console` instead of `https://IP:8443`
  
Same goes for 
  1. minishift console --machine-readable
  1. minishift console --url

