### PR TITLE
Issue #3037 Check config value before starting systemtray

### DIFF
--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -256,9 +256,11 @@ func runStart(cmd *cobra.Command, args []string) {
 	autoMountHostFolders(hostVm.Driver)
 
 	// start the minishift system tray
-	err = startTray()
-	if err != nil {
-		fmt.Println(err)
+	if viper.GetBool(configCmd.AutoStartTray.Name) {
+		err = startTray()
+		if err != nil {
+			fmt.Println(err)
+		}
 	}
 
 	if !isNoProvision() {


### PR DESCRIPTION
Fixes: #3037 

Here's the artefacts for [darwin](https://5673-62728051-gh.circle-artifacts.com/0/ms/darwin-amd64/systemtray/minishift) and [windows](https://5673-62728051-gh.circle-artifacts.com/0/ms/windows-amd64/systemtray/minishift.exe)

/cc @amitkrout 