### PR TITLE
Fix devfile registry template label

### DIFF
--- a/addons/che/templates/che-devfile-registry-template.yaml
+++ b/addons/che/templates/che-devfile-registry-template.yaml
@@ -97,5 +97,5 @@ parameters:
   description: Always pull by default. Can be IfNotPresent
 labels:
   app: che
-  component: plugin-registry
+  component: devfile-registry
   template: che-devfile-registry


### PR DESCRIPTION
Sorry guys for introducing it in https://github.com/minishift/minishift/pull/3333/files#diff-bbf0404171dd76fd7527d27231269f1bR100
I'm not really aware if it affects any functionality but it would be good to have consistent labels =)

Steps to test the pull request

  1. Apply Che minishift addon
  2. Check is you're able to create and run workspaces

You may face some issues if you run your minishift on linux+KVM. More see https://github.com/minishift/minishift/pull/3333#issuecomment-530737439
MacOS or Linux+VirtualBox should work fine

