### PR TITLE
Issue #3002 pass VBOX_MSI_INSTALL_PATH env to systray process

### DIFF
--- a/pkg/minishift/systemtray/minishifttray.go
+++ b/pkg/minishift/systemtray/minishifttray.go
@@ -55,6 +55,7 @@ func minishiftTrayCommand() (*exec.Cmd, error) {
 	exportCmd.Stdout = nil
 	exportCmd.SysProcAttr = process.SysProcForBackgroundProcess()
 	exportCmd.Env = process.EnvForBackgroundProcess()
+	exportCmd.Env = append(exportCmd.Env, fmt.Sprintf("VBOX_MSI_INSTALL_PATH=%s", goos.Getenv("VBOX_MSI_INSTALL_PATH")))
 	return exportCmd, nil
 }
 


### PR DESCRIPTION
Fixes #3002 

/cc @amitkrout @agajdosi Could you guys verify if this fixes the issue both in windows 7 and 10
