### PR TITLE
Issue #3430 Install hyperkit when setup command is ran

### DIFF
--- a/cmd/minishift/cmd/config/config.go
+++ b/cmd/minishift/cmd/config/config.go
@@ -109,6 +109,8 @@ var (
 	WarnDeprecationCheck      = createConfigSetting("warn-check-deprecation", SetBool, nil, nil, true, true)
 	SkipCheckKVMDriver        = createConfigSetting("skip-check-kvm-driver", SetBool, nil, nil, true, nil)
 	WarnCheckKVMDriver        = createConfigSetting("warn-check-kvm-driver", SetBool, nil, nil, true, false)
+	SkipCheckHyperkit         = createConfigSetting("skip-check-hyperkit", SetBool, nil, nil, true, nil)
+	WarnCheckHyperkit         = createConfigSetting("warn-check-hyperkit", SetBool, nil, nil, true, false)
 	SkipCheckHyperkitDriver   = createConfigSetting("skip-check-hyperkit-driver", SetBool, nil, nil, true, nil)
 	WarnCheckHyperkitDriver   = createConfigSetting("warn-check-hyperkit-driver", SetBool, nil, nil, true, false)
 	SkipCheckHyperVDriver     = createConfigSetting("skip-check-hyperv-driver", SetBool, nil, nil, true, nil)

--- a/cmd/minishift/cmd/start_preflight.go
+++ b/cmd/minishift/cmd/start_preflight.go
@@ -104,6 +104,12 @@ func preflightChecksBeforeStartingHost() {
 	switch viper.GetString(configCmd.VmDriver.Name) {
 	case "hyperkit":
 		preflightCheckSucceedsOrFails(
+			configCmd.SkipCheckHyperkit.Name,
+			checkHyperkitInstalled,
+			"Checking if hyperkit is installed",
+			configCmd.WarnCheckHyperkit.Name,
+			driverErrorMessage)
+		preflightCheckSucceedsOrFails(
 			configCmd.SkipCheckHyperkitDriver.Name,
 			checkHyperkitDriver,
 			"Checking if hyperkit driver is installed",
@@ -324,6 +330,28 @@ func checkHyperkitDriver() bool {
 		return false
 	}
 
+	return true
+}
+
+func checkHyperkitInstalled() bool {
+	//Check if hyperkit binary is present
+	path, err := exec.LookPath("hyperkit")
+	if err != nil {
+		return false
+	}
+	// follow symlink
+	fi, _ := os.Stat(path)
+	if fi.Mode()&os.ModeSymlink != 0 {
+		path, err = os.Readlink(path)
+		if err != nil {
+			return false
+		}
+	}
+	fmt.Println("\n   Hyperkit is available at", path)
+	fmt.Print("   Checking for setuid bit ... ")
+	if fi.Mode()&os.ModeSetuid == 0 {
+		return false
+	}
 	return true
 }
 


### PR DESCRIPTION
Downloads hyperkit binary from
github.com/code-ready/machine-driver-hyperkit/releases

Fixes #3430 

Steps to test the pull request

  1. remove any previous installation of hyperkit and the hyperkit driver
(` rm -rf $(which hyperkit) $(which docker-machine-driver-hyperkit)`)
  2. `minishift start` should fail
  3. `sudo minishift setup`
  4. `minishift start` should succeed now

