### PR TITLE
Issue #2907 Update registry route addon to use passthrough route instead edge

### DIFF
--- a/addons/registry-route/registry-route.addon
+++ b/addons/registry-route/registry-route.addon
@@ -1,17 +1,50 @@
 # Name: registry-route
 # Description: Create an edge terminated route for the OpenShift registry
+# URL: https://docs.okd.io/latest/install_config/registry/securing_and_exposing_registry.html
 
-!openshift adm ca create-server-cert --signer-cert=/var/lib/origin/openshift.local.config/master/ca.crt --signer-key=/var/lib/origin/openshift.local.config/master/ca.key --signer-serial=/var/lib/origin/openshift.local.config/master/ca.serial.txt --hostnames='docker-registry-default.#{routing-suffix},docker-registry-default.#{routing-suffix}:443,docker-registry.default.svc.cluster.local,172.30.1.1' --cert=/etc/secrets/registry.crt --key=/etc/secrets/registry.key
-!openshift create route edge docker-registry --service=docker-registry --ca-cert=/var/lib/origin/openshift.local.config/master/ca.crt --cert=/etc/secrets/registry.crt --key=/etc/secrets/registry.key --hostname='docker-registry-default.#{routing-suffix}' --config=/var/lib/origin/openshift.local.config/master/admin.kubeconfig
+echo  -- Create secret directory
+ssh sudo mkdir -p /var/lib/minishift/secrets
+ssh sudo chown #{user} /var/lib/minishift/secrets
 
-!ssh sudo mkdir -p /etc/docker/certs.d/docker-registry-default.#{routing-suffix}
-!ssh sudo chown #{user} /etc/docker/certs.d/docker-registry-default.#{routing-suffix}
+echo  -- Creating server cert
+!ssh /var/lib/minishift/bin/oc adm ca create-server-cert --signer-cert=/var/lib/minishift/base/openshift-apiserver/ca.crt --signer-key=/var/lib/minishift/base/openshift-apiserver/ca.key --signer-serial=/var/lib/minishift/base/openshift-apiserver/ca.serial.txt --hostnames='docker-registry-default.#{routing-suffix},docker-registry-default.#{routing-suffix}:443,docker-registry.default.svc.cluster.local,172.30.1.1' --cert=/var/lib/minishift/secrets/registry.crt --key=/var/lib/minishift/secrets/registry.key
+
+echo  -- Creating the secret for the registry certificates
+!ssh /var/lib/minishift/bin/oc create secret generic registry-certificates --from-file=/var/lib/minishift/secrets/registry.crt --from-file=/var/lib/minishift/secrets/registry.key -n default
+
+echo  -- Adding the secret to the registry pod’s service accounts (including the default service account)
+!oc secrets link registry registry-certificates -n default --as system:admin
+!oc secrets link default registry-certificates -n default --as system:admin
+
+echo  -- Pausing the docker-registry service
+!oc rollout pause dc/docker-registry -n default --as system:admin
+
+echo  -- Adding the secret volume to the registry deployment configuration
+!oc set volume dc/docker-registry --add --type=secret --secret-name=registry-certificates -m /etc/secrets -n default --as system:admin
+
+echo  -- Enabling TLS by adding the environment variables to the registry deployment configuration
+!oc set env dc/docker-registry REGISTRY_HTTP_TLS_CERTIFICATE=/etc/secrets/registry.crt REGISTRY_HTTP_TLS_KEY=/etc/secrets/registry.key -n default --as system:admin
+
+echo  -- Updating the scheme used for the registry’s liveness probe from HTTP to HTTPS
+!oc patch dc/docker-registry -p '{"spec": {"template": {"spec": {"containers":[{"name":"registry","livenessProbe":  {"httpGet": {"scheme":"HTTPS"}}}]}}}}' -n default --as system:admin
+
+echo  -- Updating the scheme used for the registry’s readiness probe from HTTP to HTTPS
+!oc patch dc/docker-registry -p '{"spec": {"template": {"spec": {"containers":[{"name":"registry","readinessProbe":  {"httpGet": {"scheme":"HTTPS"}}}]}}}}' -n default --as system:admin
+
+echo  -- Resuming the docker-registry service
+!oc rollout resume dc/docker-registry -n default --as system:admin
+
+echo  -- Creating passthrough route for docker-registry service
+!oc create route passthrough --service=docker-registry --hostname=docker-registry-default.#{routing-suffix} -n default --as system:admin
+
+ssh sudo mkdir -p /etc/docker/certs.d/docker-registry-default.#{routing-suffix}
+ssh sudo chown #{user} /etc/docker/certs.d/docker-registry-default.#{routing-suffix}
 
 docker cp origin:/var/lib/origin/openshift.local.config/master/ca.crt /etc/docker/certs.d/docker-registry-default.#{routing-suffix}/ca.crt
 
-echo Add-on '#{addon-name}' created docker-registry route. Please run following commands to login to the OpenShift docker registry:
-echo $ eval $(minishift docker-env)
-echo $ eval $(minishift oc-env)
+echo  -- Add-on '#{addon-name}' created docker-registry route. Please run following commands to login to the OpenShift docker registry:
+echo  -- $ eval $(minishift docker-env)
+echo  -- $ eval $(minishift oc-env)
 echo
-echo $ docker login -u developer -p `oc whoami -t` docker-registry-default.#{routing-suffix}
+echo  -- $ docker login -u developer -p `oc whoami -t` docker-registry-default.#{routing-suffix}
 echo


### PR DESCRIPTION
Fixes #2907 


Steps to test the pull request

```console
$ minishift delete
-- make sure you take artifact from PR locally --
$ minishift start
$ minishift addon install --defaults
$ minishift addon apply registry-route
```

Now follow the steps on the provided issue #2907 
