### PR TITLE
Issue #3053 Remove Boot2Docker from documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Various versions - Minishift, default OpenShift, default B2D ISO
+# Various versions - Minishift, default OpenShift, default CentOS ISO
 MINISHIFT_VERSION = 1.28.0
 OPENSHIFT_VERSION = v3.11.0
-B2D_ISO_VERSION = v1.3.0
 CENTOS_ISO_VERSION = v1.13.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 
@@ -61,7 +60,7 @@ LOCAL_DOCS_DIR ?= $(CURDIR)/docs
 CONTAINER_DOCS_DIR = /minishift-docs
 DOCS_SYNOPISIS_DIR = docs/source/_tmp
 DOCS_UID ?= $(shell docker run -tiv $(LOCAL_DOCS_DIR):$(CONTAINER_DOCS_DIR) $(DOCS_BUILDER_IMAGE) id)
-DOC_VARIABLES = -e OPENSHIFT_VERSION=$(OPENSHIFT_VERSION) -e MINISHIFT_VERSION=$(MINISHIFT_VERSION) -e CENTOS_ISO_VERSION=$(CENTOS_ISO_VERSION) -e B2D_ISO_VERSION=$(B2D_ISO_VERSION)
+DOC_VARIABLES = -e OPENSHIFT_VERSION=$(OPENSHIFT_VERSION) -e MINISHIFT_VERSION=$(MINISHIFT_VERSION) -e CENTOS_ISO_VERSION=$(CENTOS_ISO_VERSION)
 
 # MISC
 START_COMMIT_MESSAGE_VALIDATION = 83af4780db01d9a4607925af83297e32b38a1603
@@ -299,4 +298,3 @@ validate_commits: $(GOPATH)/bin/git-validation ## Validates commit messages matc
 .PHONY: help
 help: ## Prints this help
 	@grep -E '^[^.]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}'
-

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -111,8 +111,6 @@ task :adoc_variables => :init do
   minishift_version    = ENV['MINISHIFT_VERSION']    || 'unset'
   openshift_version    = ENV['OPENSHIFT_VERSION']    || 'unset'
   centos_iso_version   = ENV['CENTOS_ISO_VERSION']   || 'unset'
-  minikube_iso_version = ENV['MINIKUBE_ISO_VERSION'] || 'unset'
-  b2d_iso_version      = ENV['B2D_ISO_VERSION']      || 'unset'
 
   contents = <<EOF
 :project: Minishift
@@ -122,8 +120,6 @@ task :adoc_variables => :init do
 :minishift-version: #{minishift_version}
 :openshift-version: #{openshift_version}
 :centos-iso-version: #{centos_iso_version}
-:minikube-iso-version: #{minikube_iso_version}
-:b2d-iso-version: #{b2d_iso_version}
 EOF
 
   ADOC_VARIABLES.each { |f| File.write(f, contents) }

--- a/docs/source/_topic_map.yml
+++ b/docs/source/_topic_map.yml
@@ -41,6 +41,8 @@ Topics:
         File: static-ip
       - Name: Minishift Docker Daemon
         File: docker-daemon
+      - Name: Choosing the ISO Image
+        File: choosing-iso-image
       - Name: Experimental Features
         File: experimental-features
       - Name: Run Against An Existing Machine

--- a/docs/source/troubleshooting/troubleshooting-misc.adoc
+++ b/docs/source/troubleshooting/troubleshooting-misc.adoc
@@ -34,33 +34,6 @@ Depending on your operating system and shell environment, certain special charac
 
 Workaround: When creating and entering passwords, wrap the string with single quotes in the following format: `'<password>'`
 
-
-[[authentication-required-to-push-image]]
-== Authentication required to push image to OpenShift integrated Docker registry
-
-If you are using a Fedora, CentOS or RHEL host and you want to push to the OpenShift registry as described in xref:../openshift/openshift-docker-registry.adoc#[Accessing the OpenShift Docker Registry], you have to use the CentOS xref:../using/basic-usage.adoc#choosing-iso-image[ISO].
-Using the Boot2Docker or Minikube xref:../using/basic-usage.adoc#choosing-iso-image[ISO] will result in the following authorization error:
-
-----
-$ docker login -u developer -p `oc whoami -t` 172.30.1.1:5000
-Login Succeeded
-$ docker pull busybox
-$ docker tag busybox 172.30.1.1:5000/myproject/busybox:latest
-$ docker push 172.30.1.1:5000/myproject/busybox:latest
-The push refers to a repository [172.30.1.1:5000/myproject/busybox]
-6a749002dd6a: Preparing 
-unauthorized: authentication required
-----
-
-The reason is an incompatibility between the Docker client shipped with your host and the Docker daemon which is running inside the {project} VM.
-
-Workaround: Use the xref:../using/basic-usage.adoc#choosing-iso-image[CentOS ISO] when using {project} on Fedora, CentOS or RHEL.
-For example:
-
-----
-minishift start --iso-url centos
-----
-
 [[invalid-x509-certificate]]
 == X.509 certificate is valid for 10.0.2.15, 127.0.0.1, 172.17.0.1, 172.30.0.1, 192.168.99.100, not 192.168.99.101
 

--- a/docs/source/using/basic-usage.adoc
+++ b/docs/source/using/basic-usage.adoc
@@ -20,7 +20,7 @@ When you use {project}, you interact with the following components:
 
 The xref:../using/basic-usage.adoc#diagram-minishift-architecture[{project} architecture] diagram outlines these components.
 The `minishift` binary, placed on the `PATH` for easy execution, is used to xref:../using/basic-usage.adoc#minishift-start-overview[`start`], xref:../using/basic-usage.adoc#minishift-stop-overview[`stop`] and xref:../using/basic-usage.adoc#minishift-delete-overview[`delete`] the {project} VM.
-The VM itself is bootstrapping off a xref:../using/basic-usage.adoc#choosing-iso-image[pluggable] Live ISO.
+The VM itself is bootstrapped off of a xref:../using/choosing-iso-image.adoc#[pluggable, live ISO image].
 
 Some {project} commands, for example xref:../using/docker-daemon.adoc#[`docker-env`], interact with the Docker daemon, whilst others communicate with the OpenShift cluster, for example the xref:../command-ref/minishift_openshift.adoc#[`openshift`] command.
 
@@ -61,63 +61,6 @@ For details, see the GitHub issue link:https://github.com/minishift/minishift/is
 
 The xref:../command-ref/minishift_delete.adoc#[`minishift delete`] command deletes the OpenShift cluster, and also shuts down and deletes the {project} VM.
 No data or state are preserved.
-
-[[choosing-iso-image]]
-== Choosing the ISO Image
-
-When you start {project}, it downloads a live ISO image that the hypervisor uses to provision the {project} VM.
-
-The following ISO images are available:
-
-- link:https://github.com/minishift/minishift-centos-iso/releases[{project} CentOS] (Default).
-This ISO image is based on link:https://www.centos.org/[CentOS], which is an enterprise-ready Linux distribution that more closely resembles a production environment.
-The image size is larger than the Boot2Docker ISO image.
-
-- link:https://github.com/minishift/minishift-b2d-iso/releases[{project} Boot2Docker].
-This ISO image is based on link:https://github.com/boot2docker/boot2docker[Boot2Docker], which is a lightweight Linux distribution customized to run Docker containers.
-The image size is small and optimized for development but not for production.
-
-By default, {project} uses the {project} CentOS ISO image.
-To choose the {project} Boot2Docker ISO image instead, you can do one of the following:
-
-- Use the *b2d* alias to download and use the latest Boot2Docker ISO:
-+
-----
-$ minishift start --iso-url b2d
-----
-
-- Specify explicitly the download URL of the {project} Boot2Docker ISO image. For example:
-+
-[subs="attributes"]
-----
-$ minishift start --iso-url https://github.com/minishift/minishift-b2d-iso/releases/download/{b2d-iso-version}/minishift-b2d.iso
-----
-
-- Manually download the {project} Boot2Docker ISO image from the link:https://github.com/minishift/minishift-b2d-iso/releases[releases page] and enter the file URI to the image:
-
-[NOTE]
-====
-The path given for a file URI must be an absolute path.
-====
-- On Linux or macOS, the path must begin with *_/_*.
-For example:
-+
-----
-$ minishift start --iso-url file:///path/to/image.iso
-----
-
-- On Windows, the path must begin with a drive letter (*_C:_*, *_D:_*).
-For example:
-+
-----
-C:\> minishift.exe start --iso-url file://c:/path/to/image.iso
-----
-
-[NOTE]
-====
-You cannot run {project} with both ISO images concurrently.
-To switch between ISO images, delete the {project} instance and start a new instance with the ISO image that you want to use.
-====
 
 [[runtime-options]]
 == Runtime Options

--- a/docs/source/using/choosing-iso-image.adoc
+++ b/docs/source/using/choosing-iso-image.adoc
@@ -1,0 +1,57 @@
+include::variables.adoc[]
+
+= Choosing the ISO Image
+:icons:
+:toc: macro
+:toc-title:
+:toclevels: 1
+
+toc::[]
+
+[[choosing-iso-image-overview]]
+== Overview
+
+When you start {project}, it downloads a live ISO image that the hypervisor uses to provision the {project} VM.
+
+By default, {project} uses the link:https://github.com/minishift/minishift-centos-iso/releases[{project} CentOS ISO image].
+This ISO image is based on link:https://www.centos.org/[CentOS], an enterprise-ready Linux distribution that resembles a production environment.
+
+[NOTE]
+====
+You cannot run the same {project} instance with different ISO images concurrently.
+To switch between ISO images, delete the {project} instance and start a new instance with the ISO image that you want to use.
+====
+
+[[choosing-iso-image-using-remote-image]]
+== Using a Remote ISO Image
+
+To use a remotely available ISO image, specify the URL of the {project} ISO image during `minishift start` using the `--iso-url` flag:
+
+[subs="+attributes"]
+----
+$ minishift start --iso-url https://github.com/minishift/minishift-centos-iso/releases/download/{centos-iso-version}/minishift-centos7.iso
+----
+
+[[choosing-iso-image-using-local-image]]
+== Using a Local ISO Image
+
+To use a locally available ISO image, follow these steps:
+
+. Manually download the {project} CentOS ISO image from the link:https://github.com/minishift/minishift-centos-iso/releases[Minishift CentOS ISO releases page].
+. Specify the file URI to the image during `minishift start` using the `--iso-url` flag.
+
+The path given for a file URI must be an absolute path.
+
+On Linux or macOS, the path must begin with *_/_*.
+For example:
+
+----
+$ minishift start --iso-url file:///path/to/image.iso
+----
+
+On Windows, the path must begin with a drive letter such as *_C:_*.
+For example:
+
+----
+C:\> minishift.exe start --iso-url file://d:/path/to/image.iso
+----

--- a/docs/source/using/host-folders.adoc
+++ b/docs/source/using/host-folders.adoc
@@ -93,11 +93,6 @@ On Windows hosts, the `minishift hostfolder add` command also provides a `users-
 When this option is specified, no UNC path needs to be specified and *_C:\Users_* is assumed.
 ====
 
-[WARNING]
-====
-When you use the Boot2Docker ISO with the VirtualBox driver, VirtualBox guest additions are automatically enabled and occupy the *_/Users_* mount point.
-====
-
 ==== SSHFS
 
 [[adding-sshfs-hostfolder]]

--- a/docs/source/using/index.adoc
+++ b/docs/source/using/index.adoc
@@ -13,6 +13,7 @@ It covers the basic commands as well as advanced features like profiles, image c
 - xref:../using/host-folders.adoc#[Host Folders]
 - xref:../using/static-ip.adoc#[Assign Static IP Address]
 - xref:../using/docker-daemon.adoc#[{project} Docker Daemon]
+- xref:../using/choosing-iso-image.adoc#[Choosing the ISO Image]
 - xref:../using/experimental-features.adoc#[Experimental Features]
 - xref:../using/run-against-an-existing-machine.adoc#[Run Against An Existing Machine]
 

--- a/docs/source/using/static-ip.adoc
+++ b/docs/source/using/static-ip.adoc
@@ -31,13 +31,6 @@ However, it will not work on all of the driver plug-ins at the moment due to the
 Since the Internal Virtual Switch for Hyper-V does not provide a DHCP offer option, an IP address needs to be provided in a different way.
 Functionality is provided to assign an IP address on startup using the Data Exchange Service for Hyper-V.
 
-[IMPORTANT]
-====
-This only works with the CentOS or RHEL xref:../using/basic-usage.adoc#choosing-iso-image[ISO] in combination with Hyper-V.
-The Boot2Docker ISO image experiences a problem when the values are being sent to the {project} instance and consumed by the Boot2Docker ISO.
-We are looking into the issue and hope to provide a solution in the future.
-====
-
 to make this work, you need to create a link:https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/setup-nat-network[Virtual Switch using NAT].
 
 [NOTE]
@@ -78,7 +71,7 @@ Failing to do so will result in connectivity issues.
 
 [IMPORTANT]
 ====
-This only works with the CentOS or RHEL xref:../using/basic-usage.adoc#choosing-iso-image[ISO] and is currently not supported on KVM as the driver plug-in relies on the DHCP offer to determine the IP address.
+This feature is not supported on KVM as the driver plug-in relies on the DHCP offer to determine the IP address.
 ====
 
 The following command will set the IP address that was assigned as fixed:


### PR DESCRIPTION
Fixes #3053.

This also removes references to the Minikube ISO.