### PR TITLE
Issue #3054 Add command to start and stop systemtray in background

### DIFF
--- a/cmd/minishift/cmd/daemon/daemon.go
+++ b/cmd/minishift/cmd/daemon/daemon.go
@@ -1,5 +1,3 @@
-// +build !systemtray
-
 /*
 Copyright (C) 2018 Red Hat, Inc.
 
@@ -16,29 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package services
+package daemon
 
 import (
-	"runtime"
-
-	"github.com/anjannath/systray"
-	"github.com/minishift/minishift/pkg/minishift/systemtray"
 	"github.com/spf13/cobra"
 )
 
-// systemtrayCmd represents the systemtray command
-var systemtrayServiceCmd = &cobra.Command{
-	Use:   "systemtray",
-	Short: "Run minishift systemtray",
-	Long:  "Run a systemtray in the notification area of top bar/start menu",
+var DaemonCmd = &cobra.Command{
+	Use:   "daemon",
+	Short: "Starts a minishift service daemon.",
+	Long:  `Starts a minishift service daemon, this is only to be used internally by Minishift`,
 	Run: func(cmd *cobra.Command, args []string) {
-		systray.Run(systemtray.OnReady, systemtray.OnExit)
+		cmd.Help()
 	},
 	Hidden: true,
-}
-
-func init() {
-	if runtime.GOOS != "linux" {
-		ServicesCmd.AddCommand(systemtrayServiceCmd)
-	}
 }

--- a/cmd/minishift/cmd/daemon/proxy.go
+++ b/cmd/minishift/cmd/daemon/proxy.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package services
+package daemon
 
 import (
 	"github.com/minishift/minishift/cmd/minishift/cmd/config"
@@ -33,7 +33,7 @@ var (
 	proxyUpstreamAddrFromFlag string
 	proxyReEncryptFlag        bool
 
-	servicesProxyCmd = &cobra.Command{
+	daemonProxyCmd = &cobra.Command{
 		Use:    "proxy",
 		Short:  "Starts a proxy server on host",
 		Long:   `Starts a proxy server on host`,
@@ -43,10 +43,10 @@ var (
 )
 
 func init() {
-	servicesProxyCmd.Flags().IntVarP(&proxyServerPortFromFlag, proxyServerPortFlag, "p", 3128, "The server port.")
-	servicesProxyCmd.Flags().StringVarP(&proxyUpstreamAddrFromFlag, proxyUpstreamFlag, "u", "", "The upstream proxy address.")
-	servicesProxyCmd.Flags().BoolVarP(&proxyReEncryptFlag, "reencrypt", "r", false, "Re-encrypt traffic")
-	ServicesCmd.AddCommand(servicesProxyCmd)
+	daemonProxyCmd.Flags().IntVarP(&proxyServerPortFromFlag, proxyServerPortFlag, "p", 3128, "The server port.")
+	daemonProxyCmd.Flags().StringVarP(&proxyUpstreamAddrFromFlag, proxyUpstreamFlag, "u", "", "The upstream proxy address.")
+	daemonProxyCmd.Flags().BoolVarP(&proxyReEncryptFlag, "reencrypt", "r", false, "Re-encrypt traffic")
+	DaemonCmd.AddCommand(daemonProxyCmd)
 }
 
 func runProxy(cmd *cobra.Command, args []string) {

--- a/cmd/minishift/cmd/daemon/sftpd.go
+++ b/cmd/minishift/cmd/daemon/sftpd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package services
+package daemon
 
 import (
 	"fmt"
@@ -42,7 +42,7 @@ var (
 	connectionCount uint64
 	sftpdServerPort int
 
-	servicesSftpdCmd = &cobra.Command{
+	daemonSftpdCmd = &cobra.Command{
 		Use:    "sftpd",
 		Short:  "Starts sftp server on host for sshfs based host folders.",
 		Long:   `Starts sftp server on host for sshfs based host folders.`,
@@ -55,8 +55,8 @@ var (
 
 func init() {
 	authorizedKeysMap = make(map[string]bool)
-	servicesSftpdCmd.Flags().IntVarP(&sftpdServerPort, sftpdServerPortFlag, "p", 2022, "The server port.")
-	ServicesCmd.AddCommand(servicesSftpdCmd)
+	daemonSftpdCmd.Flags().IntVarP(&sftpdServerPort, sftpdServerPortFlag, "p", 2022, "The server port.")
+	DaemonCmd.AddCommand(daemonSftpdCmd)
 }
 
 func runSftp(cmd *cobra.Command, args []string) {

--- a/cmd/minishift/cmd/daemon/systemtray.go
+++ b/cmd/minishift/cmd/daemon/systemtray.go
@@ -1,3 +1,5 @@
+// +build !systemtray
+
 /*
 Copyright (C) 2018 Red Hat, Inc.
 
@@ -14,18 +16,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package services
+package daemon
 
 import (
+	"runtime"
+
+	"github.com/anjannath/systray"
+	"github.com/minishift/minishift/pkg/minishift/systemtray"
 	"github.com/spf13/cobra"
 )
 
-var ServicesCmd = &cobra.Command{
-	Use:     "services SUBCOMMAND [flags]",
-	Aliases: []string{"service"},
-	Short:   "Manage Minishift services",
-	Long:    `Manage Minishift services.`,
+// systemtrayServiceCmd represents the systemtray command
+var systemtrayDaemonCmd = &cobra.Command{
+	Use:   "systemtray",
+	Short: "Run minishift systemtray.",
+	Long:  "Run a systemtray in the notification area of top bar/start menu.",
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		systray.Run(systemtray.OnReady, systemtray.OnExit)
 	},
+	Hidden: true,
+}
+
+func init() {
+	if runtime.GOOS != "linux" {
+		DaemonCmd.AddCommand(systemtrayDaemonCmd)
+	}
 }

--- a/cmd/minishift/cmd/root.go
+++ b/cmd/minishift/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minishift/minishift/cmd/minishift/cmd/addon"
 	cmdAddon "github.com/minishift/minishift/cmd/minishift/cmd/addon"
 	configCmd "github.com/minishift/minishift/cmd/minishift/cmd/config"
+	daemonCmd "github.com/minishift/minishift/cmd/minishift/cmd/daemon"
 	"github.com/minishift/minishift/cmd/minishift/cmd/dns"
 	hostfolderCmd "github.com/minishift/minishift/cmd/minishift/cmd/hostfolder"
 	"github.com/minishift/minishift/cmd/minishift/cmd/image"
@@ -257,6 +258,7 @@ func init() {
 	RootCmd.AddCommand(cmdOpenshift.OpenShiftCmd)
 	RootCmd.AddCommand(hostfolderCmd.HostFolderCmd)
 	RootCmd.AddCommand(servicesCmd.ServicesCmd)
+	RootCmd.AddCommand(daemonCmd.DaemonCmd)
 	RootCmd.AddCommand(addon.AddonsCmd)
 	RootCmd.AddCommand(image.ImageCmd)
 	RootCmd.AddCommand(cmdProfile.ProfileCmd)

--- a/cmd/minishift/cmd/services/list.go
+++ b/cmd/minishift/cmd/services/list.go
@@ -17,15 +17,27 @@ limitations under the License.
 package services
 
 import (
+	"fmt"
+
+	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
 	"github.com/spf13/cobra"
 )
 
-var ServicesCmd = &cobra.Command{
-	Use:     "services SUBCOMMAND [flags]",
-	Aliases: []string{"service"},
-	Short:   "Manage Minishift services",
-	Long:    `Manage Minishift services.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
-	},
+// serviceListCmd represents the list command
+var serviceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the available Minishift services.",
+	Long:  "List the available Minishift services.",
+	Run:   runServiceList,
+}
+
+func init() {
+	ServicesCmd.AddCommand(serviceListCmd)
+}
+
+func runServiceList(cmd *cobra.Command, args []string) {
+	fmt.Printf("The following Minishift services are available: \n")
+	for _, component := range minishiftConstants.ValidServices {
+		fmt.Printf("\t- %s\n", component)
+	}
 }

--- a/cmd/minishift/cmd/services/start.go
+++ b/cmd/minishift/cmd/services/start.go
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"runtime"
+
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
+	"github.com/minishift/minishift/pkg/minishift/network/proxy"
+	"github.com/minishift/minishift/pkg/minishift/systemtray"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
+	"github.com/spf13/cobra"
+)
+
+const (
+	serviceNotSpecifiedError = "You must specify a service to start (use 'minishift services list' to find available services)."
+)
+
+// daemonStartCmd represents the start command
+var daemonStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start a minishift service.",
+	Long:  "Start a minishift service.",
+	Run:   runServiceStart,
+}
+
+func init() {
+	ServicesCmd.AddCommand(daemonStartCmd)
+}
+
+func runServiceStart(cmd *cobra.Command, args []string) {
+	if len(args) <= 0 {
+		atexit.ExitWithMessage(1, serviceNotSpecifiedError)
+	}
+	service := args[0]
+	if !minishiftStrings.Contains(minishiftConstants.ValidServices, service) {
+		atexit.ExitWithMessage(1, InvalidServiceNameError)
+	}
+
+	switch service {
+	case minishiftConstants.SystemtrayDaemon:
+		if runtime.GOOS == "linux" {
+			atexit.ExitWithMessage(0, "System tray is not supported in Linux")
+		}
+		minishiftTray := systemtray.NewMinishiftTray(minishiftConfig.AllInstancesConfig)
+		minishiftTray.EnsureRunning()
+	case minishiftConstants.SftpdDaemon:
+		// Add code to start sftpd
+		atexit.ExitWithMessage(0, "Start functionality for SFTP daemon is not available")
+	case minishiftConstants.ProxyDaemon:
+		proxy.EnsureProxyDaemonRunning()
+	default:
+		return
+	}
+}

--- a/cmd/minishift/cmd/services/stop.go
+++ b/cmd/minishift/cmd/services/stop.go
@@ -1,0 +1,89 @@
+/*
+Copyright (C) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	minishiftConfig "github.com/minishift/minishift/pkg/minishift/config"
+	minishiftConstants "github.com/minishift/minishift/pkg/minishift/constants"
+	"github.com/minishift/minishift/pkg/minishift/network/proxy"
+	"github.com/minishift/minishift/pkg/minishift/systemtray"
+	"github.com/minishift/minishift/pkg/util/os/atexit"
+	minishiftStrings "github.com/minishift/minishift/pkg/util/strings"
+	"github.com/spf13/cobra"
+)
+
+const (
+	ServiceNotSpecifiedError = "You need to specify a service to stop"
+	InvalidServiceNameError  = "You have specified an invalid service name"
+)
+
+// daemonStopCmd represents the stop command
+var daemonStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop a minishift service.",
+	Long:  "Stop a minishift service.",
+	Run:   runServiceStop,
+}
+
+func init() {
+	ServicesCmd.AddCommand(daemonStopCmd)
+}
+
+func runServiceStop(cmd *cobra.Command, args []string) {
+	if len(args) <= 0 {
+		atexit.ExitWithMessage(1, ServiceNotSpecifiedError)
+	}
+
+	service := args[0]
+
+	if !minishiftStrings.Contains(minishiftConstants.ValidServices, service) {
+		atexit.ExitWithMessage(1, InvalidServiceNameError)
+	}
+
+	switch service {
+	case minishiftConstants.SystemtrayDaemon:
+		if runtime.GOOS == "linux" {
+			atexit.ExitWithMessage(0, "System tray is not supported in Linux")
+		}
+		minishiftTray := systemtray.NewMinishiftTray(minishiftConfig.AllInstancesConfig)
+		if pid := minishiftTray.GetPID(); pid > 0 {
+			proc, _ := os.FindProcess(pid)
+			proc.Kill()
+			atexit.ExitWithMessage(0, fmt.Sprintf("Killed process with PID: %d\n", pid))
+		}
+	case minishiftConstants.SftpdDaemon:
+		pid := minishiftConfig.AllInstancesConfig.SftpdPID
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			atexit.ExitWithMessage(1, "Unable to get Sftp daemon process using PID")
+		}
+		proc.Kill()
+		atexit.ExitWithMessage(0, fmt.Sprintf("Killed process with PID: %d\n", pid))
+	case minishiftConstants.ProxyDaemon:
+		if pid := proxy.GetPID(); pid > 0 {
+			proc, _ := os.FindProcess(pid)
+			proc.Kill()
+			atexit.ExitWithMessage(0, fmt.Sprintf("Killed process with PID: %d\n", pid))
+		}
+	default:
+		return
+	}
+}

--- a/docs/source/using/experimental-features.adoc
+++ b/docs/source/using/experimental-features.adoc
@@ -295,6 +295,12 @@ the following command:
 $ minishift config set auto-start-tray false
 ----
 
+To start the tray as a daemon process without starting the cluster:
+
+----
+$ minishift service start systemtray
+----
+
 [[timezone]]
 == Timezone Setup
 

--- a/pkg/minishift/constants/constants.go
+++ b/pkg/minishift/constants/constants.go
@@ -40,11 +40,15 @@ const (
 	HypervDefaultVirtualSwitchName = "Default Switch"
 	DockerbridgeSubnetCmd          = `docker network inspect -f "{{range .IPAM.Config }}{{ .Subnet }}{{end}}" bridge`
 	MinishiftEnableExperimental    = "MINISHIFT_ENABLE_EXPERIMENTAL"
+	SystemtrayDaemon               = "systemtray"
+	SftpdDaemon                    = "sftpd"
+	ProxyDaemon                    = "proxy"
 )
 
 var (
 	ValidIsoAliases = []string{CentOsIsoAlias}
 	ValidComponents = []string{"automation-service-broker", "service-catalog", "template-service-broker"}
+	ValidServices   = []string{SystemtrayDaemon, SftpdDaemon, ProxyDaemon}
 )
 
 // ProfileAuthorizedKeysPath returns the path of authorized_keys file in profile dir used for authentication purpose

--- a/pkg/minishift/hostfolder/sshfs_hostfolder.go
+++ b/pkg/minishift/hostfolder/sshfs_hostfolder.go
@@ -216,7 +216,7 @@ func createSftpCommand() (*exec.Cmd, error) {
 	}
 
 	args := []string{
-		"services",
+		"daemon",
 		"sftpd"}
 	exportCmd := exec.Command(cmd, args...)
 	// don't inherit any file handles

--- a/pkg/minishift/network/proxy/localproxy.go
+++ b/pkg/minishift/network/proxy/localproxy.go
@@ -168,7 +168,7 @@ func createProxyCommand() (*exec.Cmd, error) {
 	}
 
 	args := []string{
-		"services",
+		"daemon",
 		"proxy"}
 	exportCmd := exec.Command(cmd, args...)
 	// don't inherit any file handles
@@ -179,4 +179,11 @@ func createProxyCommand() (*exec.Cmd, error) {
 	exportCmd.Env = process.EnvForBackgroundProcess()
 
 	return exportCmd, nil
+}
+
+func GetPID() int {
+	if isRunning() {
+		return config.AllInstancesConfig.ProxyPID
+	}
+	return 0
 }

--- a/pkg/minishift/systemtray/minishifttray.go
+++ b/pkg/minishift/systemtray/minishifttray.go
@@ -45,7 +45,7 @@ func minishiftTrayCommand() (*exec.Cmd, error) {
 		return nil, err
 	}
 	args := []string{
-		"services",
+		"daemon",
 		"systemtray",
 	}
 	exportCmd := exec.Command(cmd, args...)
@@ -104,4 +104,11 @@ func (s *MinishiftTray) isRunning() bool {
 	} else {
 		return false
 	}
+}
+
+func (s *MinishiftTray) GetPID() int {
+	if s.isRunning() {
+		return s.globalConfig.SystrayPID
+	}
+	return 0
 }

--- a/pkg/minishift/systemtray/minishifttraystub.go
+++ b/pkg/minishift/systemtray/minishifttraystub.go
@@ -33,3 +33,7 @@ func NewMinishiftTray(globalConfig *minishiftConfig.GlobalConfigType) *Minishift
 func (s *MinishiftTray) EnsureRunning() error {
 	return nil
 }
+
+func (s *MinishiftTray) GetPID() int {
+	return 0
+}


### PR DESCRIPTION
Fixes #3054 #3062 


Steps to test the pull request

Use these binaries for [windows](https://5829-62728051-gh.circle-artifacts.com/0/ms/windows-amd64/systemtray/minishift.exe) and [darwin](https://5829-62728051-gh.circle-artifacts.com/0/ms/darwin-amd64/systemtray/minishift)

  1. `minishift services start systemtray` ==> Starts the tray in background
  2. `minishift start` ==> shouldn't launch a new tray, as one is already running
  3. `minishift service stop systemtray` ==> kills the tray process

Going forward we can daemonize this command and make the tray launch at os start.

