### PR TITLE
Issue #3470 remove -F and -p flags on ssh calls

### DIFF
--- a/vendor/github.com/docker/machine/libmachine/ssh/client.go
+++ b/vendor/github.com/docker/machine/libmachine/ssh/client.go
@@ -67,7 +67,6 @@ const (
 
 var (
 	baseSSHArgs = []string{
-		"-F", "/dev/null",
 		"-o", "ConnectionAttempts=3", // retry 3 times if SSH connection fails
 		"-o", "ConnectTimeout=10", // timeout after 10 seconds
 		"-o", "ControlMaster=no", // disable ssh multiplexing
@@ -370,8 +369,10 @@ func NewExternalClient(sshBinaryPath, user, host string, port int, auth *Auth) (
 		}
 	}
 
-	// Set which port to use for SSH.
-	args = append(args, "-p", fmt.Sprintf("%d", port))
+	if port != 22 {
+		// Set which port to use for SSH.
+		args = append(args, "-p", fmt.Sprintf("%d", port))
+	}
 
 	client.BaseArgs = args
 


### PR DESCRIPTION
Fixes #3470

Steps to test the pull request

  1. run minishift start
  2. not sure how to verify full ssh command line is being logged, I verified it by creating a shim for ssh and by placing it in my path.
  3. verify ssh calls do not contain -F /dev/null (because we want to use sshconfig that is available already), and -p is included only when the port number is different from the default 22.

