### PR TITLE
Remove ' from --enable option value

### DIFF
--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -42,7 +42,7 @@ $ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--ser
 For OKD 3.10.0 or later the command is:
 
 ----
-$ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--enable=*,service-catalog'"
+$ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--enable=*,service-catalog"
 ----
 
 [[local-proxy-server]]


### PR DESCRIPTION
Fix #2938.

With ' in option value minishift fails to start with error

```
Starting OpenShift cluster -- Extra 'oc' cluster up flags (experimental) ...
   '--enable=*,service-catalog''
.Error during 'cluster up' execution: Error starting the cluster. ssh command error:
command : /var/lib/minishift/bin/oc cluster up --routing-suffix 192.168.42.250.nip.io --base-dir /var/lib/minishift/base --image 'openshift/origin-${component}:v3.11.0' --public-hostname 192.168.42.250 --enable=*,service-catalog'
err     : exit status 1
output  : bash: -c: line 0: unexpected EOF while looking for matching `''
bash: -c: line 1: syntax error: unexpected end of file
```
