### PR TITLE
Issue #3024 PR checks on Travis do not have GH API token defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 
 script: |
   make prerelease
-  make coverage
+  export MINISHIFT_GITHUB_API_TOKEN=f62950fc041df6f8788a7d23157a39936a0af440 make coverage
 
 after_success: |
   cd out


### PR DESCRIPTION
Fixes #3024 

PR adds token with nearly-zero permissions (can only be used to call Github API with increased limit of 1000reqs/h) of newly created blank account. Using this solution we expose useless token, but keep the private and valuable one safe. Unfortunately circle-ci nor travis does not allow to expose just one token, it is all or nothing. So I use this solution.
