### PR TITLE
Issue #2922 Update centos iso from 1.12.0 to 1.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 MINISHIFT_VERSION = 1.25.0
 OPENSHIFT_VERSION = v3.11.0
 B2D_ISO_VERSION = v1.3.0
-CENTOS_ISO_VERSION = v1.12.0
+CENTOS_ISO_VERSION = v1.13.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 
 # Go and compilation related variables


### PR DESCRIPTION
Fixes #2922 


Steps to test the pull request

  1. 
  2. 
  3. 
  4. 

