### PR TITLE
Issue #2676 Addon for enabling mutating and admission webhooks

### DIFF
--- a/addons/admissions-webhook/admissions-webhook.addon
+++ b/addons/admissions-webhook/admissions-webhook.addon
@@ -1,0 +1,22 @@
+# Name: admissions-webhook
+# Description: Enables admissions and mutating webhook
+# Url: https://github.com/knative/docs/blob/master/install/Knative-with-Minishift.md#enable-admission-controller-webhook
+# OpenShift-Version: >=3.10.0
+# Var-Defaults: MINISHIFT_DATA_HOME=/var/lib/minishift,CONFIG_LOCATION_KUBERNETES_API=base/kube-apiserver,MASTER_CONFIG_FILE=master-config.yaml
+
+ssh sudo cp -fp #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/#{MASTER_CONFIG_FILE} #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-tmp.yaml
+
+PATCH := cat patch.json
+# Patch the kube apiserver configuration to enable admission and mutating webhooks
+ssh sudo grep "MutatingAdmissionWebhook" #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/#{MASTER_CONFIG_FILE} > /dev/null || sudo #{MINISHIFT_DATA_HOME}/bin/oc ex config patch #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-tmp.yaml --patch='#{PATCH}' > #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/#{MASTER_CONFIG_FILE}
+
+echo -- Restarting Openshift API server ..
+docker stop $(docker ps -l -q --filter "label=io.kubernetes.container.name=apiserver")
+echo -- Restarting Kube API server ..
+docker stop $(docker ps -l -q --filter "label=io.kubernetes.container.name=api")
+
+# Remove the temporary file
+ssh sudo rm #{MINISHIFT_DATA_HOME}/#{CONFIG_LOCATION_KUBERNETES_API}/master-config-tmp.yaml
+
+ssh until curl -f -k https://#{ip}:8443/healthz;do sleep 1;done
+echo -- Successfully installed addon admission-webhook ... OK

--- a/addons/admissions-webhook/patch.json
+++ b/addons/admissions-webhook/patch.json
@@ -1,0 +1,20 @@
+{
+    "admissionConfig": {
+        "pluginConfig": {
+            "ValidatingAdmissionWebhook": {
+                "configuration": {
+                    "apiVersion": "apiserver.config.k8s.io/v1alpha1",
+                    "kind": "WebhookAdmission",
+                    "kubeConfigFile": "/dev/null"
+                }
+            },
+            "MutatingAdmissionWebhook": {
+                "configuration": {
+                    "apiVersion": "apiserver.config.k8s.io/v1alpha1",
+                    "kind": "WebhookAdmission",
+                    "kubeConfigFile": "/dev/null"
+                }
+            }
+        }
+    }
+}

--- a/cmd/minishift/cmd/util/util.go
+++ b/cmd/minishift/cmd/util/util.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	DefaultAssets = []string{"anyuid", "admin-user", "xpaas", "registry-route", "che", "htpasswd-identity-provider"}
+	DefaultAssets = []string{"anyuid", "admin-user", "xpaas", "registry-route", "che", "htpasswd-identity-provider", "admissions-webhook"}
 )
 
 func VMExists(client *libmachine.Client, machineName string) bool {

--- a/docs/source/using/addons.adoc
+++ b/docs/source/using/addons.adoc
@@ -341,7 +341,9 @@ By default, this is not allowed in OpenShift.
 | registry-route
 | Creates an edge terminated route for the OpenShift registry.
 | htpasswd-identity-provider
-| User can change and add default login username and password for the OpenShift instance
+| User can change and add default login username and password for the OpenShift instance.
+| admissions-webhook
+| Enables validating and mutating admission webhooks.
 
 | xpaas
 | Imports xPaaS templates.

--- a/pkg/minishift/addon/manager/addon_manager_test.go
+++ b/pkg/minishift/addon/manager/addon_manager_test.go
@@ -64,7 +64,7 @@ func Test_create_addon_manager(t *testing.T) {
 
 	addOns := manager.List()
 
-	expectedNumberOfAddOns := 6
+	expectedNumberOfAddOns := 7
 	assert.Len(t, addOns, expectedNumberOfAddOns)
 }
 

--- a/test/integration/features/addons/cmd-addons.feature
+++ b/test/integration/features/addons/cmd-addons.feature
@@ -11,6 +11,7 @@ Feature: Addons command and its subcommands
       And stdout should match "xpaas\s*: disabled\s*P\(0\)"
       And stdout should match "che\s*: disabled\s*P\(0\)"
       And stdout should match "htpasswd-identity-provider\s*: disabled\s*P\(0\)"
+      And stdout should match "admissions-webhook\s*: disabled\s*P\(0\)"
 
   @minishift-only @quick
   Scenario: Verbose listing of add-ons installed by default
@@ -79,7 +80,7 @@ Feature: Addons command and its subcommands
      When executing "minishift addons install --defaults" succeeds
      Then stdout should contain
       """
-      Default add-ons 'anyuid, admin-user, xpaas, registry-route, che, htpasswd-identity-provider' installed
+      Default add-ons 'anyuid, admin-user, xpaas, registry-route, che, htpasswd-identity-provider, admissions-webhook' installed
       """
      When executing "minishift addons list" succeeds
      Then stdout should contain "admin-user"

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -6,7 +6,7 @@ Feature: Basic
      When executing "minishift addons install --defaults" succeeds
      Then stdout should contain
       """
-      Default add-ons 'anyuid, admin-user, xpaas, registry-route, che, htpasswd-identity-provider' installed
+      Default add-ons 'anyuid, admin-user, xpaas, registry-route, che, htpasswd-identity-provider, admissions-webhook' installed
       """
 
   Scenario: User can enable the anyuid add-on


### PR DESCRIPTION
Fixes <place holder for #issue number>


Steps to test the pull request

  1. `minishift start`
  2. `minishift addons install --defaults`
  3.  `minishift addons apply admissions-webhook`
  4.  `minishift openshift config view --target kube`

