### PR TITLE
Issue #3171 Tests fail to get status of container in older PS/cmd

### DIFF
--- a/test/integration/features/cmd-openshift.feature
+++ b/test/integration/features/cmd-openshift.feature
@@ -36,10 +36,10 @@ cluster in VM provided by Minishift.
         finished last time. When container is new and had never finished then this time value is set to 0001-01-01T00:00:00Z.
         On restart of OpenShift cluster containers are terminated, which sets FinishedAt to actual time. This value persist
         after next start of container.
-    Given stdout of command "minishift ssh -- "docker inspect --format={{.State.FinishedAt}} origin"" is equal to "0001-01-01T00:00:00Z"
+    Given stdout of command "minishift ssh -- 'docker inspect --format={{.State.FinishedAt}} origin'" is equal to "0001-01-01T00:00:00Z"
      When executing "minishift openshift restart" succeeds
      Then stdout should contain "OpenShift restarted successfully"
-      And stdout of command "minishift ssh -- "docker inspect --format={{.State.FinishedAt}} origin"" is not equal to "0001-01-01T00:00:00Z"
+      And stdout of command "minishift ssh -- 'docker inspect --format={{.State.FinishedAt}} origin'" is not equal to "0001-01-01T00:00:00Z"
 
   Scenario: Pods docker-registry and router are ready after OpenShift restart
      When executing "oc get pods -n default --as system:admin" retrying 20 times with wait period of "15s"

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -249,7 +249,7 @@ func (m *MinishiftRunner) GetProfileList() string {
 }
 
 func (m *MinishiftRunner) GetContainerID(containerName string) (string, error) {
-	cmd := fmt.Sprintf(`ssh -- docker ps -a -f "name=%v" --format {{.ID}}`, containerName)
+	cmd := fmt.Sprintf(`ssh -- 'docker ps -a -f name=%v --format {{.ID}}'`, containerName)
 	cmdOut, cmdErr, _, err := m.RunCommand(cmd)
 	if err != nil {
 		return "", err
@@ -268,7 +268,8 @@ func (m *MinishiftRunner) GetContainerID(containerName string) (string, error) {
 }
 
 func (m *MinishiftRunner) GetContainerStatusUsingImageID(imageID string) (string, error) {
-	cmdOut, cmdErr, _, err := m.RunCommand("ssh -- docker inspect -f '{{.State.Status}}' " + imageID)
+	cmd := fmt.Sprintf(`ssh -- 'docker inspect -f {{.State.Status}} %v'`, imageID)
+	cmdOut, cmdErr, _, err := m.RunCommand(cmd)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #3171 


Steps to test the pull request

  1. `make integration GODOG_OPTS=-tags=basic`

I've tested the PR on Windows 7 and 10 and Fedora, works fine.

