### PR TITLE
Issue #2875 Add option to login to redhat.registry.io

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -59,6 +59,7 @@ var (
 	RemoteSSHUser         = createConfigSetting("remote-ssh-user", SetString, nil, nil, true, nil)
 	SSHKeyToConnectRemote = createConfigSetting("remote-ssh-key", SetString, nil, nil, true, nil)
 	TimeZone              = createConfigSetting("timezone", SetString, []setFn{validations.IsValidTimezone}, nil, true, nil)
+	RegistryLogin         = createConfigSetting("registry-login", SetBool, nil, nil, true, nil)
 
 	// cluster up
 	SkipRegistryCheck = createConfigSetting("skip-registry-check", SetBool, nil, nil, true, nil)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -206,6 +206,11 @@ func runStart(cmd *cobra.Command, args []string) {
 		minishiftConfig.InstanceStateConfig.Write()
 	}
 	timezone.SetTimeZone(hostVm)
+	if viper.GetBool(configCmd.RegistryLogin.Name) {
+		if err = minishiftCluster.LoginToRegistry(libMachineClient); err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		}
+	}
 	registrationUtil.RegisterHost(libMachineClient)
 
 	// Forcibly set nameservers when configured
@@ -696,6 +701,7 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.String(configCmd.SSHKeyToConnectRemote.Name, "", "SSH private key location on the host to connect remote machine")
 	startFlagSet.String(configCmd.ISOUrl.Name, minishiftConstants.CentOsIsoAlias, "Location of the minishift ISO. Can be a URL, file URI or one of the following short names: [centos b2d].")
 	startFlagSet.String(configCmd.TimeZone.Name, constants.DefaultTimeZone, "TimeZone for Minishift VM")
+	startFlagSet.Bool(configCmd.RegistryLogin.Name, false, "Login to registry.redhat.io")
 
 	startFlagSet.AddFlag(dockerEnvFlag)
 	startFlagSet.AddFlag(dockerEngineOptFlag)

--- a/pkg/minishift/cluster/registry.go
+++ b/pkg/minishift/cluster/registry.go
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/state"
+	"github.com/minishift/minishift/pkg/minikube/constants"
+	"github.com/minishift/minishift/pkg/minishift/registration"
+)
+
+type RegistryActionFunc func(sshCommander provision.SSHCommander, param *registration.RegistrationParameters, IsRHEL bool) error
+
+func doRegistryAction(api libmachine.API, registryAction RegistryActionFunc) error {
+	host, err := api.Load(constants.MachineName)
+	if err != nil {
+		return err
+	}
+
+	if !drivers.MachineInState(host.Driver, state.Running)() {
+		return fmt.Errorf("Unable to perform registration action. VM not in running state")
+	}
+
+	sshCommander := provision.GenericSSHCommander{Driver: host.Driver}
+	return registryAction(sshCommander, RegistrationParameters, false)
+}
+
+// LoginToRegistry returns true if successfully logged in to registry.redhat.com
+func LoginToRegistry(api libmachine.API) error {
+	return doRegistryAction(api, registration.RSHMRegisterAndLoginToRedhatRegistry)
+}

--- a/pkg/minishift/registration/utils.go
+++ b/pkg/minishift/registration/utils.go
@@ -17,11 +17,19 @@ limitations under the License.
 package registration
 
 import (
+	"errors"
 	"fmt"
+	"github.com/golang/glog"
+	"github.com/minishift/minishift/pkg/util"
+	"github.com/minishift/minishift/pkg/util/progressdots"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/provision"
+	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
 )
 
 type RegistrationParameters struct {
@@ -99,4 +107,112 @@ func UnregisterHostVM(host *host.Host, param *RegistrationParameters) (bool, err
 		"Unregistering machine",
 		registrator.Unregister,
 		param)
+}
+
+func RSHMRegisterAndLoginToRedhatRegistry(sshCommander provision.SSHCommander, param *RegistrationParameters, isRHEL bool) error {
+	var err error
+	keyringDocsLink := "https://docs.okd.io/latest/minishift/troubleshooting/troubleshooting-misc.html#Remove-password-from-keychain"
+	for i := 1; i < 4; i++ {
+		// request username (disallow empty value)
+		if param.Username == "" {
+			// Check if Terminal tty supported or not
+			if !param.IsTtySupported {
+				return fmt.Errorf(("Not a tty supported terminal, Retries are disabled"))
+			}
+			for param.Username == "" {
+				param.Username = param.GetUsernameInteractive(RHSMName + " username")
+			}
+		}
+		// request password (disallow empty value)
+		if param.Password == "" {
+			if i == 1 {
+				fmt.Printf("   Retriving password from keychain ...")
+				param.Password, err = param.GetPasswordKeyring(param.Username)
+				if err != nil {
+					fmt.Println(" FAIL ")
+				} else {
+					fmt.Println(" OK ")
+				}
+			}
+
+			for param.Password == "" {
+				param.Password = param.GetPasswordInteractive(RHSMName + " password")
+				fmt.Printf("   Storing password in keychain ...")
+				err := param.SetPasswordKeyring(param.Username, param.Password)
+				if err != nil {
+					fmt.Println(" FAIL ")
+				} else {
+					fmt.Println(" OK ")
+				}
+				if glog.V(3) {
+					fmt.Println(err)
+				}
+			}
+		}
+
+		// prepare subscription command
+		subscriptionCommand := fmt.Sprintf("sudo -E subscription-manager register --auto-attach "+
+			"--username %s "+
+			"--password '%s' ",
+			param.Username,
+			minishiftStrings.EscapeSingleQuote(param.Password))
+
+		// prepare docker login command for registry.redhat.io
+		dockerLoginCommand := fmt.Sprintf("docker login --username %s --password %s %s",
+			param.Username,
+			minishiftStrings.EscapeSingleQuote(param.Password),
+			RedHatRegistry)
+
+		fmt.Printf("   Login to %s in progress ", RedHatRegistry)
+		// Initialize progressDots channel
+		progressDots := progressdots.New()
+		progressDots.Start()
+		// Login to docker registry
+		_, err = sshCommander.SSHCommand(dockerLoginCommand)
+		progressDots.Stop()
+		if err == nil {
+			fmt.Println(" OK ")
+		} else {
+			fmt.Println(" FAIL ")
+		}
+
+		if isRHEL {
+			fmt.Printf("   Registration in progress ")
+			// Initialize progressDots channel again for registration
+			progressDots = progressdots.New()
+			progressDots.Start()
+			startTime := time.Now()
+			// start timed SSH command to register
+			_, err = sshCommander.SSHCommand(subscriptionCommand)
+			progressDots.Stop()
+			if err == nil {
+				fmt.Print(" OK ")
+			} else {
+				fmt.Print(" FAIL ")
+			}
+			fmt.Printf("[%s]\n", util.TimeElapsed(startTime, true))
+		}
+
+		if err == nil {
+			return nil
+		}
+
+		// general error when registration fails
+		if strings.Contains(err.Error(), "Invalid username or password") {
+			fmt.Printf("   Invalid username or password. To delete stored password refer to %s. Retry: %d\n", keyringDocsLink, i)
+		} else {
+			return errors.New(redactPassword(err.Error()))
+		}
+
+		// always reset credentials
+		param.Username = ""
+		param.Password = ""
+	}
+	return nil
+}
+
+func redactPassword(msg string) string {
+	pattern := regexp.MustCompile(`--password .*`)
+	msgWithRedactedPass := pattern.ReplaceAllString(msg, "--password ********")
+	return msgWithRedactedPass
 }


### PR DESCRIPTION
Fixes #2875


Steps to test the pull request

```console
$ ./minishift start --no-provision
-- Starting profile 'minishift'
-- Check if deprecated options are used ... OK
-- Checking if https://github.com is reachable ... OK
-- Checking if requested OpenShift version 'v3.11.0' is valid ... SKIP
-- Checking if requested OpenShift version 'v3.11.0' is supported ... SKIP
-- Checking if requested hypervisor 'xhyve' is supported on this platform ... OK
-- Checking if xhyve driver is installed ... 
   Driver is available at /usr/local/bin/docker-machine-driver-xhyve
   Checking for setuid bit ... OK
-- Checking the ISO URL ... OK
-- Checking if provided oc flags are supported ... OK
-- Starting the OpenShift cluster using 'xhyve' hypervisor ...
-- Minishift VM will be configured with ...
   Memory:    4 GB
   vCPUs :    2
   Disk size: 20 GB
-- Starting Minishift VM .................. OK
-- Checking for IP address ... OK
-- Checking for nameservers ... OK
-- Checking if external host is reachable from the Minishift VM ... 
   Pinging 8.8.8.8 ... OK
-- Checking HTTP connectivity from the VM ... 
   Retrieving http://minishift.io/index.html ... OK
-- Checking if persistent storage volume is mounted ... OK
-- Checking available disk space ... 1% used OK
-- Writing current configuration for static assignment of IP address ... OK

$ ./minishift start --no-provision --registry-login
-- Starting profile 'minishift'
-- Check if deprecated options are used ... OK
-- Checking if https://github.com is reachable ... OK
-- Checking if requested OpenShift version 'v3.11.0' is valid ... SKIP
-- Checking if requested OpenShift version 'v3.11.0' is supported ... SKIP
-- Checking if requested hypervisor 'xhyve' is supported on this platform ... OK
-- Checking if xhyve driver is installed ... 
   Driver is available at /usr/local/bin/docker-machine-driver-xhyve
   Checking for setuid bit ... OK
-- Checking the ISO URL ... OK
-- Checking if provided oc flags are supported ... OK
-- Starting the OpenShift cluster using 'xhyve' hypervisor ...
-- Minishift VM will be configured with ...
   Memory:    4 GB
   vCPUs :    2
   Disk size: 20 GB
-- Starting Minishift VM .................. OK
   Red Hat Developers or Red Hat Subscription Management (RHSM) username: kumarpraveen.nitdgp@gmail.com
   Retriving password from keychain ... OK 
   Login to registry.redhat.io in progress .... OK 
-- Checking for IP address ... OK
-- Checking for nameservers ... OK
-- Checking if external host is reachable from the Minishift VM ... 
   Pinging 8.8.8.8 ... OK
-- Checking HTTP connectivity from the VM ... 
   Retrieving http://minishift.io/index.html ... OK
-- Checking if persistent storage volume is mounted ... OK
-- Checking available disk space ... 1% used OK
-- Writing current configuration for static assignment of IP address ... OK

$ ./minishift ssh -- docker pull registry.redhat.io/rhel:latest
Trying to pull repository registry.redhat.io/rhel ... 
latest: Pulling from registry.redhat.io/rhel
50a402dbfd72: Pulling fs layer
c6796217be8f: Pulling fs layer
c6796217be8f: Verifying Checksum
```


cc @agajdosi
