### PR TITLE
Issue #2840 Add macOS support to setup command

### DIFF
--- a/cmd/minishift/cmd/setup.go
+++ b/cmd/minishift/cmd/setup.go
@@ -47,7 +47,8 @@ func init() {
 }
 
 func runSetup(cmd *cobra.Command, args []string) {
-	if os.CurrentOS() == "windows" {
+	switch os.CurrentOS() {
+	case "windows":
 		if !powershell.IsAdmin() {
 			atexit.ExitWithMessage(1, "Run 'minishift setup' as an administrator.")
 		}
@@ -62,7 +63,15 @@ func runSetup(cmd *cobra.Command, args []string) {
 		fmt.Println("Pre-requisites are ready.\nRun following commands to start your minishift instance:\n" +
 			" minishift config set hyperv-virtual-switch minishift-external\n minishift start\n" +
 			"Note: Above two commands doesn't need to be run in Administrator mode.")
-	} else {
+	case "darwin":
+		// Check if driver is already present and configured, if not
+		// Download docker-machine-driver-xhyve from github/machine-drivers
+		// Move it to path, add to proper group and set permissions
+		if err := hypervisor.CheckAndConfigureHypervisor(); err != nil {
+			atexit.ExitWithMessage(1, err.Error())
+		}
+
+	default:
 		fmt.Println("The implementation of this command is not available for this operating system.\n" +
 			"Please continue with setting pre-requisites through manual process.")
 	}

--- a/pkg/minishift/setup/hypervisor/virtualization_darwin.go
+++ b/pkg/minishift/setup/hypervisor/virtualization_darwin.go
@@ -17,15 +17,109 @@ limitations under the License.
 package hypervisor
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+)
+
+const (
+	driverBinaryDir   = "/usr/local/bin"
+	driverBinaryPath  = driverBinaryDir + "/docker-machine-driver-xhyve"
+	driverDownloadUrl = "https://github.com/machine-drivers/docker-machine-driver-xhyve/releases/download/v0.3.3/docker-machine-driver-xhyve"
 )
 
 func CheckHypervisorAvailable() error {
-	fmt.Println("Checking Hypervisor Availability ...")
 	return nil
 }
 
 func CheckAndConfigureHypervisor() error {
-	fmt.Println("Checking and Configuring Hypervisor  ...")
+	if isRoot() {
+		fmt.Println("Configuring Xhyve Hypervisor ...")
+		err := downloadXhyveDriver(driverBinaryPath, driverDownloadUrl)
+		return err
+	}
+	return errors.New("This command needs to be executed as administrator or with sudo.")
+}
+
+func isXhyveConfigured() bool {
+	//Following check is also present in cmd/start_preflight.go
+	path, err := exec.LookPath("docker-machine-driver-xhyve")
+
+	if err != nil {
+		return false
+	}
+
+	fi, _ := os.Stat(path)
+	// follow symlinks
+	if fi.Mode()&os.ModeSymlink != 0 {
+		path, err = os.Readlink(path)
+		if err != nil {
+			return false
+		}
+	}
+	fmt.Println("Driver is available at", path)
+
+	fmt.Print("Checking for setuid bit ... ")
+	if fi.Mode()&os.ModeSetuid == 0 {
+		print("FAIL")
+		return false
+	}
+	print("OK")
+	return true
+}
+
+func downloadXhyveDriver(filepath string, url string) error {
+	fmt.Println("Checking if docker-machine-driver-xhyve is already present and configured ... ")
+	if isXhyveConfigured() {
+		return nil
+	}
+	os.MkdirAll(driverBinaryDir, 0751)
+
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	fmt.Printf("Downloading docker-machine-driver-xhyve binary to %s ... ", filepath)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+	fmt.Print("OK")
+
+	fmt.Printf("\nSetting permissions and group for %s ... ", filepath)
+	err = out.Chown(0, 0)
+	if err != nil {
+		return err
+	}
+
+	err = out.Chmod(os.ModeSetuid | 0751)
+	if err != nil {
+		return err
+	}
+	fmt.Print("OK")
+
 	return nil
+}
+
+func isRoot() bool {
+	user, err := user.Current()
+	if err != nil {
+		fmt.Println("Error getting current user.")
+		return false
+	}
+	if user.Gid == "0" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #2840 


Steps to test the pull request

  1. On a clean mac (without prerequisite of minishift set)
  2.  `minishift start` ==> this will fail
  3.  `minishift setup` ==> error msg saying to run command with sudo
  4.  `sudo minishift setup`

