### PR TITLE
Set CHE_INFRA_OPENSHIFT_PROJECT for backward compatibility

### DIFF
--- a/addons/che/templates/che-server-template.yaml
+++ b/addons/che/templates/che-server-template.yaml
@@ -123,6 +123,13 @@ objects:
             value: "5"
           - name: CHE_INFRA_KUBERNETES_MASTER__URL
             value: "${CHE_INFRA_KUBERNETES_MASTER__URL}"
+            # this is environment variable that is used
+            # for configuring namespace on Che < 7.4.0
+            # It's needed for backward compatibility
+          - name: CHE_INFRA_OPENSHIFT_PROJECT
+            value: "${CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT}"
+            # this is environment variable that is used
+            # for configuring namespace on Che >= 7.4.0
           - name: CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT
             value: "${CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT}"
           - name: CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME


### PR DESCRIPTION
The minishift addon uses hardcoded 7.1.0 Che Image, it's why we still need to set deprecated in 7.4.0 `CHE_INFRA_OPENSHIFT_PROJECT` configuration env var

Fixes https://github.com/minishift/minishift/issues/3401 and should fix https://github.com/eclipse/che/issues/15380 as well

Steps to test the pull request

1. Apply Che minishift addon
2. Open Che in browser
3. Create any workspace
4. Try to start it