### PR TITLE
ISSUE #3247 Fix minishift openshift component list Description

### DIFF
--- a/cmd/minishift/cmd/openshift/component_list.go
+++ b/cmd/minishift/cmd/openshift/component_list.go
@@ -27,8 +27,8 @@ import (
 // version command represent current running openshift version and available one.
 var componentListCmd = &cobra.Command{
 	Use:   "list [component-name]",
-	Short: "Add component to an OpenShift cluster (Works only with OpenShift version >= 3.10.x)",
-	Long:  "Add component to an OpenShift cluster (Works only with OpenShift version >= 3.10.x)",
+	Short: "List valid components that can be added to an OpenShift cluster (Works only with OpenShift version >= 3.10.x)",
+	Long:  "List valid components that can be added to an OpenShift cluster (Works only with OpenShift version >= 3.10.x)",
 	Run:   runComponentList,
 }
 


### PR DESCRIPTION
Fixes #3247 

This pull request updates the description for `minishift openshift component list`. It is currently the same as `minishift openshift component add`. I based the description off of what is in this [documentation](https://github.com/minishift/minishift/blob/master/docs/source/openshift/openshift-client-binary.adoc).

Steps to test the pull request:

  1. Verify using `minishift openshift component --help` that the description for `list` is as follows:
```
Available Commands:
  add      Add component to an OpenShift cluster (Works only with OpenShift version >= 3.10.x)
  list        List valid components that can be added to an OpenShift cluster (Works only with OpenShift version >= 3.10.x)
```

