### PR TITLE
Update installing.adoc

### DIFF
--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -32,13 +32,13 @@ Ensure that any SSH binary in the system `PATH` does not generate warning messag
 On macOS, you can also use link:https://caskroom.github.io[Homebrew Cask] to install the stable version of {project}:
 
 ----
-$ brew cask install minishift
+$ brew install --cask minishift
 ----
 
 To update the binary, run following command:
 
 ----
-$ brew cask install --force minishift
+$ brew install --cask --force minishift
 ----
 
 == Next Steps


### PR DESCRIPTION
Using the current commands listed you get the following warning using macOS 10.15.7 and Homebrew 2.6.0.

```
% brew cask install --force minishift
Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
```

Fixes <place holder for #issue number>


Steps to test the pull request

  1. 
  2. 
  3. 
  4. 

