### PR TITLE
Issue #2933 HypervVirtualSwitch flag default value should be set in start.go

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -160,7 +160,7 @@ var (
 	DnsmasqContainerImage = createConfigSetting("network-dnsmasq-container", SetString, nil, nil, true, nil)
 
 	// Hyper-V vSwitch set to Default Switch by default
-	HypervVirtualSwitch = createConfigSetting("hyperv-virtual-switch", SetString, []setFn{validations.IsValidHypervVirtualSwitch}, nil, true, "Default Switch")
+	HypervVirtualSwitch = createConfigSetting("hyperv-virtual-switch", SetString, []setFn{validations.IsValidHypervVirtualSwitch}, nil, true, nil)
 
 	// Save start flags to viper config
 	SaveStartFlags = createConfigSetting("save-start-flags", SetBool, nil, nil, true, true)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -708,7 +708,7 @@ func initStartFlags() *flag.FlagSet {
 		startFlagSet.String(configCmd.IPAddress.Name, "", "Specify IP address to assign to the instance (Hyper-V only)")
 		startFlagSet.String(configCmd.Netmask.Name, "", "Specify netmask to use for the IP address. Ignored if no IP address specified (Hyper-V only)")
 		startFlagSet.String(configCmd.Gateway.Name, "", "Specify gateway to use for the instance. Ignored if no IP address specified (Hyper-V only)")
-		startFlagSet.String(configCmd.HypervVirtualSwitch.Name, "", "Specify which Virtual Switch to use for the instance (Hyper-V only)")
+		startFlagSet.String(configCmd.HypervVirtualSwitch.Name, "Default Switch", "Specify which Virtual Switch to use for the instance (Hyper-V only)")
 	}
 	startFlagSet.AddFlag(nameServersFlag)
 


### PR DESCRIPTION
Fixes #2933 


Steps to test the pull request

1. Disable HyperV
2. Restart as prompted
3. minishift start --vm-driver virtualbox

