### PR TITLE
Issue #3091 Fail when json configuration is invalid

### DIFF
--- a/pkg/minishift/config/allinstancesconfig.go
+++ b/pkg/minishift/config/allinstancesconfig.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/minishift/minishift/pkg/minishift/hostfolder/config"
 	"io/ioutil"
 	"os"
@@ -81,6 +82,10 @@ func (cfg *GlobalConfigType) read() error {
 	raw, err := ioutil.ReadFile(cfg.FilePath)
 	if err != nil {
 		return err
+	}
+
+	if !json.Valid(raw) {
+		return errors.New("Invalid JSON")
 	}
 
 	json.Unmarshal(raw, &cfg)

--- a/pkg/minishift/config/instance_config.go
+++ b/pkg/minishift/config/instance_config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 
@@ -80,6 +81,10 @@ func (cfg *InstanceConfigType) read() error {
 	raw, err := ioutil.ReadFile(cfg.FilePath)
 	if err != nil {
 		return err
+	}
+
+	if !json.Valid(raw) {
+		return errors.New("Invalid JSON")
 	}
 
 	json.Unmarshal(raw, &cfg)

--- a/pkg/minishift/config/instance_state_config.go
+++ b/pkg/minishift/config/instance_state_config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 
@@ -86,6 +87,10 @@ func (cfg *InstanceStateConfigType) read() error {
 	raw, err := ioutil.ReadFile(cfg.FilePath)
 	if err != nil {
 		return err
+	}
+
+	if !json.Valid(raw) {
+		return errors.New("Invalid JSON")
 	}
 
 	json.Unmarshal(raw, &cfg)


### PR DESCRIPTION
edit `allinstances.json` and put in an erroneous character.