### PR TITLE
[WIP] Issue #3163 Remove separate systemtray tragets from makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,6 @@ jobs:
         name: Make prerelease
         command: cd $GOPATH/src/github.com/minishift/minishift && make prerelease
     - run:
-        name: Make systemtray 
-        command: cd $GOPATH/src/github.com/minishift/minishift && make cross_systemtray
-    - run:
         name: Validate Commits
         command: cd $GOPATH/src/github.com/minishift/minishift && make validate_commits
 ## Currently unable to use environment variables in the store_artifacts path in V2


### PR DESCRIPTION
Fixes #3163 

Steps to test the pull request

  1. `make clean`
  2.  `make cross`
  3.  `make`
  
Should build minishift, minishift.exe on linux environment, and all the binaries in macOS environment. (with systemtray wherever applicable)

