### PR TITLE
Align labels with che operator and helm provided

### DIFF
--- a/addons/che/templates/che-server-template.yaml
+++ b/addons/che/templates/che-server-template.yaml
@@ -75,12 +75,14 @@ objects:
     revisionHistoryLimit: 2
     selector:
       app: che
+      component: che
     strategy:
       type: ${STRATEGY}
     template:
       metadata:
         labels:
           app: che
+          component: che
       spec:
         containers:
         - env:
@@ -387,4 +389,5 @@ parameters:
   value: 'true'
 labels:
   app: che
+  component: che
   template: che


### PR DESCRIPTION
Fixes https://github.com/eclipse/che/issues/14260

Steps to test the pull request
  1. Deploy che with chectl `server:start --platform=minishift --installer=minishift-addon`
  2. Try to stop Che with chectl `server:stop`
  Expected: Che DeploymentConfig should be scaled to 0.
