### PR TITLE
Issue #3139 Add Make to development prerequisites

### DIFF
--- a/docs/source/contributing/developing.adoc
+++ b/docs/source/contributing/developing.adoc
@@ -17,6 +17,7 @@ The following sections describe how to build and test {project}.
 == Prerequisites
 
 - Git
+- Make
 - A recent Go distribution (>=1.8)
 
 [NOTE]


### PR DESCRIPTION
Fixes #3139 

**Note:** Originally, I had intended to include steps for installing Make, but we currently do not have such instructions for Git or a recent Go distribution. For this reason, I assume that we expect developers to know how to install the prerequisites.