### PR TITLE
Documentation Only - Homebrew Mac Steps

### DIFF
--- a/docs/source/getting-started/installing.adoc
+++ b/docs/source/getting-started/installing.adoc
@@ -32,13 +32,13 @@ Ensure that any SSH binary in the system `PATH` does not generate warning messag
 On macOS, you can also use link:https://caskroom.github.io[Homebrew Cask] to install the stable version of {project}:
 
 ----
-$ brew install --cask minishift
+$ brew install minishift --no-quarantine
 ----
 
 To update the binary, run following command:
 
 ----
-$ brew install --cask --force minishift
+$ brew install --force minishift --no-quarantine
 ----
 
 == Next Steps


### PR DESCRIPTION
You no longer need to use `--cask` and to save other warnings you can add `--no-quarantine`
