### PR TITLE
[WIP] Issue #3229 - Add remote SSH port to remote machine parameters

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -56,6 +56,7 @@ var (
 	RegistryMirror        = createConfigSetting("registry-mirror", SetSlice, nil, nil, true, nil)
 	AddonEnv              = createConfigSetting("addon-env", SetSlice, nil, nil, true, nil)
 	RemoteIPAddress       = createConfigSetting("remote-ipaddress", SetString, nil, nil, true, nil)
+	RemoteIPPort          = createConfigSetting("remote-ipport", SetString, nil, nil, true, "22")
 	RemoteSSHUser         = createConfigSetting("remote-ssh-user", SetString, nil, nil, true, nil)
 	SSHKeyToConnectRemote = createConfigSetting("remote-ssh-key", SetString, nil, nil, true, nil)
 	TimeZone              = createConfigSetting("timezone", SetString, []setFn{validations.IsValidTimezone}, nil, true, nil)

--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -56,7 +56,7 @@ var (
 	RegistryMirror        = createConfigSetting("registry-mirror", SetSlice, nil, nil, true, nil)
 	AddonEnv              = createConfigSetting("addon-env", SetSlice, nil, nil, true, nil)
 	RemoteIPAddress       = createConfigSetting("remote-ipaddress", SetString, nil, nil, true, nil)
-	RemoteIPPort          = createConfigSetting("remote-ipport", SetString, nil, nil, true, "22")
+	RemoteIPPort          = createConfigSetting("remote-ipport", SetInt, nil, nil, true, 22)
 	RemoteSSHUser         = createConfigSetting("remote-ssh-user", SetString, nil, nil, true, nil)
 	SSHKeyToConnectRemote = createConfigSetting("remote-ssh-key", SetString, nil, nil, true, nil)
 	TimeZone              = createConfigSetting("timezone", SetString, []setFn{validations.IsValidTimezone}, nil, true, nil)

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -18,10 +18,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/minishift/minishift/pkg/minishift/timezone"
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/minishift/minishift/pkg/minishift/timezone"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/docker/go-units"
@@ -160,6 +161,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	if viper.GetString(configCmd.VmDriver.Name) == genericDriver {
 		cmdUtil.ValidateGenericDriverFlags(viper.GetString(configCmd.RemoteIPAddress.Name),
+			viper.GetString(configCmd.RemoteIPPort.Name),
 			viper.GetString(configCmd.RemoteSSHUser.Name),
 			viper.GetString(configCmd.SSHKeyToConnectRemote.Name))
 	}
@@ -445,6 +447,7 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 		HypervVirtualSwitch:   viper.GetString(configCmd.HypervVirtualSwitch.Name),
 		ShellProxyEnv:         shellProxyEnv,
 		RemoteIPAddress:       viper.GetString(configCmd.RemoteIPAddress.Name),
+		RemoteIPPort:          viper.GetString(configCmd.RemoteIPPort.Name),
 		RemoteSSHUser:         viper.GetString(configCmd.RemoteSSHUser.Name),
 		SSHKeyToConnectRemote: viper.GetString(configCmd.SSHKeyToConnectRemote.Name),
 		UsingLocalProxy:       viper.GetBool(configCmd.LocalProxy.Name),
@@ -471,7 +474,7 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 
 		fmt.Print("-- Starting Minishift VM ...")
 	} else {
-		s, err := sshutil.NewRawSSHClient(machineConfig.RemoteIPAddress, machineConfig.SSHKeyToConnectRemote, machineConfig.RemoteSSHUser)
+		s, err := sshutil.NewRawSSHClient(machineConfig.RemoteIPAddress, machineConfig.RemoteIPPort, machineConfig.SSHKeyToConnectRemote, machineConfig.RemoteSSHUser)
 		if err != nil {
 			atexit.ExitWithMessage(1, fmt.Sprintf("Error creating ssh client: %v", err))
 		}
@@ -693,6 +696,7 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.String(configCmd.OpenshiftVersion.Name, version.GetOpenShiftVersion(), fmt.Sprintf("The OpenShift version to run, eg. latest or %s", version.GetOpenShiftVersion()))
 
 	startFlagSet.String(configCmd.RemoteIPAddress.Name, "", "IP address of the remote machine to provision OpenShift on")
+	startFlagSet.String(configCmd.RemoteIPPort.Name, "", "IP port of the remote machine to provision OpenShift on")
 	startFlagSet.String(configCmd.RemoteSSHUser.Name, "", "The username of the remote machine to provision OpenShift on")
 	startFlagSet.String(configCmd.SSHKeyToConnectRemote.Name, "", "SSH private key location on the host to connect remote machine")
 	startFlagSet.String(configCmd.ISOUrl.Name, minishiftConstants.CentOsIsoAlias, "Location of the minishift ISO. Can be a URL, file URI or one of the following short names: [centos].")

--- a/cmd/minishift/cmd/start.go
+++ b/cmd/minishift/cmd/start.go
@@ -161,7 +161,6 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	if viper.GetString(configCmd.VmDriver.Name) == genericDriver {
 		cmdUtil.ValidateGenericDriverFlags(viper.GetString(configCmd.RemoteIPAddress.Name),
-			viper.GetString(configCmd.RemoteIPPort.Name),
 			viper.GetString(configCmd.RemoteSSHUser.Name),
 			viper.GetString(configCmd.SSHKeyToConnectRemote.Name))
 	}
@@ -447,7 +446,7 @@ func startHost(libMachineClient *libmachine.Client) *host.Host {
 		HypervVirtualSwitch:   viper.GetString(configCmd.HypervVirtualSwitch.Name),
 		ShellProxyEnv:         shellProxyEnv,
 		RemoteIPAddress:       viper.GetString(configCmd.RemoteIPAddress.Name),
-		RemoteIPPort:          viper.GetString(configCmd.RemoteIPPort.Name),
+		RemoteIPPort:          viper.GetInt(configCmd.RemoteIPPort.Name),
 		RemoteSSHUser:         viper.GetString(configCmd.RemoteSSHUser.Name),
 		SSHKeyToConnectRemote: viper.GetString(configCmd.SSHKeyToConnectRemote.Name),
 		UsingLocalProxy:       viper.GetBool(configCmd.LocalProxy.Name),
@@ -696,7 +695,7 @@ func initStartFlags() *flag.FlagSet {
 	startFlagSet.String(configCmd.OpenshiftVersion.Name, version.GetOpenShiftVersion(), fmt.Sprintf("The OpenShift version to run, eg. latest or %s", version.GetOpenShiftVersion()))
 
 	startFlagSet.String(configCmd.RemoteIPAddress.Name, "", "IP address of the remote machine to provision OpenShift on")
-	startFlagSet.String(configCmd.RemoteIPPort.Name, "", "IP port of the remote machine to provision OpenShift on")
+	startFlagSet.Int(configCmd.RemoteIPPort.Name, 22, "IP port of the remote machine to provision OpenShift on")
 	startFlagSet.String(configCmd.RemoteSSHUser.Name, "", "The username of the remote machine to provision OpenShift on")
 	startFlagSet.String(configCmd.SSHKeyToConnectRemote.Name, "", "SSH private key location on the host to connect remote machine")
 	startFlagSet.String(configCmd.ISOUrl.Name, minishiftConstants.CentOsIsoAlias, "Location of the minishift ISO. Can be a URL, file URI or one of the following short names: [centos].")

--- a/cmd/minishift/cmd/util/util.go
+++ b/cmd/minishift/cmd/util/util.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/docker/machine/libmachine"
@@ -161,16 +160,12 @@ func GetNoProxyConfig(api libmachine.API) (string, string, error) {
 	return noProxyVar, noProxyValue, nil
 }
 
-func ValidateGenericDriverFlags(remoteIPAddress, remoteIPPort, remoteSSHUser, sshKeyToConnectRemote string) {
+func ValidateGenericDriverFlags(remoteIPAddress, remoteSSHUser, sshKeyToConnectRemote string) {
 	if remoteIPAddress == "" || remoteSSHUser == "" || sshKeyToConnectRemote == "" {
 		msg := fmt.Sprintf("Generic driver require additional information i.e. IP address of remote machine, path to ssh key and ssh username of the remote host.\n"+
 			"Provide following flags to use generic driver:\n"+
 			"--%s string\n--%s string\n--%s string\n", configCmd.RemoteIPAddress.Name, configCmd.RemoteSSHUser.Name, configCmd.SSHKeyToConnectRemote.Name)
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error: %s", msg))
-	}
-	_, err := strconv.Atoi(remoteIPPort)
-	if err != nil {
-		atexit.ExitWithMessage(1, fmt.Sprintf("The provided SSH Port %s is not valid.", remoteIPPort))
 	}
 }
 

--- a/cmd/minishift/cmd/util/util.go
+++ b/cmd/minishift/cmd/util/util.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/docker/machine/libmachine"
@@ -160,12 +161,16 @@ func GetNoProxyConfig(api libmachine.API) (string, string, error) {
 	return noProxyVar, noProxyValue, nil
 }
 
-func ValidateGenericDriverFlags(remoteIPAddress, remoteSSHUser, sshKeyToConnectRemote string) {
+func ValidateGenericDriverFlags(remoteIPAddress, remoteIPPort, remoteSSHUser, sshKeyToConnectRemote string) {
 	if remoteIPAddress == "" || remoteSSHUser == "" || sshKeyToConnectRemote == "" {
 		msg := fmt.Sprintf("Generic driver require additional information i.e. IP address of remote machine, path to ssh key and ssh username of the remote host.\n"+
 			"Provide following flags to use generic driver:\n"+
 			"--%s string\n--%s string\n--%s string\n", configCmd.RemoteIPAddress.Name, configCmd.RemoteSSHUser.Name, configCmd.SSHKeyToConnectRemote.Name)
 		atexit.ExitWithMessage(1, fmt.Sprintf("Error: %s", msg))
+	}
+	_, err := strconv.Atoi(remoteIPPort)
+	if err != nil {
+		atexit.ExitWithMessage(1, fmt.Sprintf("The provided SSH Port %s is not valid.", remoteIPPort))
 	}
 }
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -176,7 +176,7 @@ type MachineConfig struct {
 	ShellProxyEnv         util.ProxyConfig // Only used for proxy purpose
 	HypervVirtualSwitch   string
 	RemoteIPAddress       string // Only used for generic driver purpose to connect remote machine
-	RemoteIPPort          string // Only used for generic driver purpose to connect remote machine
+	RemoteIPPort          int    // Only used for generic driver purpose to connect remote machine
 	RemoteSSHUser         string // Only used for generic driver purpose to specify ssh user
 	SSHKeyToConnectRemote string // Only used for generic driver purpose to specify ssh key path
 	UsingLocalProxy       bool

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -176,6 +176,7 @@ type MachineConfig struct {
 	ShellProxyEnv         util.ProxyConfig // Only used for proxy purpose
 	HypervVirtualSwitch   string
 	RemoteIPAddress       string // Only used for generic driver purpose to connect remote machine
+	RemoteIPPort          string // Only used for generic driver purpose to connect remote machine
 	RemoteSSHUser         string // Only used for generic driver purpose to specify ssh user
 	SSHKeyToConnectRemote string // Only used for generic driver purpose to specify ssh key path
 	UsingLocalProxy       bool

--- a/pkg/minikube/cluster/cluster_common.go
+++ b/pkg/minikube/cluster/cluster_common.go
@@ -25,6 +25,7 @@ import (
 
 type genericDriverOptions struct {
 	remoteIP              string
+	remotePort            string
 	remoteSSHUser         string
 	sshKeyToConnectRemote string
 }
@@ -33,6 +34,7 @@ func (g genericDriverOptions) String(key string) string {
 	genericStringOptions := make(map[string]string)
 	genericStringOptions["generic-ssh-user"] = g.remoteSSHUser
 	genericStringOptions["generic-ip-address"] = g.remoteIP
+	genericStringOptions["generic-ssh-port"] = g.remotePort
 	genericStringOptions["generic-ssh-key"] = g.sshKeyToConnectRemote
 	return genericStringOptions[key]
 }
@@ -56,6 +58,7 @@ func createGenericDriverConfig(config MachineConfig) drivers.Driver {
 	d := generic.NewDriver(constants.MachineName, constants.Minipath)
 	remoteOptions := genericDriverOptions{
 		remoteIP:              config.RemoteIPAddress,
+		remotePort:            config.RemoteIPPort,
 		remoteSSHUser:         config.RemoteSSHUser,
 		sshKeyToConnectRemote: config.SSHKeyToConnectRemote,
 	}

--- a/pkg/minikube/cluster/cluster_common.go
+++ b/pkg/minikube/cluster/cluster_common.go
@@ -25,7 +25,7 @@ import (
 
 type genericDriverOptions struct {
 	remoteIP              string
-	remotePort            string
+	remotePort            int
 	remoteSSHUser         string
 	sshKeyToConnectRemote string
 }
@@ -34,7 +34,6 @@ func (g genericDriverOptions) String(key string) string {
 	genericStringOptions := make(map[string]string)
 	genericStringOptions["generic-ssh-user"] = g.remoteSSHUser
 	genericStringOptions["generic-ip-address"] = g.remoteIP
-	genericStringOptions["generic-ssh-port"] = g.remotePort
 	genericStringOptions["generic-ssh-key"] = g.sshKeyToConnectRemote
 	return genericStringOptions[key]
 }
@@ -46,7 +45,7 @@ func (g genericDriverOptions) StringSlice(key string) []string {
 func (g genericDriverOptions) Int(key string) int {
 	genericIntOptions := make(map[string]int)
 	genericIntOptions["generic-engine-port"] = 2376
-	genericIntOptions["generic-ssh-port"] = 22
+	genericIntOptions["generic-ssh-port"] = g.remotePort
 	return genericIntOptions[key]
 }
 

--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -63,11 +63,10 @@ func NewSSHClient(d drivers.Driver) (*ssh.Client, error) {
 	return client, nil
 }
 
-func NewRawSSHClient(ip, port, sshKeyPath, username string) (*ssh.Client, error) {
-	p, _ := strconv.Atoi(port)
+func NewRawSSHClient(ip string, port int, sshKeyPath, username string) (*ssh.Client, error) {
 	h := &sshHost{
 		IP:         ip,
-		Port:       p,
+		Port:       port,
 		SSHKeyPath: sshKeyPath,
 		Username:   username,
 	}

--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -63,10 +63,11 @@ func NewSSHClient(d drivers.Driver) (*ssh.Client, error) {
 	return client, nil
 }
 
-func NewRawSSHClient(ip, sshKeyPath, username string) (*ssh.Client, error) {
+func NewRawSSHClient(ip, port, sshKeyPath, username string) (*ssh.Client, error) {
+	p, _ := strconv.Atoi(port)
 	h := &sshHost{
 		IP:         ip,
-		Port:       22,
+		Port:       p,
 		SSHKeyPath: sshKeyPath,
 		Username:   username,
 	}


### PR DESCRIPTION
This PR adds `--remote-ipport` to allow connection to SSH ports different than 22 on remote VMs.

Steps to test the pull request

  1. Run minishift start with params:

`$ minishift start --vm-driver generic --remote-ipaddress 1.2.3.4 --remote-ipport 30022 --remote-ssh-user root --remote-ssh-key machine-key`

