### PR TITLE
Issue #2964 Disable Java CentOS stack in Che feature file

### DIFF
--- a/test/integration/features/addons/addon-che-with-anyuid.feature
+++ b/test/integration/features/addons/addon-che-with-anyuid.feature
@@ -54,7 +54,7 @@ Feature: Che add-on in combination with anyuid addon.
     | Eclipse Vert.x        | https://github.com/openshiftio-vertx-boosters/vertx-http-booster         |
 #   | Java CentOS           | https://github.com/che-samples/console-java-simple.git                   | ignored due to issue #2824
     | Spring Boot           | https://github.com/snowdrop/spring-boot-http-booster                     |
-    | CentOS WildFly Swarm  | https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http  |
+#   | CentOS WildFly Swarm  | https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http  | Keep disabled until #2824 is fixed
     | Python                | https://github.com/che-samples/console-python3-simple.git                |
     | PHP                   | https://github.com/che-samples/web-php-simple.git                        |
     | C++                   | https://github.com/che-samples/console-cpp-simple.git                    |

--- a/test/integration/features/addons/addon-che.feature
+++ b/test/integration/features/addons/addon-che.feature
@@ -47,7 +47,7 @@ Feature: Che add-on
     Examples:
     | stack                 | sample                                                                   |
     | Eclipse Vert.x        | https://github.com/openshiftio-vertx-boosters/vertx-http-booster         |
-    | Java CentOS           | https://github.com/che-samples/console-java-simple.git                   |
+#   | Java CentOS           | https://github.com/che-samples/console-java-simple.git                   | Keep disabled until #2824 is fixed
     | Spring Boot           | https://github.com/snowdrop/spring-boot-http-booster                     |
     | CentOS WildFly Swarm  | https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http  |
     | Python                | https://github.com/che-samples/console-python3-simple.git                |


### PR DESCRIPTION
Fixes #2964


Steps to test the pull request

  1. make integration GODOG_OPTS="-tags addon-che,addon-che-with-anyuid"
  2. 
  3. 
  4. 

